### PR TITLE
Add .script_json for all scripts [ci skip]

### DIFF
--- a/dashboard/config/scripts_json/20-hour.script_json
+++ b/dashboard/config/scripts_json/20-hour.script_json
@@ -1,0 +1,4134 @@
+{
+  "script": {
+    "name": "20-hour",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "supported_locales": [
+        "de-DE"
+      ],
+      "curriculum_umbrella": "CSF"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "20-hour"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Computer Science",
+      "name": "Introduction to Computer Science",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computer Science",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Maze",
+      "name": "The Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Computational Thinking",
+      "name": "Computational Thinking",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Artist",
+      "name": "The Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Algorithms",
+      "name": "Algorithms",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Artist 2",
+      "name": "The Artist 2",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Farmer",
+      "name": "The Farmer",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Artist 3",
+      "name": "The Artist 3",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Song Writing",
+      "name": "Song Writing",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Song Writing",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Farmer 2",
+      "name": "The Farmer 2",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Abstraction",
+      "name": "Abstraction",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Abstraction",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Artist 4",
+      "name": "The Artist 4",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Relay Programming",
+      "name": "Relay Programming",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Farmer 3",
+      "name": "The Farmer 3",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Internet",
+      "name": "The Internet",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "The Artist 5",
+      "name": "The Artist 5",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "key": "Wrap-up",
+      "name": "Wrap-up",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug1:u_1_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computer Science",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug1:u_1_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2_5"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_10"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_11"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_12"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_13"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_14"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_15"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_16"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_17"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_18"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Maze:2_19"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug2:u_2_1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug2:u_2_1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug3:u_3_1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug3:u_3_1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_9"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_9"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist:1_10"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist:1_10"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug4:u_4_1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug4:u_4_1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_3"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_5"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_6"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_7"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_8"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_9"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_10"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_10"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist2:4_11"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist2:4_11"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug5:u_5_1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug5:u_5_1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_3"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_4"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_6"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_6"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_7"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_7"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_8"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_8"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_9"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_9"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_10"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_10"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_11"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer:karel_1_11"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug6:u_6_1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug6:u_6_1"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_1"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_3"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_5"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_6"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_6"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_7"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_7"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_7_5"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_7_5"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_8"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_8"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_9"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_9"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist3:2_10"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist3:2_10"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug7:u_7_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Song Writing",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug7:u_7_1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_6"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_6"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_7"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_7"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_8"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_8"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_9"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_9"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_10"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer2:karel_2_10"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug8:u_8_1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug8:u_8_1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_5"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_6"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_6"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_7"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_8"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_9"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_9"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist4:3_10"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist4:3_10"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug9:u_9_1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug9:u_9_1"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_seq_1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_seq_1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_seq_2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_seq_2"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_repeat"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_repeat"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_while"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_while"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_if"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_if"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_if_else"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_if_else"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_function_1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_function_2"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_3"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Farmer3:karel_debug_function_3"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug10:u_10_1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug10:u_10_1"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_1"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_3"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_5"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Artist5:5_6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Artist5:5_6"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Unplug11:u_11_1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      },
+      "level_keys": [
+        "blockly:Unplug11:u_11_1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug1:u_1_1",
+        "script_level.level_keys": [
+          "blockly:Unplug1:u_1_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computer Science",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_1",
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_3",
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_4",
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_6",
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_7",
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_8",
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_9",
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_10",
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_11",
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_12",
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_13",
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_14",
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_15",
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_16",
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_17",
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_18",
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_19",
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug2:u_2_1",
+        "script_level.level_keys": [
+          "blockly:Unplug2:u_2_1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug3:u_3_1",
+        "script_level.level_keys": [
+          "blockly:Unplug3:u_3_1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_1",
+        "script_level.level_keys": [
+          "blockly:Artist:1_1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_2",
+        "script_level.level_keys": [
+          "blockly:Artist:1_2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_3",
+        "script_level.level_keys": [
+          "blockly:Artist:1_3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_4",
+        "script_level.level_keys": [
+          "blockly:Artist:1_4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_5",
+        "script_level.level_keys": [
+          "blockly:Artist:1_5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_6",
+        "script_level.level_keys": [
+          "blockly:Artist:1_6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_7",
+        "script_level.level_keys": [
+          "blockly:Artist:1_7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_8",
+        "script_level.level_keys": [
+          "blockly:Artist:1_8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_9",
+        "script_level.level_keys": [
+          "blockly:Artist:1_9"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist:1_10",
+        "script_level.level_keys": [
+          "blockly:Artist:1_10"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug4:u_4_1",
+        "script_level.level_keys": [
+          "blockly:Unplug4:u_4_1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_1",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_2",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_3",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_4",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_5",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_6",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_7",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_8",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_9",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_10",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_10"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist2:4_11",
+        "script_level.level_keys": [
+          "blockly:Artist2:4_11"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "The Artist 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug5:u_5_1",
+        "script_level.level_keys": [
+          "blockly:Unplug5:u_5_1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_1",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_2",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_3",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_4",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_5",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_6",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_6"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_7",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_7"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_8",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_8"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_9",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_9"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_10",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_10"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer:karel_1_11",
+        "script_level.level_keys": [
+          "blockly:Farmer:karel_1_11"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "The Farmer",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug6:u_6_1",
+        "script_level.level_keys": [
+          "blockly:Unplug6:u_6_1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_1",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_2",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_3",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_4",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_5",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_6",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_6"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_7",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_7"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_7_5",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_7_5"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_8",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_8"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_9",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_9"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist3:2_10",
+        "script_level.level_keys": [
+          "blockly:Artist3:2_10"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "The Artist 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug7:u_7_1",
+        "script_level.level_keys": [
+          "blockly:Unplug7:u_7_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Song Writing",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_1",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_2",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_3",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_4",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_5",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_6",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_6"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_7",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_7"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_8",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_8"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_9",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_9"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer2:karel_2_10",
+        "script_level.level_keys": [
+          "blockly:Farmer2:karel_2_10"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "The Farmer 2",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug8:u_8_1",
+        "script_level.level_keys": [
+          "blockly:Unplug8:u_8_1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_1",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_2",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_3",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_4",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_5",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_6",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_6"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_7",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_8",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_9",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_9"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist4:3_10",
+        "script_level.level_keys": [
+          "blockly:Artist4:3_10"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "The Artist 4",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug9:u_9_1",
+        "script_level.level_keys": [
+          "blockly:Unplug9:u_9_1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_seq_1",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_seq_1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_seq_2",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_seq_2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_repeat",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_repeat"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_while",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_while"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_if",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_if"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_if_else",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_if_else"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_function_1",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_function_2",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Farmer3:karel_debug_function_3",
+        "script_level.level_keys": [
+          "blockly:Farmer3:karel_debug_function_3"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "The Farmer 3",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug10:u_10_1",
+        "script_level.level_keys": [
+          "blockly:Unplug10:u_10_1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_1",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_2",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_3",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_4",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_5",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Artist5:5_6",
+        "script_level.level_keys": [
+          "blockly:Artist5:5_6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "The Artist 5",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Unplug11:u_11_1",
+        "script_level.level_keys": [
+          "blockly:Unplug11:u_11_1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "20-hour"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/2016_sciencePD-phase2b.script_json
+++ b/dashboard/config/scripts_json/2016_sciencePD-phase2b.script_json
@@ -1,0 +1,763 @@
+{
+  "script": {
+    "name": "2016_sciencePD-phase2b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "2016_sciencePD-phase2b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Reviewing the Modules",
+      "name": "Reviewing the Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Advanced StarLogo Nova",
+      "name": "Advanced StarLogo Nova",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Remixing Phases 1 and 2",
+      "name": "Remixing Phases 1 and 2",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed2a"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed2a"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed2b"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed2b"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed3a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed3a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed3b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed3b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4a"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed4a"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed4b"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4c"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed4c"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4d"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 breed4d"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed2a",
+        "script_level.level_keys": [
+          "sciPD2 breed2a"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed2b",
+        "script_level.level_keys": [
+          "sciPD2 breed2b"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed3a",
+        "script_level.level_keys": [
+          "sciPD2 breed3a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed3b",
+        "script_level.level_keys": [
+          "sciPD2 breed3b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4a",
+        "script_level.level_keys": [
+          "sciPD2 breed4a"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4b",
+        "script_level.level_keys": [
+          "sciPD2 breed4b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4c",
+        "script_level.level_keys": [
+          "sciPD2 breed4c"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4d",
+        "script_level.level_keys": [
+          "sciPD2 breed4d"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD-phase2b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/2016_sciencePD_phase1.script_json
+++ b/dashboard/config/scripts_json/2016_sciencePD_phase1.script_json
@@ -1,0 +1,1988 @@
+{
+  "script": {
+    "name": "2016_sciencePD_phase1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "2016_sciencePD_phase1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "What to Expect",
+      "name": "What to Expect",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Introduction to Complex Adaptive Systems",
+      "name": "Introduction to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Introduction to Computational Science",
+      "name": "Introduction to Computational Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Agent Based Modeling of Complex Adaptive Systems",
+      "name": "Agent Based Modeling of Complex Adaptive Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Using Computer Models in Science",
+      "name": "Using Computer Models in Science",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Using Models in the Classroom",
+      "name": "Using Models in the Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Dispositions and Classroom Culture",
+      "name": "Dispositions and Classroom Culture",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Computational Thinking And The Framework For K-12 Science Education",
+      "name": "Computational Thinking And The Framework For K-12 Science Education",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Introduction to StarLogo Nova",
+      "name": "Introduction to StarLogo Nova",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "The Tutorial",
+      "name": "The Tutorial",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "key": "Post-Survey",
+      "name": "Post-Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour 2016-17 CSinSci"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "PDECS tour 2016-17 CSinSci"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment 2016-17"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD commitment 2016-17"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment match 16-17"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD commitment match 16-17"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD what to expect 16-17"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD what to expect 16-17"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD intro video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD expectations"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD meet and greet 16-17"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD meet and greet 16-17"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Break 16-17"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD Break 16-17"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD intro to CS video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD intro to CS 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD intro to CS 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD intro to CS forum"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD agent based video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD agent based 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD agent based 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD agent based forum"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD computer models video"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD computer models 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD computer models 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD computer models forum"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD class models video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD class models 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD class models 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD class models forum"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD culture video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD culture 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD culture 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD culture forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD framework video"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD framework 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD framework 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD framework forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro video"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD finish 16-17"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      },
+      "level_keys": [
+        "sciPD finish 16-17"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD Intro",
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour 2016-17 CSinSci",
+        "script_level.level_keys": [
+          "PDECS tour 2016-17 CSinSci"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment 2016-17",
+        "script_level.level_keys": [
+          "sciPD commitment 2016-17"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment match 16-17",
+        "script_level.level_keys": [
+          "sciPD commitment match 16-17"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD what to expect 16-17",
+        "script_level.level_keys": [
+          "sciPD what to expect 16-17"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro video",
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD expectations",
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD meet and greet 16-17",
+        "script_level.level_keys": [
+          "sciPD meet and greet 16-17"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD Break 16-17",
+        "script_level.level_keys": [
+          "sciPD Break 16-17"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive video",
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 1",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 2",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive forum",
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS video",
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 1",
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 2",
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS forum",
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based video",
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 1",
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 2",
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based forum",
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models video",
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 1",
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 2",
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models forum",
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models video",
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 1",
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 2",
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models forum",
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture video",
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 1",
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 2",
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture forum",
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework video",
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 1",
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 2",
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework forum",
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro video",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 5",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 6",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 7",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 8",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD finish 16-17",
+        "script_level.level_keys": [
+          "sciPD finish 16-17"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/2016_sciencePD_phase2b.script_json
+++ b/dashboard/config/scripts_json/2016_sciencePD_phase2b.script_json
@@ -1,0 +1,1043 @@
+{
+  "script": {
+    "name": "2016_sciencePD_phase2b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "2016_sciencePD_phase2b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Reviewing the Modules",
+      "name": "Reviewing the Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Advanced StarLogo Nova",
+      "name": "Advanced StarLogo Nova",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Remixing Phases 1 and 2",
+      "name": "Remixing Phases 1 and 2",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciencePD2b remixing"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 mods"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 remember"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 challenge"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 SLN explore"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 sliders"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD breeds"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 camera"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 wiggle"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 color"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 procedures"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 conditionals"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 remix1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciencePD2b remixing",
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 mods",
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remember",
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 challenge",
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 SLN explore",
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 sliders",
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD breeds",
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 camera",
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 wiggle",
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 color",
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 procedures",
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 conditionals",
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remix1",
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "2016_sciencePD_phase2b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/2018hoc-ab.script_json
+++ b/dashboard/config/scripts_json/2018hoc-ab.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "2018hoc-ab",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "2018hoc-ab"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Labyrinth",
+      "name": "Labyrinth",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Labyrinth",
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HoCAB_labyrinth1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Labyrinth",
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      },
+      "level_keys": [
+        "HoCAB_labyrinth1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HoCAB_labyrinth2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Labyrinth",
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      },
+      "level_keys": [
+        "HoCAB_labyrinth2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "HoCAB_labyrinth1",
+        "script_level.level_keys": [
+          "HoCAB_labyrinth1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Labyrinth",
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HoCAB_labyrinth2",
+        "script_level.level_keys": [
+          "HoCAB_labyrinth2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Labyrinth",
+        "lesson_group.key": "",
+        "script.name": "2018hoc-ab"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/AlgebraA.script_json
+++ b/dashboard/config/scripts_json/AlgebraA.script_json
@@ -1,0 +1,3152 @@
+{
+  "script": {
+    "name": "AlgebraA",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/algebra/courseA/{LESSON}",
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "AlgebraA"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Calc: Evaluation Blocks",
+      "name": "Calc: Evaluation Blocks",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Eval: Strings and Images",
+      "name": "Eval: Strings and Images",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Unplugged: Contracts",
+      "name": "Unplugged: Contracts",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Eval: Writing Contracts",
+      "name": "Eval: Writing Contracts",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Calc: Defining Variables",
+      "name": "Calc: Defining Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Unplugged: Fast Functions",
+      "name": "Unplugged: Fast Functions",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Fast Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Eval: Defining Functions",
+      "name": "Eval: Defining Functions",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Unplugged: The Design Recipe",
+      "name": "Unplugged: The Design Recipe",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Eval: Functions",
+      "name": "Eval: Functions",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "key": "Play Lab: Defining Functions",
+      "name": "Play Lab: Defining Functions",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Blocks to Math 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Blocks to Math 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Blocks to Math 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Blocks to Math 4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 5"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 6"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 7"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images 8"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Multi Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Contracts"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Contracts"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts A"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts B"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts C"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts D"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts E"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts F"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts 4"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Contracts 4 B"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Vars 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Vars 1.1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Vars 2"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Vars 2.1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "MSM Defining Vars 1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "MSM Defining Vars 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "MSM Defining Vars 3"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "MSM Defining Vars 4"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Defining Vars Free Play 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 2"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 3"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 4"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 5"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 6"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Fast Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "DesignRecipe"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Define Funcs 5"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Multi Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Multi Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Multi Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 10"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 11"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "msm variables multi 13"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "DesignRecipe"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe .1"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe 6"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Design Recipe 1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Design Recipe 2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Calc Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Eval Design Recipe Free Play"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rocket Height Course A"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Rocket Height Course A"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket 7"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket 8"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 1",
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 2",
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 3",
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 4",
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 5",
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 6",
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 7",
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 8",
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Strings Images 1",
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Contracts",
+        "script_level.level_keys": [
+          "Contracts"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts A",
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts B",
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts C",
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts D",
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts E",
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts F",
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4",
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4 B",
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1",
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1.1",
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2",
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2.1",
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 1",
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 2",
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 3",
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 4",
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Defining Vars Free Play 1",
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 1",
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 2",
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 3",
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 4",
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 5",
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 6",
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesignRecipe",
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Fast Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 1",
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 2",
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 3",
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 4",
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 5",
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 1",
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 2",
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 3",
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 4",
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 1",
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 2",
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 3",
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 10",
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 11",
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 13",
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesignRecipe",
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe .1",
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 4",
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 6",
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 1",
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 2",
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 3",
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 4",
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe Free Play",
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rocket Height Course A",
+        "script_level.level_keys": [
+          "Rocket Height Course A"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 6",
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 7",
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 8",
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraA"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/AlgebraB.script_json
+++ b/dashboard/config/scripts_json/AlgebraB.script_json
@@ -1,0 +1,1801 @@
+{
+  "script": {
+    "name": "AlgebraB",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/algebra/courseB/{LESSON}",
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "AlgebraB"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unplugged: Video Games and Coordinate Planes",
+      "name": "Unplugged: Video Games and Coordinate Planes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Play Lab: Defining Variables (Big Game)",
+      "name": "Play Lab: Defining Variables (Big Game)",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Play Lab: Animation (Big Game)",
+      "name": "Play Lab: Animation (Big Game)",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Unplugged: Booleans",
+      "name": "Unplugged: Booleans",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Eval: Boolean Operators",
+      "name": "Eval: Boolean Operators",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Play Lab: Booleans",
+      "name": "Play Lab: Booleans",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Play Lab: Boolean (Big Game)",
+      "name": "Play Lab: Boolean (Big Game)",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Unplugged: Conditionals and Piecewise Functions",
+      "name": "Unplugged: Conditionals and Piecewise Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Eval: Conditionals",
+      "name": "Eval: Conditionals",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Unplugged: Collision Detection and the Distance Formula",
+      "name": "Unplugged: Collision Detection and the Distance Formula",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "key": "Play Lab: Collision Detection (Big Game)",
+      "name": "Play Lab: Collision Detection (Big Game)",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VideoGamesCoordinatePlanes"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "VideoGamesCoordinatePlanes"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Ninjacat Demo B"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Ninjacat Demo B"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Coordinates Multi 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Coordinates Multi 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Vars 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Vars 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Vars 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Vars 4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Animation 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Animation 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Animation 3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Animation 4"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Booleans"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Booleans"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Blocks to Bools 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Blocks to Bools 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Blocks to Bools 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Booleans Free Play"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Sam the Butterfly 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Sam the Butterfly 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Sam the Butterfly 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Sam the Butterfly 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Sam the Butterfly 5"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Booleans 1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Booleans 4"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Booleans 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Booleans 3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Booleans 5"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ConditionalsPiecewiseFunctions"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "ConditionalsPiecewiseFunctions"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Luigi's Pizza 1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Luigi's Pizza 2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Luigi's Pizza 3"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Luigi's Pizza 4"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Cond 4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Eval Cond 5"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Player 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Player 2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CollisionDetection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "CollisionDetection"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Collision 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Collision 3"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Collision 4"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      },
+      "level_keys": [
+        "Big Game Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "VideoGamesCoordinatePlanes",
+        "script_level.level_keys": [
+          "VideoGamesCoordinatePlanes"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Ninjacat Demo B",
+        "script_level.level_keys": [
+          "Ninjacat Demo B"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Coordinates Multi 1",
+        "script_level.level_keys": [
+          "Coordinates Multi 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 1",
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 2",
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 3",
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 4",
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 1",
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 2",
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 3",
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 4",
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Booleans",
+        "script_level.level_keys": [
+          "Booleans"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 1",
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 3",
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 4",
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 5",
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 6",
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 1",
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 3",
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 4",
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans Free Play",
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 1",
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 2",
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 3",
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 4",
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 5",
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 1",
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 4",
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 2",
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 3",
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 5",
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ConditionalsPiecewiseFunctions",
+        "script_level.level_keys": [
+          "ConditionalsPiecewiseFunctions"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 1",
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 2",
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 3",
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 4",
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 4",
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 5",
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 1",
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 2",
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CollisionDetection",
+        "script_level.level_keys": [
+          "CollisionDetection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 1",
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 3",
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 4",
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Final",
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "AlgebraB"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSF_Secret_Sample.script_json
+++ b/dashboard/config/scripts_json/CSF_Secret_Sample.script_json
@@ -1,0 +1,503 @@
+{
+  "script": {
+    "name": "CSF_Secret_Sample",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSF_Secret_Sample"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sample Stage",
+      "name": "Sample Stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "newCSFsample"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "newCSFsample"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample3assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample3assessment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample7assessment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample7assessment"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample9a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample9a"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample10a"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "sample10a"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "kikiTesta"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      },
+      "level_keys": [
+        "kikiTesta"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "newCSFsample",
+        "script_level.level_keys": [
+          "newCSFsample"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample1",
+        "script_level.level_keys": [
+          "sample1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample2",
+        "script_level.level_keys": [
+          "sample2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample3",
+        "script_level.level_keys": [
+          "sample3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample3assessment",
+        "script_level.level_keys": [
+          "sample3assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample4",
+        "script_level.level_keys": [
+          "sample4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample5",
+        "script_level.level_keys": [
+          "sample5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample6",
+        "script_level.level_keys": [
+          "sample6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample7assessment",
+        "script_level.level_keys": [
+          "sample7assessment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample8",
+        "script_level.level_keys": [
+          "sample8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample9a",
+        "script_level.level_keys": [
+          "sample9a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample10a",
+        "script_level.level_keys": [
+          "sample10a"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "kikiTesta",
+        "script_level.level_keys": [
+          "kikiTesta"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSF_Secret_Sample_Story.script_json
+++ b/dashboard/config/scripts_json/CSF_Secret_Sample_Story.script_json
@@ -1,0 +1,608 @@
+{
+  "script": {
+    "name": "CSF_Secret_Sample_Story",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSF_Secret_Sample_Story"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sample Stage",
+      "name": "Sample Stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "storyline1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "storyline1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "storyline2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "storyline2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "storyline3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "storyline3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "storyline4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "storyline4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample3assessment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample3assessment"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample4"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample5"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample6"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample7assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample7assessment"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "storyline5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "storyline5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample9a"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample9a"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sample10a"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      },
+      "level_keys": [
+        "sample10a"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "storyline1",
+        "script_level.level_keys": [
+          "storyline1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "storyline2",
+        "script_level.level_keys": [
+          "storyline2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "storyline3",
+        "script_level.level_keys": [
+          "storyline3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample1",
+        "script_level.level_keys": [
+          "sample1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "storyline4",
+        "script_level.level_keys": [
+          "storyline4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample2",
+        "script_level.level_keys": [
+          "sample2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample3",
+        "script_level.level_keys": [
+          "sample3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample3assessment",
+        "script_level.level_keys": [
+          "sample3assessment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample4",
+        "script_level.level_keys": [
+          "sample4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample5",
+        "script_level.level_keys": [
+          "sample5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample6",
+        "script_level.level_keys": [
+          "sample6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample7assessment",
+        "script_level.level_keys": [
+          "sample7assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample8",
+        "script_level.level_keys": [
+          "sample8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "storyline5",
+        "script_level.level_keys": [
+          "storyline5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample9a",
+        "script_level.level_keys": [
+          "sample9a"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sample10a",
+        "script_level.level_keys": [
+          "sample10a"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "CSF_Secret_Sample_Story"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSP-Unit3-Support.script_json
+++ b/dashboard/config/scripts_json/CSP-Unit3-Support.script_json
@@ -1,0 +1,588 @@
+{
+  "script": {
+    "name": "CSP-Unit3-Support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSP-Unit3-Support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 3 Overview",
+      "name": "Unit 3 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Chunk 1 Overview",
+      "name": "Chunk 1 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Chunk 2 Overview",
+      "name": "Chunk 2 Overview",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Chunk 3 Overview",
+      "name": "Chunk 3 Overview",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Chunk 4 Overview",
+      "name": "Chunk 4 Overview",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Chunk 5 Overview",
+      "name": "Chunk 5 Overview",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "key": "Practice Performance Task",
+      "name": "Practice Performance Task",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 breakdown of u3 chunks"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 breakdown of u3 chunks"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 tips for prep"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 tips for prep"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 concepts"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 1 concepts"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 resources"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 1 resources"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 concepts"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 2 concepts"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 resources"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 2 resources"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 concepts"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 3 concepts"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 resources"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 3 resources"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 4 concepts"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 4 resources"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 concepts"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 5 concepts"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 resources"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 5 resources"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 practice PT"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      },
+      "level_keys": [
+        "CSPPD3-u3 practice PT"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 breakdown of u3 chunks",
+        "script_level.level_keys": [
+          "CSPPD3-u3 breakdown of u3 chunks"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD3-u3 tips for prep"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 1 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 concepts"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 1 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 resources"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 2 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 concepts"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 2 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 resources"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 3 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 concepts"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 3 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 resources"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 4 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 4 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 5 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 concepts"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 5 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 resources"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 practice PT",
+        "script_level.level_keys": [
+          "CSPPD3-u3 practice PT"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSP-Unit3-Support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPLessonSamples.script_json
+++ b/dashboard/config/scripts_json/CSPLessonSamples.script_json
@@ -1,0 +1,552 @@
+{
+  "script": {
+    "name": "CSPLessonSamples",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPLessonSamples"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lesson 14",
+      "name": "Lesson 14",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "key": "Lesson 15",
+      "name": "Lesson 15",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Video - Lesson 14 - B and W"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Video - Lesson 14 - B and W"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make your own B and W Image"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Video - Color 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Video - Color 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Video - Color 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation Flappy"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation Bee"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Favicon Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Favicon Instructions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Free Play"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Free Play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Video - Lesson 14 - B and W",
+        "script_level.level_keys": [
+          "Pixelation - Video - Lesson 14 - B and W"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make your own B and W Image",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 14",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Video - Color 1",
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Video - Color 2",
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Video - Color 3",
+        "script_level.level_keys": [
+          "Pixelation - Video - Color 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy",
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee",
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Favicon Instructions",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Favicon Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Free Play",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Free Play"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Lesson 15",
+        "lesson_group.key": "",
+        "script.name": "CSPLessonSamples"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD.script_json
+++ b/dashboard/config/scripts_json/CSPPD.script_json
@@ -1,0 +1,1463 @@
+{
+  "script": {
+    "name": "CSPPD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "What is CSP?",
+      "name": "What is CSP?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "Exploring CSP Instructional Materials",
+      "name": "Exploring CSP Instructional Materials",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "Impact of Computer Science",
+      "name": "Impact of Computer Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "Growth Mindset",
+      "name": "Growth Mindset",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD presurvey"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Welcome to the Family!"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "Welcome to the Family!"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "PDECS commitment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "PDECS commitment match"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "PDECS attendance commitment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD pause"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD program overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD curriculum overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD unit matching"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD course goals"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD PT description"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD PT description"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD AP quiz"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD AP quiz"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD PD overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD PD overview"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD PD Phases"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD PD Phases"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD phase matching"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD phase matching"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD PD goals"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 10,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD PD goals"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD program overlap"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 11,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD program overlap"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD instructional materials"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD instructional materials"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD materials overview"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD materials overview"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD materials question1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD materials question1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD impact of CS"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD impact of CS"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid2 question"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD impact in program"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD impact in program"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD what is growth mindset"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset in the classroom"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset question"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset strategies"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD strategies"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD strategies"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD teaching strategies video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD teaching strategies video"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD strategies"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD strategies"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD facilitators"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD facilitators"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD forum introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD forum introduction"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD postsurvey"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD postsurvey"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD end of p1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      },
+      "level_keys": [
+        "CSPPD end of p1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD presurvey",
+        "script_level.level_keys": [
+          "CSPPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Welcome to the Family!",
+        "script_level.level_keys": [
+          "Welcome to the Family!"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment",
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment match",
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS attendance commitment",
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD pause",
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD program overview",
+        "script_level.level_keys": [
+          "CSPPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD curriculum overview",
+        "script_level.level_keys": [
+          "CSPPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD unit matching",
+        "script_level.level_keys": [
+          "CSPPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD course goals",
+        "script_level.level_keys": [
+          "CSPPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD PT description",
+        "script_level.level_keys": [
+          "CSPPD PT description"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD AP quiz",
+        "script_level.level_keys": [
+          "CSPPD AP quiz"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD PD overview",
+        "script_level.level_keys": [
+          "CSPPD PD overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD PD Phases",
+        "script_level.level_keys": [
+          "CSPPD PD Phases"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD phase matching",
+        "script_level.level_keys": [
+          "CSPPD phase matching"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD PD goals",
+        "script_level.level_keys": [
+          "CSPPD PD goals"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 10,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD program overlap",
+        "script_level.level_keys": [
+          "CSPPD program overlap"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 11,
+        "lesson.key": "What is CSP?",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD instructional materials",
+        "script_level.level_keys": [
+          "CSPPD instructional materials"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD materials overview",
+        "script_level.level_keys": [
+          "CSPPD materials overview"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD materials question1",
+        "script_level.level_keys": [
+          "CSPPD materials question1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Exploring CSP Instructional Materials",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD impact of CS",
+        "script_level.level_keys": [
+          "CSPPD impact of CS"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid1",
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2",
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2 question",
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD impact in program",
+        "script_level.level_keys": [
+          "CSPPD impact in program"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD what is growth mindset",
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset in the classroom",
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset question",
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset strategies",
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD strategies",
+        "script_level.level_keys": [
+          "CSPPD strategies"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD teaching strategies video",
+        "script_level.level_keys": [
+          "CSPPD teaching strategies video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD strategies",
+        "script_level.level_keys": [
+          "CSPPD strategies"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD facilitators",
+        "script_level.level_keys": [
+          "CSPPD facilitators"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD forum introduction",
+        "script_level.level_keys": [
+          "CSPPD forum introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD postsurvey",
+        "script_level.level_keys": [
+          "CSPPD postsurvey"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD end of p1",
+        "script_level.level_keys": [
+          "CSPPD end of p1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "CSPPD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD2.script_json
+++ b/dashboard/config/scripts_json/CSPPD2.script_json
@@ -1,0 +1,1232 @@
+{
+  "script": {
+    "name": "CSPPD2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Welcome to the Course!",
+      "name": "Welcome to the Course!",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to the Course!",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Lesson Chunk 1- Sending Binary Messages",
+      "name": "Lesson Chunk 1- Sending Binary Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Lesson Chunk 2- Encoding and Sending Numbers",
+      "name": "Lesson Chunk 2- Encoding and Sending Numbers",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Lesson Chunk 3- Encoding and Sending Text",
+      "name": "Lesson Chunk 3- Encoding and Sending Text",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Lesson Chunk 4- Compressing and Storing Information",
+      "name": "Lesson Chunk 4- Compressing and Storing Information",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Practice PT",
+      "name": "Practice PT",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "key": "Wrap Up and Next Steps",
+      "name": "Wrap Up and Next Steps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 tips for prep"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 participation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 participation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 lesson 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Course!",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 lesson 1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 lesson 1 reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Course!",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 lesson 1 reflection"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 lessons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 1 lessons"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PIvideo"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 PIvideo"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 1 reflection"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 lessons"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2 lessons"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 reflection"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2 reflection"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 lessons"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 3 lessons"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 share protocol"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 share protocol"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 reflection"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 3 reflection"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 lessons"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 4 lessons"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 share compression"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 share compression"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 pixel video 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 pixel video 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 pixel video 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 pixel video 2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 4 reflection"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 PT"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT activity"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 PT activity"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 PT forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT reflection"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 PT reflection"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 congrats"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 congrats"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 next step announcements"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 next step announcements"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      },
+      "level_keys": [
+        "CSPPD2 survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 welcome",
+        "script_level.level_keys": [
+          "CSPPD2 welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 overview",
+        "script_level.level_keys": [
+          "CSPPD2 overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD2 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 participation",
+        "script_level.level_keys": [
+          "CSPPD2 participation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 lesson 1",
+        "script_level.level_keys": [
+          "CSPPD2 lesson 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Course!",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 lesson 1 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 lesson 1 reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Course!",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 1",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 1 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 lessons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PIvideo",
+        "script_level.level_keys": [
+          "CSPPD2 PIvideo"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 1 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 1- Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 lessons"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 reflection"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 2- Encoding and Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 3",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 3 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 lessons"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 share protocol",
+        "script_level.level_keys": [
+          "CSPPD2 share protocol"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 3 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 reflection"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 3- Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 4",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 4 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 lessons"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 share compression",
+        "script_level.level_keys": [
+          "CSPPD2 share compression"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 pixel video 1",
+        "script_level.level_keys": [
+          "CSPPD2 pixel video 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 pixel video 2",
+        "script_level.level_keys": [
+          "CSPPD2 pixel video 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 4 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Chunk 4- Compressing and Storing Information",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT",
+        "script_level.level_keys": [
+          "CSPPD2 PT"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT activity",
+        "script_level.level_keys": [
+          "CSPPD2 PT activity"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT forum",
+        "script_level.level_keys": [
+          "CSPPD2 PT forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT reflection",
+        "script_level.level_keys": [
+          "CSPPD2 PT reflection"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 congrats",
+        "script_level.level_keys": [
+          "CSPPD2 congrats"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 next step announcements",
+        "script_level.level_keys": [
+          "CSPPD2 next step announcements"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 survey",
+        "script_level.level_keys": [
+          "CSPPD2 survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Wrap Up and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "CSPPD2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD3-Unit2.script_json
+++ b/dashboard/config/scripts_json/CSPPD3-Unit2.script_json
@@ -1,0 +1,1155 @@
+{
+  "script": {
+    "name": "CSPPD3-Unit2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD3-Unit2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "key": "Unit 2 Overview",
+      "name": "Unit 2 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "key": "Challenge Overview",
+      "name": "Challenge Overview",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 overivew"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 overivew"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 tips for prep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 tips for prep"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 plan"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 unit 2 overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 unit 2 overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 breakdown of u2 chunks"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 breakdown of u2 chunks"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 unit overview checkin"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 unit overview checkin"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 concepts"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 1 concepts"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 1 resources"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 checkin"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 1 checkin"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 concepts"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 2 concepts"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 resources"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 2 resources"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 checkin"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 chunk 2 checkin"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 pt overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 pt overview"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 checkin"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 11,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 checkin"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 challenge overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 challenge overview"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 what is a challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 completing the challenge"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 completing the challenge"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 list of challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 list of challenges"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 pick a challenge"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 complete the challenge overview"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 do the challenge"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 do the challenge"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 share out overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 share out overview"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 post to forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 post to forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 submit forum link"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 submit forum link"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 final progress check"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 post survey"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 Welcome",
+        "script_level.level_keys": [
+          "CSPPD3-u2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 overivew",
+        "script_level.level_keys": [
+          "CSPPD3-u2 overivew"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD3-u2 tips for prep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 plan",
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 unit 2 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u2 unit 2 overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 breakdown of u2 chunks",
+        "script_level.level_keys": [
+          "CSPPD3-u2 breakdown of u2 chunks"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 unit overview checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u2 unit overview checkin"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 1 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 concepts"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 1 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 1 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 1 checkin"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 2 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 concepts"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 2 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 resources"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 chunk 2 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u2 chunk 2 checkin"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 pt overview",
+        "script_level.level_keys": [
+          "CSPPD3-u2 pt overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u2 checkin"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 11,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u2 challenge overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 what is a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 what is a challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 completing the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 completing the challenge"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 list of challenges",
+        "script_level.level_keys": [
+          "CSPPD3-u2 list of challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 pick a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 pick a challenge"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 complete the challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u2 complete the challenge overview"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 do the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 do the challenge"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 share out overview",
+        "script_level.level_keys": [
+          "CSPPD3-u2 share out overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 post to forum",
+        "script_level.level_keys": [
+          "CSPPD3-u2 post to forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 submit forum link",
+        "script_level.level_keys": [
+          "CSPPD3-u2 submit forum link"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 final progress check",
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 post survey",
+        "script_level.level_keys": [
+          "CSPPD3-u2 post survey"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD3-Unit3-pt2.script_json
+++ b/dashboard/config/scripts_json/CSPPD3-Unit3-pt2.script_json
@@ -1,0 +1,602 @@
+{
+  "script": {
+    "name": "CSPPD3-Unit3-pt2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD3-Unit3-pt2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Challenge Overview",
+      "name": "Challenge Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 challenge overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 challenge overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 what is a challenge"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 completing the challenge"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 completing the challenge"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 list of challenges"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 list of challenges"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 pick a challenge"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 complete the challenge overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 do the challenge"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 do the challenge"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 share out overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 share out overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 post to forum"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 post to forum"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 submit forum link"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 submit forum link"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 final progress check"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 post survey"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      },
+      "level_keys": [
+        "CSPPD3-u3 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 challenge overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 what is a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 what is a challenge"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 completing the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 completing the challenge"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 list of challenges",
+        "script_level.level_keys": [
+          "CSPPD3-u3 list of challenges"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 pick a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 pick a challenge"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 complete the challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 complete the challenge overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 do the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 do the challenge"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 share out overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 share out overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 post to forum",
+        "script_level.level_keys": [
+          "CSPPD3-u3 post to forum"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 submit forum link",
+        "script_level.level_keys": [
+          "CSPPD3-u3 submit forum link"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 final progress check",
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 post survey",
+        "script_level.level_keys": [
+          "CSPPD3-u3 post survey"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3-pt2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD3-Unit3.script_json
+++ b/dashboard/config/scripts_json/CSPPD3-Unit3.script_json
@@ -1,0 +1,1589 @@
+{
+  "script": {
+    "name": "CSPPD3-Unit3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD3-Unit3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Unit 3 Overview",
+      "name": "Unit 3 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Chunk 1 Overview",
+      "name": "Chunk 1 Overview",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Chunk 2 Overview",
+      "name": "Chunk 2 Overview",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Chunk 3 Overview",
+      "name": "Chunk 3 Overview",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Chunk 4 Overview",
+      "name": "Chunk 4 Overview",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Chunk 5 Overview",
+      "name": "Chunk 5 Overview",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Practice Performance Task",
+      "name": "Practice Performance Task",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Challenge Overview",
+      "name": "Challenge Overview",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 tips for prep"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 plan"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 unit 3 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 unit 3 overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 breakdown of u3 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 breakdown of u3 chunks"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 unit overview checkin"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 unit overview checkin"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 1 concepts"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 1 resources"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 checkin"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 1 checkin"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 concepts"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 2 concepts"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 resources"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 2 resources"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 checkin"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 2 checkin"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 concepts"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 3 concepts"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 resources"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 3 resources"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 checkin"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 3 checkin"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 concepts"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 4 concepts"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 resources"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 4 resources"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 checkin"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 4 checkin"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 concepts"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 5 concepts"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 resources"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 5 resources"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 checkin-b"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 chunk 5 checkin-b"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 practice PT"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 practice PT"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 pause and reflect"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 pause and reflect"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 challenge overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 challenge overview"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 what is a challenge"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 completing the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 completing the challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 list of challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 list of challenges"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 pick a challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 complete the challenge overview"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 do the challenge"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 do the challenge"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 share out overview"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 share out overview"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 post to forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 post to forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 submit forum link"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 submit forum link"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 final progress check"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u3 post survey"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u3 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 Welcome",
+        "script_level.level_keys": [
+          "CSPPD3-u3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD3-u3 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 plan",
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 unit 3 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 unit 3 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 breakdown of u3 chunks",
+        "script_level.level_keys": [
+          "CSPPD3-u3 breakdown of u3 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 unit overview checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u3 unit overview checkin"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 1 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 1 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 1 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 1 checkin"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 2 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 concepts"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 2 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 resources"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 2 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 2 checkin"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 3 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 concepts"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 3 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 resources"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 3 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 3 checkin"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 3 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 4 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 concepts"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 4 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 resources"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 4 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 4 checkin"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 5 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 concepts"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 5 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 resources"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 chunk 5 checkin-b",
+        "script_level.level_keys": [
+          "CSPPD3-u3 chunk 5 checkin-b"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Chunk 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 practice PT",
+        "script_level.level_keys": [
+          "CSPPD3-u3 practice PT"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 pause and reflect",
+        "script_level.level_keys": [
+          "CSPPD3-u3 pause and reflect"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Practice Performance Task",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 challenge overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 what is a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 what is a challenge"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 completing the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 completing the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 list of challenges",
+        "script_level.level_keys": [
+          "CSPPD3-u3 list of challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 pick a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 pick a challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 complete the challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 complete the challenge overview"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 do the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u3 do the challenge"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 share out overview",
+        "script_level.level_keys": [
+          "CSPPD3-u3 share out overview"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 post to forum",
+        "script_level.level_keys": [
+          "CSPPD3-u3 post to forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 submit forum link",
+        "script_level.level_keys": [
+          "CSPPD3-u3 submit forum link"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 final progress check",
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u3 post survey",
+        "script_level.level_keys": [
+          "CSPPD3-u3 post survey"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD3-Unit4.script_json
+++ b/dashboard/config/scripts_json/CSPPD3-Unit4.script_json
@@ -1,0 +1,1372 @@
+{
+  "script": {
+    "name": "CSPPD3-Unit4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD3-Unit4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Unit 4 Overview",
+      "name": "Unit 4 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Chapter 1 Overview",
+      "name": "Chapter 1 Overview",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Chapter 2 Overview",
+      "name": "Chapter 2 Overview",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Practice Performance Tasks",
+      "name": "Practice Performance Tasks",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice Performance Tasks",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Challenge Overview",
+      "name": "Challenge Overview",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 tips for prep"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 plan"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 unit 4 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 unit 4 overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 breakdown of u4 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 breakdown of u4 chunks"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 unit overview checkin"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 unit overview checkin"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 concepts"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 resources"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 resources pt2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 resources pt3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 resources pt4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 checkin"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 1 checkin"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 concepts"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 2 concepts"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 chunk 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 2 chunk 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 chunk 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 2 chunk 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 checkin"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 chapter 2 checkin"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 practice PT"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Tasks",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 practice PT"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 pause and reflect"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Practice Performance Tasks",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 pause and reflect"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 challenge overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 challenge overview"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 what is a challenge"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 completing the challenge"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 completing the challenge"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 list of challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 list of challenges"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 pick a challenge"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 complete the challenge overview"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 do the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 do the challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 share out overview"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 share out overview"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 post to forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 post to forum"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 submit forum link"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 submit forum link"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 final progress check"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u4 post survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u4 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 Welcome",
+        "script_level.level_keys": [
+          "CSPPD3-u4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u4 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD3-u4 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 plan",
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 unit 4 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u4 unit 4 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 breakdown of u4 chunks",
+        "script_level.level_keys": [
+          "CSPPD3-u4 breakdown of u4 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 unit overview checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u4 unit overview checkin"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 concepts"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 resources pt2",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 resources pt3",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 resources pt4",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 resources pt4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 1 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 1 checkin"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Chapter 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 2 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 concepts"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 2 chunk 1",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 chunk 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 2 chunk 2",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 chunk 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 chapter 2 checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u4 chapter 2 checkin"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Chapter 2 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 practice PT",
+        "script_level.level_keys": [
+          "CSPPD3-u4 practice PT"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Practice Performance Tasks",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 pause and reflect",
+        "script_level.level_keys": [
+          "CSPPD3-u4 pause and reflect"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Practice Performance Tasks",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u4 challenge overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 what is a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u4 what is a challenge"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 completing the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u4 completing the challenge"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 list of challenges",
+        "script_level.level_keys": [
+          "CSPPD3-u4 list of challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 pick a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u4 pick a challenge"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 complete the challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u4 complete the challenge overview"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 do the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u4 do the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 share out overview",
+        "script_level.level_keys": [
+          "CSPPD3-u4 share out overview"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 post to forum",
+        "script_level.level_keys": [
+          "CSPPD3-u4 post to forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 submit forum link",
+        "script_level.level_keys": [
+          "CSPPD3-u4 submit forum link"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 final progress check",
+        "script_level.level_keys": [
+          "CSPPD3-u2 final progress check"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u4 post survey",
+        "script_level.level_keys": [
+          "CSPPD3-u4 post survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CSPPD3-Unit5.script_json
+++ b/dashboard/config/scripts_json/CSPPD3-Unit5.script_json
@@ -1,0 +1,1043 @@
+{
+  "script": {
+    "name": "CSPPD3-Unit5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CSPPD3-Unit5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Unit 5 Overview",
+      "name": "Unit 5 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Explore PT Breakdown",
+      "name": "Explore PT Breakdown",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Create PT Breakdown",
+      "name": "Create PT Breakdown",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Challenge Overview",
+      "name": "Challenge Overview",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 tips for prep"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 plan"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 unit 5 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 unit 5 overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 breakdown of u5 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 breakdown of u5 chunks"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 philosophy and tools"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 philosophy and tools"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 unit overview checkin"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 unit overview checkin"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 1 concepts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 chapter 1 concepts"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 1 resources"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 chapter 1 resources"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 Explore PT checkin"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 Explore PT checkin"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 2 concepts"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 chapter 2 concepts"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 2 resources"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 chapter 2 resources"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 Create PT checkin"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 Create PT checkin"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 challenge overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 challenge overview"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 completing the challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 completing the challenge"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 list of challenges"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 pick a challenge"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 complete the challenge overview"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 reflect on challenge"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 share out overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 share out overview"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 post to forum"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 post to forum"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 submit forum link"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 submit forum link"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 post survey"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 Welcome",
+        "script_level.level_keys": [
+          "CSPPD3-u5 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u5 overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 tips for prep",
+        "script_level.level_keys": [
+          "CSPPD3-u5 tips for prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 plan",
+        "script_level.level_keys": [
+          "CSPPD3-u2 plan"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 unit 5 overview",
+        "script_level.level_keys": [
+          "CSPPD3-u5 unit 5 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 breakdown of u5 chunks",
+        "script_level.level_keys": [
+          "CSPPD3-u5 breakdown of u5 chunks"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 philosophy and tools",
+        "script_level.level_keys": [
+          "CSPPD3-u5 philosophy and tools"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 unit overview checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u5 unit overview checkin"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 chapter 1 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 1 concepts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 chapter 1 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 1 resources"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 Explore PT checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u5 Explore PT checkin"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Explore PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 chapter 2 concepts",
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 2 concepts"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 chapter 2 resources",
+        "script_level.level_keys": [
+          "CSPPD3-u5 chapter 2 resources"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 Create PT checkin",
+        "script_level.level_keys": [
+          "CSPPD3-u5 Create PT checkin"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Create PT Breakdown",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u5 challenge overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 completing the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u5 completing the challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 list of challenges",
+        "script_level.level_keys": [
+          "CSPPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 pick a challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u5 pick a challenge"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Challenge Overview",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 complete the challenge overview",
+        "script_level.level_keys": [
+          "CSPPD3-u5 complete the challenge overview"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u5 reflect on challenge"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 share out overview",
+        "script_level.level_keys": [
+          "CSPPD3-u5 share out overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 post to forum",
+        "script_level.level_keys": [
+          "CSPPD3-u5 post to forum"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 submit forum link",
+        "script_level.level_keys": [
+          "CSPPD3-u5 submit forum link"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 post survey",
+        "script_level.level_keys": [
+          "CSPPD3-u5 post survey"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "CSPPD3-Unit5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/CodeStudioPuzzleChallenge.script_json
+++ b/dashboard/config/scripts_json/CodeStudioPuzzleChallenge.script_json
@@ -1,0 +1,608 @@
+{
+  "script": {
+    "name": "CodeStudioPuzzleChallenge",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "CodeStudioPuzzleChallenge"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Puzzles",
+      "name": "Puzzles",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 5 - Bee"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 5 - Bee"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 6 - Bee"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 6 - Bee"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 7 - Bee"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 7 - Bee"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 10 - Bee"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 10 - Bee"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 10b - Bee"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 10b - Bee"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 8 - Bee"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 8 - Bee"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 9 - Bee"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 9 - Bee"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 1 - Artist"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 1 - Artist"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 2 - Artist"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 2 - Artist"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 3 - Artist"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 3 - Artist"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 4 - Artist"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 4 - Artist"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Var - Artist"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge Var - Artist"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 11 - Artist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 11 - Artist"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 12 - Artist"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 12 - Artist"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 13 - Artist"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 13 - Artist"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 14 - Artist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge 14 - Artist"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 5 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 5 - Bee"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 6 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 6 - Bee"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 7 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 7 - Bee"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 10 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 10 - Bee"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 10b - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 10b - Bee"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 8 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 8 - Bee"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 9 - Bee",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 9 - Bee"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 1 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 1 - Artist"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 2 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 2 - Artist"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 3 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 3 - Artist"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 4 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 4 - Artist"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge Var - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Var - Artist"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 11 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 11 - Artist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 12 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 12 - Artist"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 13 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 13 - Artist"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge 14 - Artist",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge 14 - Artist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "CodeStudioPuzzleChallenge"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Course4pre.script_json
+++ b/dashboard/config/scripts_json/Course4pre.script_json
@@ -1,0 +1,4045 @@
+{
+  "script": {
+    "name": "Course4pre",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Course4pre"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Maze: Sequence",
+      "name": "Maze: Sequence",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Artist: Sequence",
+      "name": "Artist: Sequence",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Artist: Loops",
+      "name": "Artist: Loops",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Bee: Conditionals",
+      "name": "Bee: Conditionals",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Artist: Nested Loops",
+      "name": "Artist: Nested Loops",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Farmer: While Loops",
+      "name": "Farmer: While Loops",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Bee: Nested Loops",
+      "name": "Bee: Nested Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Artist: Functions",
+      "name": "Artist: Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "key": "Bee: Debugging",
+      "name": "Bee: Debugging",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 6"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 7"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 8"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 9"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze 10"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze Multi 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Match 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Maze Match 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 1 new"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 2 new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 2 new"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 3new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 3new"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 3.4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 3.4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 6"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 9"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 9"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 8"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Assessment 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Assessment 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist match 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 artist match 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Artist 3.5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Artist 4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 11"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 11"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 12"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist 12"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 9"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 10"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 10"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 11"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 11"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 12"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 12"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 13"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 14"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 15"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops match 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 artist loops match 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops multi 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 artist loops multi 2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops multi 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 artist loops multi 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 11"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 11"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 12"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 12"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 13"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 13"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 14"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 14"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 15"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 15"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals Assessment 1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 bee conditionals multi 1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 bee conditionals multi 3"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 6"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 6"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 7"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 11"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 11"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 12"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 12"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Nested Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 artist loops multi 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 artist loops multi 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 4"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 5"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 5"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 6"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 6"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 7"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 7"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops 8"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops Assessment 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 While Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 3"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 4"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 8"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 7"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 10"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Rows"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops Rows"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops Assessment 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Bee Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 bee loops multi 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 bee loops multi 1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 3"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 4"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 11"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11.5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 11.5"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 12"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 9"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 10"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 10"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist functions multi 1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "2-3 artist functions multi 1"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 2"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 3"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 3"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 4"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 4"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 5"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 6"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 7"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 8"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 8"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 9"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 9"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 10"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 10"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 11"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 11"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging Assessment 1"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 bee debug multi 1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      },
+      "level_keys": [
+        "4-5 bee debug multi 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 2",
+        "script_level.level_keys": [
+          "2-3 Maze 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 3",
+        "script_level.level_keys": [
+          "2-3 Maze 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 4",
+        "script_level.level_keys": [
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 6",
+        "script_level.level_keys": [
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 7",
+        "script_level.level_keys": [
+          "2-3 Maze 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 8",
+        "script_level.level_keys": [
+          "2-3 Maze 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 9",
+        "script_level.level_keys": [
+          "2-3 Maze 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 10",
+        "script_level.level_keys": [
+          "2-3 Maze 10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Multi 2",
+        "script_level.level_keys": [
+          "2-3 Maze Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Match 2",
+        "script_level.level_keys": [
+          "2-3 Maze Match 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 2 new",
+        "script_level.level_keys": [
+          "2-3 Artist 2 new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3new",
+        "script_level.level_keys": [
+          "2-3 Artist 3new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3.4",
+        "script_level.level_keys": [
+          "2-3 Artist 3.4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 4",
+        "script_level.level_keys": [
+          "2-3 Artist 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 6",
+        "script_level.level_keys": [
+          "2-3 Artist 6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 9",
+        "script_level.level_keys": [
+          "2-3 Artist 9"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 7",
+        "script_level.level_keys": [
+          "2-3 Artist 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 8",
+        "script_level.level_keys": [
+          "2-3 Artist 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Artist Assessment 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist match 1",
+        "script_level.level_keys": [
+          "2-3 artist match 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 1",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 2",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 3.5",
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 4",
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 11",
+        "script_level.level_keys": [
+          "2-3 Artist 11"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 12",
+        "script_level.level_keys": [
+          "2-3 Artist 12"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 9",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 10",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 10"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 11",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 11"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 12",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 12"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 13",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 14",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 15",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops match 1",
+        "script_level.level_keys": [
+          "2-3 artist loops match 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops multi 2",
+        "script_level.level_keys": [
+          "2-3 artist loops multi 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops multi 1",
+        "script_level.level_keys": [
+          "2-3 artist loops multi 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 2",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 3",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 5",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 6",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 7",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 8",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 9",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 11",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 11"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 12",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 12"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 13",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 13"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 14",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 14"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 15",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 15"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 bee conditionals multi 1",
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 bee conditionals multi 3",
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 1",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 2",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 6",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 6"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 9",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 3",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 5",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 7",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 11",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 11"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 8",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 12",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 12"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 artist loops multi 1",
+        "script_level.level_keys": [
+          "4-5 artist loops multi 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 1",
+        "script_level.level_keys": [
+          "4-5 While Loops 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 2",
+        "script_level.level_keys": [
+          "4-5 While Loops 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 3",
+        "script_level.level_keys": [
+          "4-5 While Loops 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 4",
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 5",
+        "script_level.level_keys": [
+          "4-5 While Loops 5"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 6",
+        "script_level.level_keys": [
+          "4-5 While Loops 6"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 7",
+        "script_level.level_keys": [
+          "4-5 While Loops 7"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 8",
+        "script_level.level_keys": [
+          "4-5 While Loops 8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 While Loops Assessment 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 1",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 2",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 3",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 5",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 4",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 8",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 7",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 10",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 9",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops Rows",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Rows"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Loops Assessment 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 bee loops multi 1",
+        "script_level.level_keys": [
+          "4-5 bee loops multi 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 1",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 2",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 3",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 4",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 11",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 11.5",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11.5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 12",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 9",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 10",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 10"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist functions multi 1",
+        "script_level.level_keys": [
+          "2-3 artist functions multi 1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 1",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 2",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 3",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 3"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 4",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 4"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 5",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 6",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 7",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 8",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 8"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 9",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 9"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 10",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 10"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 11",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 11"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 bee debug multi 1",
+        "script_level.level_keys": [
+          "4-5 bee debug multi 1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "Course4pre"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD-NexTech.script_json
+++ b/dashboard/config/scripts_json/ECSPD-NexTech.script_json
@@ -1,0 +1,1274 @@
+{
+  "script": {
+    "name": "ECSPD-NexTech",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD-NexTech"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "key": "What is ECS?",
+      "name": "What is ECS?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "key": "Impact of Computer Science",
+      "name": "Impact of Computer Science",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "key": "Growth Mindset",
+      "name": "Growth Mindset",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD presurvey"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS Welcome Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS commitment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS commitment match"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS attendance commitment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD pause"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD program overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD curriculum overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD unit matching"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD PD overview"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD PD Phases"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD phase matching"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD PD goals"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD program overlap"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD impact of CS"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD impact vid1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD impact vid2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD impact vid2 question"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD impact in program"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD what is growth mindset"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD growth mindset in the classroom"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD growth mindset question"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD growth mindset strategies"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD teaching strategies video"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "facilitator test"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD forum introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD postsurvey"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      },
+      "level_keys": [
+        "ECSPD end of p1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD presurvey",
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS Welcome Video",
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment",
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment match",
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS attendance commitment",
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD pause",
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overview",
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD curriculum overview",
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD unit matching",
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD overview",
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD Phases",
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD phase matching",
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD goals",
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overlap",
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact of CS",
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid1",
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2",
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2 question",
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact in program",
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD what is growth mindset",
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset in the classroom",
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset question",
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset strategies",
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD teaching strategies video",
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "facilitator test",
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD forum introduction",
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD postsurvey",
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD end of p1",
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-NexTech"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD-iZone.script_json
+++ b/dashboard/config/scripts_json/ECSPD-iZone.script_json
@@ -1,0 +1,1274 @@
+{
+  "script": {
+    "name": "ECSPD-iZone",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD-iZone"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "key": "What is ECS?",
+      "name": "What is ECS?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "key": "Impact of Computer Science",
+      "name": "Impact of Computer Science",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "key": "Growth Mindset",
+      "name": "Growth Mindset",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD presurvey"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "PDECS Welcome Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "PDECS commitment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "PDECS commitment match"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "PDECS attendance commitment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD pause"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD program overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD curriculum overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD unit matching"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD overview"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD Phases"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD phase matching"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD goals"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD program overlap"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD impact of CS"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD impact vid1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD impact vid2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD impact vid2 question"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD impact in program"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD what is growth mindset"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD growth mindset in the classroom"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD growth mindset question"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD growth mindset strategies"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD teaching strategies video"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "facilitator test"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD forum introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD postsurvey"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      },
+      "level_keys": [
+        "ECSPD end of p1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD presurvey",
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS Welcome Video",
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment",
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment match",
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS attendance commitment",
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD pause",
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overview",
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD curriculum overview",
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD unit matching",
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD overview",
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD Phases",
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD phase matching",
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD goals",
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overlap",
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact of CS",
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid1",
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2",
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2 question",
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact in program",
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD what is growth mindset",
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset in the classroom",
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset question",
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset strategies",
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD teaching strategies video",
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "facilitator test",
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD forum introduction",
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD postsurvey",
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD end of p1",
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD-iZone"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD.script_json
+++ b/dashboard/config/scripts_json/ECSPD.script_json
@@ -1,0 +1,1274 @@
+{
+  "script": {
+    "name": "ECSPD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "key": "What is ECS?",
+      "name": "What is ECS?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "key": "Impact of Computer Science",
+      "name": "Impact of Computer Science",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "key": "Growth Mindset",
+      "name": "Growth Mindset",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD presurvey"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "PDECS Welcome Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "PDECS commitment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "PDECS commitment match"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "PDECS attendance commitment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD pause"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD program overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD curriculum overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD unit matching"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD PD overview"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD PD Phases"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD phase matching"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD PD goals"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD program overlap"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD impact of CS"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD impact vid2 question"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD impact in program"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD what is growth mindset"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset in the classroom"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset question"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD growth mindset strategies"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD teaching strategies video"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "facilitator test"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD forum introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD postsurvey"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      },
+      "level_keys": [
+        "ECSPD end of p1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD presurvey",
+        "script_level.level_keys": [
+          "ECSPD presurvey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS Welcome Video",
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment",
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment match",
+        "script_level.level_keys": [
+          "PDECS commitment match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS attendance commitment",
+        "script_level.level_keys": [
+          "PDECS attendance commitment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD pause",
+        "script_level.level_keys": [
+          "ECSPD pause"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overview",
+        "script_level.level_keys": [
+          "ECSPD program overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD curriculum overview",
+        "script_level.level_keys": [
+          "ECSPD curriculum overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD unit matching",
+        "script_level.level_keys": [
+          "ECSPD unit matching"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD overview",
+        "script_level.level_keys": [
+          "ECSPD PD overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD Phases",
+        "script_level.level_keys": [
+          "ECSPD PD Phases"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD phase matching",
+        "script_level.level_keys": [
+          "ECSPD phase matching"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD goals",
+        "script_level.level_keys": [
+          "ECSPD PD goals"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD program overlap",
+        "script_level.level_keys": [
+          "ECSPD program overlap"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "What is ECS?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact of CS",
+        "script_level.level_keys": [
+          "ECSPD impact of CS"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid1",
+        "script_level.level_keys": [
+          "ECSPD impact vid1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2",
+        "script_level.level_keys": [
+          "ECSPD impact vid2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact vid2 question",
+        "script_level.level_keys": [
+          "ECSPD impact vid2 question"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD impact in program",
+        "script_level.level_keys": [
+          "ECSPD impact in program"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Impact of Computer Science",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD what is growth mindset",
+        "script_level.level_keys": [
+          "ECSPD what is growth mindset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset in the classroom",
+        "script_level.level_keys": [
+          "ECSPD growth mindset in the classroom"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset question",
+        "script_level.level_keys": [
+          "ECSPD growth mindset question"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD growth mindset strategies",
+        "script_level.level_keys": [
+          "ECSPD growth mindset strategies"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Growth Mindset",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD teaching strategies video",
+        "script_level.level_keys": [
+          "ECSPD teaching strategies video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "facilitator test",
+        "script_level.level_keys": [
+          "facilitator test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD forum introduction",
+        "script_level.level_keys": [
+          "ECSPD forum introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD postsurvey",
+        "script_level.level_keys": [
+          "ECSPD postsurvey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD end of p1",
+        "script_level.level_keys": [
+          "ECSPD end of p1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "ECSPD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD1.script_json
+++ b/dashboard/config/scripts_json/ECSPD1.script_json
@@ -1,0 +1,875 @@
+{
+  "script": {
+    "name": "ECSPD1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome to Phase 1!",
+      "name": "Welcome to Phase 1!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "key": "Background and Context",
+      "name": "Background and Context",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "key": "ECS Curriculum",
+      "name": "ECS Curriculum",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "key": "Classroom and workshop style ",
+      "name": "Classroom and workshop style ",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "PDECS Welcome Video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 professional learning program phases"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 professional learning program phases"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Matching Program Commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECS Matching Program Commitment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 cs is about"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 cs is about"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 dikjstra"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 dikjstra"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 equity in cs education"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 equity in cs education"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 background reflection"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 background reflection"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 curriculum design"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 curriculum design"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 unit overviews"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 unit overviews"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 Matching Unit Descriptions and Numbers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 Matching Unit Descriptions and Numbers"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 unit 1 overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 unit 1 overview"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 unit 2 overview"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 unit 2 overview"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 curriculum connections"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 curriculum connections"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 computational thinker"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 computational thinker"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 unifying themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 unifying themes"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS PD1 classroom culture"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECS PD1 classroom culture"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 your role"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 your role"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 student centered learning"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 student centered learning"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 Forum"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 Forum"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 post survey"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 post survey"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD1 congratulations end"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      },
+      "level_keys": [
+        "ECSPD1 congratulations end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDECS Welcome Video",
+        "script_level.level_keys": [
+          "PDECS Welcome Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 professional learning program phases",
+        "script_level.level_keys": [
+          "ECSPD1 professional learning program phases"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Matching Program Commitment",
+        "script_level.level_keys": [
+          "ECS Matching Program Commitment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to Phase 1!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 cs is about",
+        "script_level.level_keys": [
+          "ECSPD1 cs is about"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 dikjstra",
+        "script_level.level_keys": [
+          "ECSPD1 dikjstra"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 equity in cs education",
+        "script_level.level_keys": [
+          "ECSPD1 equity in cs education"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 background reflection",
+        "script_level.level_keys": [
+          "ECSPD1 background reflection"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Background and Context",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 curriculum design",
+        "script_level.level_keys": [
+          "ECSPD1 curriculum design"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 unit overviews",
+        "script_level.level_keys": [
+          "ECSPD1 unit overviews"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 Matching Unit Descriptions and Numbers",
+        "script_level.level_keys": [
+          "ECSPD1 Matching Unit Descriptions and Numbers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 unit 1 overview",
+        "script_level.level_keys": [
+          "ECSPD1 unit 1 overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 unit 2 overview",
+        "script_level.level_keys": [
+          "ECSPD1 unit 2 overview"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 curriculum connections",
+        "script_level.level_keys": [
+          "ECSPD1 curriculum connections"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 computational thinker",
+        "script_level.level_keys": [
+          "ECSPD1 computational thinker"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "ECS Curriculum",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 unifying themes",
+        "script_level.level_keys": [
+          "ECSPD1 unifying themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS PD1 classroom culture",
+        "script_level.level_keys": [
+          "ECS PD1 classroom culture"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 your role",
+        "script_level.level_keys": [
+          "ECSPD1 your role"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 student centered learning",
+        "script_level.level_keys": [
+          "ECSPD1 student centered learning"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Classroom and workshop style ",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 Forum",
+        "script_level.level_keys": [
+          "ECSPD1 Forum"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 post survey",
+        "script_level.level_keys": [
+          "ECSPD1 post survey"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD1 congratulations end",
+        "script_level.level_keys": [
+          "ECSPD1 congratulations end"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD2-NexTech.script_json
+++ b/dashboard/config/scripts_json/ECSPD2-NexTech.script_json
@@ -1,0 +1,1785 @@
+{
+  "script": {
+    "name": "ECSPD2-NexTech",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD2-NexTech"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Days 1-2 What Is a Computer?",
+      "name": "Unit 1, Days 1-2 What Is a Computer?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Days 3-4 Buying a Computer",
+      "name": "Unit 1, Days 3-4 Buying a Computer",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Days 5-7 Searching and Web 2",
+      "name": "Unit 1, Days 5-7 Searching and Web 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "name": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Day 10 Telling a Story with Data",
+      "name": "Unit 1, Day 10 Telling a Story with Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Day 11-14 Data Modeling and Design",
+      "name": "Unit 1, Day 11-14 Data Modeling and Design",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "name": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Unit 1, Day 17-19 What Is Intelligence?",
+      "name": "Unit 1, Day 17-19 What Is Intelligence?",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "key": "Wrap-up",
+      "name": "Wrap-up",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online intro"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online Units"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Strategies"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD online U1D3-4 Forum"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Forum"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Resources"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Forum"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Assessment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Resources"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Forum"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Resources"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Forum"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Resources"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Reflection"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Forum"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD Online U1Reflection"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      },
+      "level_keys": [
+        "ECSPD U1Conclusion"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Welcome",
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online intro",
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Units",
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Strategies",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD online U1D3-4 Forum",
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Assessment",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U1Conclusion",
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-NexTech"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD2-iZone.script_json
+++ b/dashboard/config/scripts_json/ECSPD2-iZone.script_json
@@ -1,0 +1,1785 @@
+{
+  "script": {
+    "name": "ECSPD2-iZone",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD2-iZone"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Days 1-2 What Is a Computer?",
+      "name": "Unit 1, Days 1-2 What Is a Computer?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Days 3-4 Buying a Computer",
+      "name": "Unit 1, Days 3-4 Buying a Computer",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Days 5-7 Searching and Web 2",
+      "name": "Unit 1, Days 5-7 Searching and Web 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "name": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Day 10 Telling a Story with Data",
+      "name": "Unit 1, Day 10 Telling a Story with Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Day 11-14 Data Modeling and Design",
+      "name": "Unit 1, Day 11-14 Data Modeling and Design",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "name": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Unit 1, Day 17-19 What Is Intelligence?",
+      "name": "Unit 1, Day 17-19 What Is Intelligence?",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "key": "Wrap-up",
+      "name": "Wrap-up",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online intro"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online Units"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Strategies"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD online U1D3-4 Forum"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Forum"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Resources"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Forum"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Assessment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Resources"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Forum"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Resources"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Forum"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Resources"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Reflection"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Forum"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD Online U1Reflection"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      },
+      "level_keys": [
+        "ECSPD U1Conclusion"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Welcome",
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online intro",
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Units",
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Strategies",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD online U1D3-4 Forum",
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Assessment",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U1Conclusion",
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2-iZone"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD2.script_json
+++ b/dashboard/config/scripts_json/ECSPD2.script_json
@@ -1,0 +1,1785 @@
+{
+  "script": {
+    "name": "ECSPD2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Days 1-2 What Is a Computer?",
+      "name": "Unit 1, Days 1-2 What Is a Computer?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Days 3-4 Buying a Computer",
+      "name": "Unit 1, Days 3-4 Buying a Computer",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Days 5-7 Searching and Web 2",
+      "name": "Unit 1, Days 5-7 Searching and Web 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "name": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Day 10 Telling a Story with Data",
+      "name": "Unit 1, Day 10 Telling a Story with Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Day 11-14 Data Modeling and Design",
+      "name": "Unit 1, Day 11-14 Data Modeling and Design",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "name": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Unit 1, Day 17-19 What Is Intelligence?",
+      "name": "Unit 1, Day 17-19 What Is Intelligence?",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "key": "Wrap-up",
+      "name": "Wrap-up",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online intro"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online Units"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Strategies"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD online U1D3-4 Forum"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Forum"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Resources"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Forum"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Assessment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Resources"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Forum"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Resources"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Forum"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Resources"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Reflection"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Forum"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD Online U1Reflection"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      },
+      "level_keys": [
+        "ECSPD U1Conclusion"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Welcome",
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online intro",
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Units",
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Strategies",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD online U1D3-4 Forum",
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Assessment",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U1Conclusion",
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ECSPD2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD3-Unit2.script_json
+++ b/dashboard/config/scripts_json/ECSPD3-Unit2.script_json
@@ -1,0 +1,1379 @@
+{
+  "script": {
+    "name": "ECSPD3-Unit2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD3-Unit2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "key": "Intro to Unit 2",
+      "name": "Intro to Unit 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "key": "Lesson Overviews",
+      "name": "Lesson Overviews",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "key": "Unit 2 Challenge",
+      "name": "Unit 2 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECS Phase 3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECS Phase 3 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit2 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit2 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 2-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 2-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Growth"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Growth"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Growth Mindset Student Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Growth Mindset Student Video"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD What Is Problem Solving"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD What Is Problem Solving"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Real Life Problem Solving"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Real Life Problem Solving"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Find Learning Strategy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Find Learning Strategy"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 1-2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 1-2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 4-6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 4-6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 7-9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 7-9 Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 10-12 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 10-12 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Binary Odometer"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Binary Odometer"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "U1L5 How the Internet Works - Video"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 13-14 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 13-14 Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Linear vs Binary Search Video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Linear vs Binary Search Video"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 15-16 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 15-16 Intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2L1516 Sorting Video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2L1516 Sorting Video"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 17 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 17 Intro"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 18-21 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 18-21 Intro"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Dani"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Dani"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD What is the Challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD What is the Challenge"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 Challenges"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 Challenges"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 Challenge Decision"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 Challenge Decision"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Pick Challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Pick Challenge"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSU2 Challenge Submission"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSU2 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit2 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit2 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 2-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 2-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Growth",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Growth"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 2 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Growth Mindset Student Video",
+        "script_level.level_keys": [
+          "ECSPD Growth Mindset Student Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD What Is Problem Solving",
+        "script_level.level_keys": [
+          "ECSPD What Is Problem Solving"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Real Life Problem Solving",
+        "script_level.level_keys": [
+          "ECSPD Real Life Problem Solving"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Find Learning Strategy",
+        "script_level.level_keys": [
+          "ECSPD Find Learning Strategy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 1-2",
+        "script_level.level_keys": [
+          "ECSPD U2 D 1-2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 3",
+        "script_level.level_keys": [
+          "ECSPD U2 D 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 4-6",
+        "script_level.level_keys": [
+          "ECSPD U2 D 4-6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 7-9 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 7-9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 10-12 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 10-12 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Binary Odometer",
+        "script_level.level_keys": [
+          "ECSPD Binary Odometer"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 How the Internet Works - Video",
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 13-14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 13-14 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Linear vs Binary Search Video",
+        "script_level.level_keys": [
+          "ECSPD Linear vs Binary Search Video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 15-16 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 15-16 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2L1516 Sorting Video",
+        "script_level.level_keys": [
+          "ECSPD U2L1516 Sorting Video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 17 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 17 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 18-21 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 18-21 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Dani",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Dani"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD What is the Challenge",
+        "script_level.level_keys": [
+          "ECSPD What is the Challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U2 Challenges"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 Challenge Decision",
+        "script_level.level_keys": [
+          "ECSPD U2 Challenge Decision"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Pick Challenge",
+        "script_level.level_keys": [
+          "ECSPD Pick Challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSU2 Challenge Submission",
+        "script_level.level_keys": [
+          "ECSU2 Challenge Submission"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD3-Unit3.script_json
+++ b/dashboard/config/scripts_json/ECSPD3-Unit3.script_json
@@ -1,0 +1,1239 @@
+{
+  "script": {
+    "name": "ECSPD3-Unit3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD3-Unit3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "key": "Intro to Unit 3",
+      "name": "Intro to Unit 3",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "key": "Unit 3 Day-by-Day",
+      "name": "Unit 3 Day-by-Day",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "key": "Unit 3 Challenge",
+      "name": "Unit 3 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit 3 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit3 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit3 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 3-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 3-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Expertise"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Expertise"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD jsfiddle"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD jsfiddle"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Strategy Review"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Stage 6 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Stage 6 Overview"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 1-2 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 1-2 Intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 3-4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 3-4 Intro"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 5 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 5 Intro"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 6-7 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 6-7 Intro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 8-10 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 8-10 Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 11-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 11-13 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 14 Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 15-16 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 15-16 Intro"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 17-19 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 17-19 Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 20-21 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 20-21 Intro"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 22-25 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 22-25 Intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 Challenges"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 Challenges"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 Challenge Decision"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 Challenge Decision"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD unit 3 Pick Challenge"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD unit 3 Pick Challenge"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSU3 Challenge Submission"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSU3 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Survey 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      },
+      "level_keys": [
+        "Unit 3 Survey 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit 3 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit3 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit3 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 3-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 3-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Expertise",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Expertise"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 3 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD jsfiddle",
+        "script_level.level_keys": [
+          "ECSPD jsfiddle"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Strategy Review",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Stage 6 Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Stage 6 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 1-2 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 1-2 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 3-4 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 3-4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 5 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 5 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 6-7 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 6-7 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 8-10 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 8-10 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 11-13 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 11-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 15-16 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 15-16 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 17-19 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 17-19 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 20-21 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 20-21 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 22-25 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 22-25 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U3 Challenges"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 Challenge Decision",
+        "script_level.level_keys": [
+          "ECSPD U3 Challenge Decision"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD unit 3 Pick Challenge",
+        "script_level.level_keys": [
+          "ECSPD unit 3 Pick Challenge"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSU3 Challenge Submission",
+        "script_level.level_keys": [
+          "ECSU3 Challenge Submission"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Survey 2",
+        "script_level.level_keys": [
+          "Unit 3 Survey 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD3-Unit4.script_json
+++ b/dashboard/config/scripts_json/ECSPD3-Unit4.script_json
@@ -1,0 +1,1344 @@
+{
+  "script": {
+    "name": "ECSPD3-Unit4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD3-Unit4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "key": "Intro to Unit 4",
+      "name": "Intro to Unit 4",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "key": "Unit 4 Day-by-Day",
+      "name": "Unit 4 Day-by-Day",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "key": "Unit 4 Challenge",
+      "name": "Unit 4 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit4 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 4 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit 4 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit4 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit4 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 4-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 4-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Manage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Manage"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD scratch"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD scratch"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Strategy Review"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 1 Intro"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 1 Intro"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 2-3 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 2-3 Intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 4 Intro"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 5-6 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 5-6 Intro"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 7-8 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 7-8 Intro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 9 Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 10-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 10-13 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 14 Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 15 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 15 Intro"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 16-17 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 16-17 Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 18 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 18 Intro"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 19 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 19 Intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 20-23 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 20-23 Intro"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 24 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 14,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 24 Intro"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 25-30 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 15,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 25-30 Intro"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 Challenges"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 Challenges"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 Challenge Decision"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 Challenge Decision"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD unit 4 Pick Challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD unit 4 Pick Challenge"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSU4 Challenge Submission fin"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSU4 Challenge Submission fin"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit4 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit 4 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 4 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit4 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit4 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 4-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 4-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Manage",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Manage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 4 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD scratch",
+        "script_level.level_keys": [
+          "ECSPD scratch"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Strategy Review",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 1 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 1 Intro"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 2-3 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 2-3 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 4 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 5-6 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 5-6 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 7-8 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 7-8 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 9 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 10-13 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 10-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 15 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 15 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 16-17 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 16-17 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 18 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 18 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 19 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 19 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 20-23 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 20-23 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 24 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 24 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 14,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 25-30 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 25-30 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 15,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U4 Challenges"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 Challenge Decision",
+        "script_level.level_keys": [
+          "ECSPD U4 Challenge Decision"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD unit 4 Pick Challenge",
+        "script_level.level_keys": [
+          "ECSPD unit 4 Pick Challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSU4 Challenge Submission fin",
+        "script_level.level_keys": [
+          "ECSU4 Challenge Submission fin"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Survey",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD3-Unit5.script_json
+++ b/dashboard/config/scripts_json/ECSPD3-Unit5.script_json
@@ -1,0 +1,1519 @@
+{
+  "script": {
+    "name": "ECSPD3-Unit5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD3-Unit5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "key": "Unit 5 Overview",
+      "name": "Unit 5 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "key": "Unit 5 lessons",
+      "name": "Unit 5 lessons",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "key": "Introduction to the Unit 5 Challenge",
+      "name": "Introduction to the Unit 5 Challenge",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "key": "Complete the Challenge",
+      "name": "Complete the Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECS Phase 3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 about"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 plan"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 intro to u5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 intro to u5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 connections"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 connections"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 what is data"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 what is data"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 tools"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 tools"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 lesson overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 lesson overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 1-3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 1-3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 4-5"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 4-5"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 6-7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 6-7"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 8"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 8"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 9-12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 9-12"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 13"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 14-16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 14-16"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 17"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 18-20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 18-20"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 21"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 22-24"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 22-24"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 25"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 25"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 26-27"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 26-27"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 28-29"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 15,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 28-29"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 30"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 16,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 30"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 challenge inside"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 challenge inside"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 what is a challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 challenge details"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 challenge details"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 list of challenges"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 pick a challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 complete the challenge overview"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 complete the challenge overview"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 share out overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 share out overview"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 post to forum"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 post to forum"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 submit"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 submit"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 post survey"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 about",
+        "script_level.level_keys": [
+          "ECSPD3-u5 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 plan",
+        "script_level.level_keys": [
+          "ECSPD3-u5 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 overview",
+        "script_level.level_keys": [
+          "ECSPD3-u5 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 intro to u5",
+        "script_level.level_keys": [
+          "ECSPD3-u5 intro to u5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 connections",
+        "script_level.level_keys": [
+          "ECSPD3-u5 connections"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 what is data",
+        "script_level.level_keys": [
+          "CSPPD3-u5 what is data"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 tools",
+        "script_level.level_keys": [
+          "ECSPD3-u5 tools"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 lesson overview",
+        "script_level.level_keys": [
+          "ECSPD3-u5 lesson overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 1-3",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 1-3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 4-5",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 4-5"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 6-7",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 6-7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 8",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 8"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 9-12",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 9-12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 13",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 14-16",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 14-16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 17",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 18-20",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 18-20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 21",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 22-24",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 22-24"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 25",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 25"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 26-27",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 26-27"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 28-29",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 28-29"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 15,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 30",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 30"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 16,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 challenge inside",
+        "script_level.level_keys": [
+          "ECSPD3-u5 challenge inside"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 what is a challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u5 what is a challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 challenge details",
+        "script_level.level_keys": [
+          "ECSPD3-u5 challenge details"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 list of challenges",
+        "script_level.level_keys": [
+          "ECSPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 pick a challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u5 pick a challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to the Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 complete the challenge overview",
+        "script_level.level_keys": [
+          "ECSPD3-u5 complete the challenge overview"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Complete the Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 share out overview",
+        "script_level.level_keys": [
+          "ECSPD3-u5 share out overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 post to forum",
+        "script_level.level_keys": [
+          "ECSPD3-u5 post to forum"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 submit",
+        "script_level.level_keys": [
+          "ECSPD3-u5 submit"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 post survey",
+        "script_level.level_keys": [
+          "ECSPD3-u5 post survey"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ECSPD3-Unit6.script_json
+++ b/dashboard/config/scripts_json/ECSPD3-Unit6.script_json
@@ -1,0 +1,1344 @@
+{
+  "script": {
+    "name": "ECSPD3-Unit6",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ECSPD3-Unit6"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "key": "Unit 6 Overview",
+      "name": "Unit 6 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "key": "Unit 6 lessons",
+      "name": "Unit 6 lessons",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "key": "Alternative Ideas for Unit 6",
+      "name": "Alternative Ideas for Unit 6",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "key": "Unit 6 Challenge",
+      "name": "Unit 6 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "key": "Share out and Submit",
+      "name": "Share out and Submit",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECS Phase 3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 about"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 plan"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 intro to u6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 intro to u6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 connections"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 connections"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 why study robotics"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 why study robotics"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 lesson overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 2-3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 2-3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 6-7"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 6-7"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 8-9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 8-9"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 10-13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 10-13"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 14"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 15"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 15"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 16-18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 16-18"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 19-23"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 19-23"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 24-33"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 24-33"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 alt lesson overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 alt lesson overview"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson ideas"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 lesson ideas"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 links to online simulations"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 links to online simulations"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 ideas for culminating projects"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 ideas for culminating projects"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge inside"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 challenge inside"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge details"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 challenge details"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 list of challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 list of challenges"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 pick a challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 pick a challenge"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 do the challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 do the challenge"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 share out overview"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 share out overview"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 post to forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 post to forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 submit forum link"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 submit forum link"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 post survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 post survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 about",
+        "script_level.level_keys": [
+          "ECSPD3-u6 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 plan",
+        "script_level.level_keys": [
+          "ECSPD3-u6 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 overview",
+        "script_level.level_keys": [
+          "ECSPD3-u6 overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 intro to u6",
+        "script_level.level_keys": [
+          "ECSPD3-u6 intro to u6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 connections",
+        "script_level.level_keys": [
+          "ECSPD3-u6 connections"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 why study robotics",
+        "script_level.level_keys": [
+          "ECSPD3-u6 why study robotics"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 lesson overview",
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 1",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 2-3",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 2-3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 4",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 5",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 6-7",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 6-7"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 8-9",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 8-9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 10-13",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 10-13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 14",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 15",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 15"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 16-18",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 16-18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 19-23",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 19-23"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 24-33",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 24-33"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 alt lesson overview",
+        "script_level.level_keys": [
+          "ECSPD3-u6 alt lesson overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 lesson ideas",
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson ideas"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 links to online simulations",
+        "script_level.level_keys": [
+          "ECSPD3-u6 links to online simulations"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 ideas for culminating projects",
+        "script_level.level_keys": [
+          "ECSPD3-u6 ideas for culminating projects"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 challenge inside",
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge inside"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 challenge details",
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge details"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 list of challenges",
+        "script_level.level_keys": [
+          "ECSPD3-u6 list of challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 pick a challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u6 pick a challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 do the challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u6 do the challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 share out overview",
+        "script_level.level_keys": [
+          "ECSPD3-u6 share out overview"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 post to forum",
+        "script_level.level_keys": [
+          "ECSPD3-u6 post to forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 submit forum link",
+        "script_level.level_keys": [
+          "ECSPD3-u6 submit forum link"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 post survey",
+        "script_level.level_keys": [
+          "ECSPD3-u6 post survey"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Share out and Submit",
+        "lesson_group.key": "",
+        "script.name": "ECSPD3-Unit6"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Equity-OnlinePD.script_json
+++ b/dashboard/config/scripts_json/Equity-OnlinePD.script_json
@@ -1,0 +1,651 @@
+{
+  "script": {
+    "name": "Equity-OnlinePD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "Equity Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Equity-OnlinePD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "key": "Introduction to Equity",
+      "name": "Introduction to Equity",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "key": "Creating Equitable Learning Environments",
+      "name": "Creating Equitable Learning Environments",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "key": "Next Steps",
+      "name": "Next Steps",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity About"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity About"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Participation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Participation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Stage1Go"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Stage1Go"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Define"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Define"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity CS"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity CS"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Strategies"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Strategies"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Stage2Go"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Stage2Go"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Self Assess"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Self Assess"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Goals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Resources"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Resources"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Reflection"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Reflection"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Stage3Go"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Stage3Go"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Review"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Review"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Keep Learning"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Keep Learning"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Celebrate"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      },
+      "level_keys": [
+        "Equity Celebrate"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Equity Welcome",
+        "script_level.level_keys": [
+          "Equity Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity About",
+        "script_level.level_keys": [
+          "Equity About"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Participation",
+        "script_level.level_keys": [
+          "Equity Participation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Stage1Go",
+        "script_level.level_keys": [
+          "Equity Stage1Go"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Define",
+        "script_level.level_keys": [
+          "Equity Define"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity CS",
+        "script_level.level_keys": [
+          "Equity CS"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Strategies",
+        "script_level.level_keys": [
+          "Equity Strategies"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Stage2Go",
+        "script_level.level_keys": [
+          "Equity Stage2Go"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Equity",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Self Assess",
+        "script_level.level_keys": [
+          "Equity Self Assess"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Goals",
+        "script_level.level_keys": [
+          "Equity Goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Resources",
+        "script_level.level_keys": [
+          "Equity Resources"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Reflection",
+        "script_level.level_keys": [
+          "Equity Reflection"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Stage3Go",
+        "script_level.level_keys": [
+          "Equity Stage3Go"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Creating Equitable Learning Environments",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Review",
+        "script_level.level_keys": [
+          "Equity Review"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Keep Learning",
+        "script_level.level_keys": [
+          "Equity Keep Learning"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Celebrate",
+        "script_level.level_keys": [
+          "Equity Celebrate"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "Equity-OnlinePD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Hour of Code.script_json
+++ b/dashboard/config/scripts_json/Hour of Code.script_json
@@ -1,0 +1,748 @@
+{
+  "script": {
+    "name": "Hour of Code",
+    "wrapup_video_id": 13,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Hour of Code"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Hour of Code 2013",
+      "name": "Hour of Code 2013",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2_5"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_10"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_11"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_12"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_13"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_14"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_15"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_16"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_17"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_18"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      },
+      "level_keys": [
+        "blockly:Maze:2_19"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_1",
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_3",
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_4",
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_6",
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_7",
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_8",
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_9",
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_10",
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_11",
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_12",
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_13",
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_14",
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_15",
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_16",
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_17",
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_18",
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_19",
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "Hour of Code"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/K5-OnlinePD.script_json
+++ b/dashboard/config/scripts_json/K5-OnlinePD.script_json
@@ -1,0 +1,3069 @@
+{
+  "script": {
+    "name": "K5-OnlinePD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "K5 Support",
+      "announcements": [
+        {
+          "notice": "Updated version of this course available! ",
+          "details": "We have released a new and improved version of this course! Click \"learn more\" to be routed to the 2019 version of Teaching Computer Science Fundamentals.",
+          "link": "https://studio.code.org/s/k5-onlinepd-2019",
+          "type": "warning",
+          "visibility": "Teacher-only"
+        }
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "K5-OnlinePD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Computer Science Fundamentals",
+      "name": "Computer Science Fundamentals",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Looking Ahead",
+      "name": "Looking Ahead",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Mastering the Basics: Sequencing",
+      "name": "Mastering the Basics: Sequencing",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Mastering the Basics: Loops",
+      "name": "Mastering the Basics: Loops",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Mastering the Basics: Conditionals",
+      "name": "Mastering the Basics: Conditionals",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Mastering the Basics: Functions",
+      "name": "Mastering the Basics: Functions",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Mastering the Basics: Events",
+      "name": "Mastering the Basics: Events",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Best Practices for Teaching Computer Science",
+      "name": "Best Practices for Teaching Computer Science",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Planning",
+      "name": "Planning",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "key": "Next Steps",
+      "name": "Next Steps",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 PreSurvey"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 PreSurvey"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Welcome 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 About"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 About"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Participation"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Participation"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Video"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 CS Video"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 CS Tips"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage1Go"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage1Go"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage2Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 WhatIsCS"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Why teach CS"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Younger Grades"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Younger Grades"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Vocabulary"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Vocabulary"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage2Go"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-Stage3Start"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-Stage3Start"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Puzzles"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Puzzles"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Unplugged Video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 What is Mastery"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3Start"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3aGo"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 FirstProgram"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseA_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseA_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseA_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseA_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseA_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Go"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3Go"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Start"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Go"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 RepeatBlock"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Review"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Review"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Start"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Go"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Review"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Review"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Start"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Go"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions2"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions3"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions4"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "courseE_artist_functions5"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Review"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Review"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Start"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Go"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 EventsVid"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 EventsVid"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Congrats"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Congrats"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CongratsFinal"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 CongratsFinal"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage8Start"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage8Start"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Culture"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Culture"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 LessonPlanning"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 LessonPlanning"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Pair"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Pair"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Problem Solving"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Problem Solving"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage8Go"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage8Go"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage9Start"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 CS Courses"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Using CS"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Using CS"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Assessment"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Assessment"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Your Plan"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Go"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage9Go"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Stage10Start"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 PostSurvey"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 PostSurvey"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Closing"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Closing"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Connect"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Connect"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Celebrate"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      },
+      "level_keys": [
+        "OPD-K5 Celebrate"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Intro",
+        "script_level.level_keys": [
+          "OPD-K5 Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 PreSurvey",
+        "script_level.level_keys": [
+          "OPD-K5 PreSurvey"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Welcome 2",
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 About",
+        "script_level.level_keys": [
+          "OPD-K5 About"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Outline",
+        "script_level.level_keys": [
+          "OPD-K5 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Participation",
+        "script_level.level_keys": [
+          "OPD-K5 Participation"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Video",
+        "script_level.level_keys": [
+          "OPD-K5 CS Video"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Tips",
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage1Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage1Go"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage2Overview",
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 WhatIsCS",
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Why teach CS",
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Younger Grades",
+        "script_level.level_keys": [
+          "OPD-K5 Younger Grades"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Vocabulary",
+        "script_level.level_keys": [
+          "OPD-K5 Vocabulary"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage2Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Computer Science Fundamentals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-Stage3Start",
+        "script_level.level_keys": [
+          "OPD-Stage3Start"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Puzzles",
+        "script_level.level_keys": [
+          "OPD-K5 Puzzles"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Unplugged Video",
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 What is Mastery",
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3aGo",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 FirstProgram",
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5",
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6",
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq7",
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8",
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10",
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Go"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Sequencing",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 RepeatBlock",
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Review",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Review"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Mastering the Basics: Loops",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Review",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Review"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1",
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2",
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3",
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4",
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5",
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Review",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Review"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Mastering the Basics: Functions",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 EventsVid",
+        "script_level.level_keys": [
+          "OPD-K5 EventsVid"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Congrats",
+        "script_level.level_keys": [
+          "OPD-K5 Congrats"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CongratsFinal",
+        "script_level.level_keys": [
+          "OPD-K5 CongratsFinal"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Mastering the Basics: Events",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage8Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage8Start"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Culture",
+        "script_level.level_keys": [
+          "OPD-K5 Culture"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 LessonPlanning",
+        "script_level.level_keys": [
+          "OPD-K5 LessonPlanning"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Pair",
+        "script_level.level_keys": [
+          "OPD-K5 Pair"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Problem Solving",
+        "script_level.level_keys": [
+          "OPD-K5 Problem Solving"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage8Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage8Go"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage9Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Courses",
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Using CS",
+        "script_level.level_keys": [
+          "OPD-K5 Using CS"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Assessment",
+        "script_level.level_keys": [
+          "OPD-K5 Assessment"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Your Plan",
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage9Go",
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Go"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Planning",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage10Start",
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 PostSurvey",
+        "script_level.level_keys": [
+          "OPD-K5 PostSurvey"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Closing",
+        "script_level.level_keys": [
+          "OPD-K5 Closing"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Connect",
+        "script_level.level_keys": [
+          "OPD-K5 Connect"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Celebrate",
+        "script_level.level_keys": [
+          "OPD-K5 Celebrate"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "K5-OnlinePD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/K5PD.script_json
+++ b/dashboard/config/scripts_json/K5PD.script_json
@@ -1,0 +1,37 @@
+{
+  "script": {
+    "name": "K5PD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "K5 Support",
+      "announcements": [
+        {
+          "notice": "This Online PD Resource is no longer available",
+          "details": "Click \"Learn More\" to find out about the new Online PD Resources.",
+          "link": "https://studio.code.org/s/k5-onlinepd-2019",
+          "type": "failure",
+          "visibility": "Teacher and student"
+        }
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "K5PD"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/MikeTest.script_json
+++ b/dashboard/config/scripts_json/MikeTest.script_json
@@ -1,0 +1,721 @@
+{
+  "script": {
+    "name": "MikeTest",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "Other plc course"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "MikeTest"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sample Stage",
+      "name": "Sample Stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "key": "Artist Functions",
+      "name": "Artist Functions",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "key": "The same thing with named levels",
+      "name": "The same thing with named levels",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "key": "You are a coding STAR",
+      "name": "You are a coding STAR",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeTest1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeTest1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeTest2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeTest2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeTest3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeAssessment1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeAssessment1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12 Mike"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 12 Mike"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mike Pair Programming"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "Mike Pair Programming"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeTest3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12 Mike"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 12 Mike"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mike Pair Programming"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "Mike Pair Programming"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeTest3"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeStarNested"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeStarNested"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeStarHard"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeStarHard"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MikeStar"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      },
+      "level_keys": [
+        "MikeStar"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MikeTest1",
+        "script_level.level_keys": [
+          "MikeTest1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeTest2",
+        "script_level.level_keys": [
+          "MikeTest2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeTest3",
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeAssessment1",
+        "script_level.level_keys": [
+          "MikeAssessment1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sample Stage",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 12 Mike",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12 Mike"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mike Pair Programming",
+        "script_level.level_keys": [
+          "Mike Pair Programming"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeTest3",
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Artist Functions",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 12 Mike",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12 Mike"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mike Pair Programming",
+        "script_level.level_keys": [
+          "Mike Pair Programming"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeTest3",
+        "script_level.level_keys": [
+          "MikeTest3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "The same thing with named levels",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeStarNested",
+        "script_level.level_keys": [
+          "MikeStarNested"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeStarHard",
+        "script_level.level_keys": [
+          "MikeStarHard"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MikeStar",
+        "script_level.level_keys": [
+          "MikeStar"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "You are a coding STAR",
+        "lesson_group.key": "",
+        "script.name": "MikeTest"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ScienceP3OLPT3.script_json
+++ b/dashboard/config/scripts_json/ScienceP3OLPT3.script_json
@@ -1,0 +1,476 @@
+{
+  "script": {
+    "name": "ScienceP3OLPT3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ScienceP3OLPT3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "key": "Assessing Computer Models",
+      "name": "Assessing Computer Models",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Assessing Computer Models",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "key": "(optional) Refresh your connection to Complex Adaptive Systems",
+      "name": "(optional) Refresh your connection to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "(optional) Refresh your connection to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3OLP33 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD3OLP33 intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 rubric"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Assessing Computer Models",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 rubric"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 implement2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Assessing Computer Models",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 implement2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 refresh"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "(optional) Refresh your connection to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 refresh"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 refresh2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "(optional) Refresh your connection to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 refresh2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 thanks"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 thanks"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 reflection"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 reflection"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 end"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      },
+      "level_keys": [
+        "sciPD33 end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD3OLP33 intro",
+        "script_level.level_keys": [
+          "sciPD3OLP33 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 rubric",
+        "script_level.level_keys": [
+          "sciPD33 rubric"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Assessing Computer Models",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 implement2",
+        "script_level.level_keys": [
+          "sciPD33 implement2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Assessing Computer Models",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 refresh",
+        "script_level.level_keys": [
+          "sciPD33 refresh"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "(optional) Refresh your connection to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 refresh2",
+        "script_level.level_keys": [
+          "sciPD33 refresh2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "(optional) Refresh your connection to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 thanks",
+        "script_level.level_keys": [
+          "sciPD33 thanks"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 reflection",
+        "script_level.level_keys": [
+          "sciPD33 reflection"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 end",
+        "script_level.level_keys": [
+          "sciPD33 end"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "ScienceP3OLPT3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Special Fun.script_json
+++ b/dashboard/config/scripts_json/Special Fun.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "Special Fun",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Special Fun"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Halloween 2015",
+      "name": "Halloween 2015",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      },
+      "level_keys": [
+        "October15 ghost 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      },
+      "level_keys": [
+        "October15 stars 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      },
+      "level_keys": [
+        "October15 JoL 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "October15 ghost 1",
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 stars 1",
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 JoL 1",
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "Special Fun"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/SpecialSeries.script_json
+++ b/dashboard/config/scripts_json/SpecialSeries.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "SpecialSeries",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "SpecialSeries"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Halloween 2015",
+      "name": "Halloween 2015",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      },
+      "level_keys": [
+        "October15 ghost 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      },
+      "level_keys": [
+        "October15 stars 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      },
+      "level_keys": [
+        "October15 JoL 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "October15 ghost 1",
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 stars 1",
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 JoL 1",
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween 2015",
+        "lesson_group.key": "",
+        "script.name": "SpecialSeries"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Test Wednesday.script_json
+++ b/dashboard/config/scripts_json/Test Wednesday.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "Test Wednesday",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Test Wednesday"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Test Wednesday"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "PDK5 Intro",
+      "name": "PDK5 Intro",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "PDK5 Intro",
+        "lesson_group.key": "",
+        "script.name": "Test Wednesday"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "PDK5 Intro",
+        "lesson_group.key": "",
+        "script.name": "Test Wednesday"
+      },
+      "level_keys": [
+        "PDK5 Intro"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Intro",
+        "script_level.level_keys": [
+          "PDK5 Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "PDK5 Intro",
+        "lesson_group.key": "",
+        "script.name": "Test Wednesday"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Testing.script_json
+++ b/dashboard/config/scripts_json/Testing.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "Testing",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Testing"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Testing",
+      "name": "Testing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing",
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Testing",
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      },
+      "level_keys": [
+        "K-1 Maze 2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Testing",
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      },
+      "level_keys": [
+        "2-3 Maze 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 2",
+        "script_level.level_keys": [
+          "K-1 Maze 2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Testing",
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Testing",
+        "lesson_group.key": "",
+        "script.name": "Testing"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/Tutorial Video - Code Studio Puzzle Challenge.script_json
+++ b/dashboard/config/scripts_json/Tutorial Video - Code Studio Puzzle Challenge.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "Tutorial Video - Code Studio Puzzle Challenge",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Puzzles",
+      "name": "Puzzles",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Artist Screencast"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge Artist Screencast"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Artist Screencast 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge Artist Screencast 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Bee Screencast"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      },
+      "level_keys": [
+        "Code Studio Puzzle Challenge Bee Screencast"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge Artist Screencast",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Artist Screencast"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge Artist Screencast 2",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Artist Screencast 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Code Studio Puzzle Challenge Bee Screencast",
+        "script_level.level_keys": [
+          "Code Studio Puzzle Challenge Bee Screencast"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Puzzles",
+        "lesson_group.key": "",
+        "script.name": "Tutorial Video - Code Studio Puzzle Challenge"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algPDmiami.script_json
+++ b/dashboard/config/scripts_json/algPDmiami.script_json
@@ -1,0 +1,2604 @@
+{
+  "script": {
+    "name": "algPDmiami",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algPDmiami"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Strings and Images",
+      "name": "Strings and Images",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Rocket-Height",
+      "name": "Rocket-Height",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Design Recipe Practice",
+      "name": "Design Recipe Practice",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Your Game - Animation",
+      "name": "Your Game - Animation",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Booleans",
+      "name": "Booleans",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Sam the Bat",
+      "name": "Sam the Bat",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Your Game - Booleans",
+      "name": "Your Game - Booleans",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Luigi's Pizza",
+      "name": "Luigi's Pizza",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Your Game - Player Movement",
+      "name": "Your Game - Player Movement",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "key": "Your Game - Collision Detection",
+      "name": "Your Game - Collision Detection",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 5"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 6"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 7"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images 8"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Multi Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 2B"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket 2B"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket 4"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket 5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Design Recipe .1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Design Recipe 6"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Design Recipe 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Design Recipe 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Calc Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Animation 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Animation 2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Animation 3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Animation 4"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 3"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 4"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 5"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Eval Booleans 6"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Blocks to Bools 1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Blocks to Bools 2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Blocks to Bools 3"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Blocks to Bools 4"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Sam the Butterfly 1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Sam the Butterfly 2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Sam the Butterfly 3"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Sam the Butterfly 4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Sam the Butterfly 5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Booleans 1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Booleans 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Booleans 3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Booleans 4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Booleans 5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Luigi's Pizza 1"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Luigi's Pizza 2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Luigi's Pizza 3"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Luigi's Pizza 4"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Collision 1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Collision 2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Collision 3"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Collision 4"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      },
+      "level_keys": [
+        "Big Game Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 5",
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 6",
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 7",
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 8",
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Strings Images 1",
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 2B",
+        "script_level.level_keys": [
+          "Play Lab Rocket 2B"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 4",
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 5",
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe .1",
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 4",
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 6",
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 1",
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 2",
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 3",
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 4",
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Design Recipe Practice",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 1",
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 2",
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 3",
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 4",
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Your Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 1",
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 3",
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 4",
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 5",
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 6",
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 1",
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 2",
+        "script_level.level_keys": [
+          "Blocks to Bools 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 3",
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 4",
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 1",
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 2",
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 3",
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 4",
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 5",
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 1",
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 2",
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 3",
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 4",
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 5",
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Your Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 1",
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 2",
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 3",
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 4",
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 1",
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 2",
+        "script_level.level_keys": [
+          "Big Game Collision 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 3",
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 4",
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Final",
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Your Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algPDmiami"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebra.script_json
+++ b/dashboard/config/scripts_json/algebra.script_json
@@ -1,0 +1,4971 @@
+{
+  "script": {
+    "name": "algebra",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebra"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unplugged: Video Games and Coordinate Planes",
+      "name": "Unplugged: Video Games and Coordinate Planes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Calc: Evaluation Blocks",
+      "name": "Evaluation Blocks and Arithmetic Expressions",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Strings and Images",
+      "name": "Strings and Images",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Unplugged: Contracts",
+      "name": "Unplugged: Contracts, Domain, and Range",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Writing Contracts",
+      "name": "Writing Contracts",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Calc: Defining Variables",
+      "name": "Defining Variables and Substitution",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Defining Variables (Big Game)",
+      "name": "The Big Game - Variables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Defining Functions",
+      "name": "Composite Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Unplugged: The Design Recipe",
+      "name": "Unplugged: The Design Recipe",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Defining Functions",
+      "name": "Rocket Height",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Functions",
+      "name": "Solving Word Problems with the Design Recipe",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Animation (Big Game)",
+      "name": "The Big Game - Animation",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Unplugged: Booleans",
+      "name": "Unplugged: Booleans and Logic",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Boolean Operators",
+      "name": "Boolean Operators",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Booleans",
+      "name": "Sam the Bat",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Boolean (Big Game)",
+      "name": "The Big Game - Booleans",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Unplugged: Conditionals and Piecewise Functions",
+      "name": "Unplugged: Conditionals and Piecewise Functions",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Eval: Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Unplugged: Collision Detection and the Distance Formula",
+      "name": "Unplugged: Collision Detection and the Pythagorean Theorem",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "key": "Play Lab: Collision Detection (Big Game)",
+      "name": "The Big Game - Collision Detection",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VideoGamesCoordinatePlanes"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "VideoGamesCoordinatePlanes"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Ninjacat Demo B"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Ninjacat Demo B"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Coordinates Multi 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Coordinates Multi 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Math 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Math 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Math 3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Math 4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 6"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images 8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Multi Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Contracts"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Contracts"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts A"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts B"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts C"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts D"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts E"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts F"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts 4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Contracts 4 B"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Vars 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Vars 1.1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Vars 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Vars 2.1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "MSM Defining Vars 1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "MSM Defining Vars 2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "MSM Defining Vars 3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "MSM Defining Vars 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Defining Vars Free Play 1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 4"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 5"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 6"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Vars 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Vars 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Vars 3"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Vars 4"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Define Funcs 5"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Multi Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Multi Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Multi Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 13,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 10"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 14,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 11"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 15,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "msm variables multi 13"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "DesignRecipe"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Rocket Contract 1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Rocket 1"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Rocket 2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 2"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 6"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 7"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket 8"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe .1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe 6"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Design Recipe 1"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Design Recipe 2"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Calc Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Design Recipe Free Play"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Animation 1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Animation 2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Animation 3"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Animation 4"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Booleans"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Booleans"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 1"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 3"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 4"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 5"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans 6"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Bools 1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Bools 3"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Blocks to Bools 4"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Booleans Free Play"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Sam the Butterfly 1"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Sam the Butterfly 2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Sam the Butterfly 3"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Sam the Butterfly 4"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Sam the Butterfly 5"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Booleans 1"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Booleans 4"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Booleans 2"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Booleans 3"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Booleans 5"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ConditionalsPiecewiseFunctions"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "ConditionalsPiecewiseFunctions"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Luigi's Pizza 1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Luigi's Pizza 2"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Luigi's Pizza 3"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Luigi's Pizza 4"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Cond 4"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Eval Cond 5"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Player 1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Player 2"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CollisionDetection"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "CollisionDetection"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Collision 1"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Collision 3"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Collision 4"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      },
+      "level_keys": [
+        "Big Game Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "VideoGamesCoordinatePlanes",
+        "script_level.level_keys": [
+          "VideoGamesCoordinatePlanes"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Ninjacat Demo B",
+        "script_level.level_keys": [
+          "Ninjacat Demo B"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Coordinates Multi 1",
+        "script_level.level_keys": [
+          "Coordinates Multi 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unplugged: Video Games and Coordinate Planes",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 1",
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 2",
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 3",
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 4",
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 5",
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 6",
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 7",
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 8",
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Strings Images 1",
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Contracts",
+        "script_level.level_keys": [
+          "Contracts"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts A",
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts B",
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts C",
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts D",
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts E",
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts F",
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4",
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4 B",
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1",
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1.1",
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2",
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2.1",
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 1",
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 2",
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 3",
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 4",
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Defining Vars Free Play 1",
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 1",
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 2",
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 3",
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 4",
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 5",
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 6",
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Calc: Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 1",
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 2",
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 3",
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 4",
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Variables (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 1",
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 2",
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 3",
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 4",
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 5",
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 1",
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 2",
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 3",
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 4",
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 1",
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 2",
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 3",
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 12,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 10",
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 13,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 11",
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 14,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 13",
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 15,
+        "lesson.key": "Eval: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesignRecipe",
+        "script_level.level_keys": [
+          "DesignRecipe"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rocket Contract 1",
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 1",
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 2",
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 2",
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 6",
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 7",
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 8",
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab: Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe .1",
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 4",
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 6",
+        "script_level.level_keys": [
+          "Eval Design Recipe 6"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 1",
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 2",
+        "script_level.level_keys": [
+          "Calc Design Recipe 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 3",
+        "script_level.level_keys": [
+          "Calc Design Recipe 3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 4",
+        "script_level.level_keys": [
+          "Calc Design Recipe 4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe Free Play",
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 1",
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 2",
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 3",
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 4",
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Animation (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Booleans",
+        "script_level.level_keys": [
+          "Booleans"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 1",
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 3",
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 4",
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 5",
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 6",
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 1",
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 3",
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 4",
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans Free Play",
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Eval: Boolean Operators",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 1",
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 2",
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 3",
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 4",
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 5",
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 1",
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 4",
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 2",
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 3",
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 5",
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Boolean (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ConditionalsPiecewiseFunctions",
+        "script_level.level_keys": [
+          "ConditionalsPiecewiseFunctions"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Conditionals and Piecewise Functions",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 1",
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 2",
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 3",
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 4",
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 4",
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 5",
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 1",
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 2",
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CollisionDetection",
+        "script_level.level_keys": [
+          "CollisionDetection"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Collision Detection and the Distance Formula",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 1",
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 3",
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 4",
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Final",
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Collision Detection (Big Game)",
+        "lesson_group.key": "",
+        "script.name": "algebra"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraFacilitator.script_json
+++ b/dashboard/config/scripts_json/algebraFacilitator.script_json
@@ -1,0 +1,721 @@
+{
+  "script": {
+    "name": "algebraFacilitator",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraFacilitator"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "key": "Why Computer Science belongs in Algebra",
+      "name": "Why Computer Science belongs in Algebra",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg functions"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg hard video"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg functional"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Intro",
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functions",
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg hard video",
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functional",
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraFacilitator"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD-NexTech.script_json
+++ b/dashboard/config/scripts_json/algebraPD-NexTech.script_json
@@ -1,0 +1,1204 @@
+{
+  "script": {
+    "name": "algebraPD-NexTech",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD-NexTech"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "key": "Why Computer Science belongs in Algebra",
+      "name": "Why Computer Science belongs in Algebra",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg attendance commitment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Teacher Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Curriculum Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Attitude Survey"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg functions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg hard video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg functional"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Facilitators"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg End of P1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      },
+      "level_keys": [
+        "PDAlg Post Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Intro",
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment",
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment match",
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg attendance commitment",
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Introduction",
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Curriculum Overview",
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Attitude Survey",
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functions",
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg hard video",
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functional",
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Facilitators",
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg End of P1",
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Post Survey",
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-NexTech"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD-iZone.script_json
+++ b/dashboard/config/scripts_json/algebraPD-iZone.script_json
@@ -1,0 +1,1204 @@
+{
+  "script": {
+    "name": "algebraPD-iZone",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD-iZone"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "key": "Why Computer Science belongs in Algebra",
+      "name": "Why Computer Science belongs in Algebra",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg attendance commitment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Teacher Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Curriculum Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Attitude Survey"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg functions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg hard video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg functional"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Facilitators"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg End of P1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      },
+      "level_keys": [
+        "PDAlg Post Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Intro",
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment",
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment match",
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg attendance commitment",
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Introduction",
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Curriculum Overview",
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Attitude Survey",
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functions",
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg hard video",
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functional",
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Facilitators",
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg End of P1",
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Post Survey",
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD-iZone"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD.script_json
+++ b/dashboard/config/scripts_json/algebraPD.script_json
@@ -1,0 +1,1204 @@
+{
+  "script": {
+    "name": "algebraPD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "key": "Why Computer Science belongs in Algebra",
+      "name": "Why Computer Science belongs in Algebra",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg attendance commitment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Teacher Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Curriculum Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Attitude Survey"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg functions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg hard video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg functional"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Facilitators"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg End of P1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      },
+      "level_keys": [
+        "PDAlg Post Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Intro",
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment",
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment match",
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg attendance commitment",
+        "script_level.level_keys": [
+          "PDAlg attendance commitment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Introduction",
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Curriculum Overview",
+        "script_level.level_keys": [
+          "PDAlg Curriculum Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Attitude Survey",
+        "script_level.level_keys": [
+          "PDAlg Attitude Survey"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functions",
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg hard video",
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functional",
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Facilitators",
+        "script_level.level_keys": [
+          "PDAlg Facilitators"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg End of P1",
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Post Survey",
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD1.script_json
+++ b/dashboard/config/scripts_json/algebraPD1.script_json
@@ -1,0 +1,1064 @@
+{
+  "script": {
+    "name": "algebraPD1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "key": "Why Computer Science belongs in Algebra",
+      "name": "Why Computer Science belongs in Algebra",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "key": "Preparing for in-person PD",
+      "name": "Preparing for in-person PD",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Teacher Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg functions"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg hard video"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg functional"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg End of P1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      },
+      "level_keys": [
+        "PDAlg Post Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Intro",
+        "script_level.level_keys": [
+          "PDAlg Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment",
+        "script_level.level_keys": [
+          "PDAlg commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg commitment match",
+        "script_level.level_keys": [
+          "PDAlg commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Introduction",
+        "script_level.level_keys": [
+          "PDAlg Teacher Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functions",
+        "script_level.level_keys": [
+          "PDAlg functions"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg hard video",
+        "script_level.level_keys": [
+          "PDAlg hard video"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg functional",
+        "script_level.level_keys": [
+          "PDAlg functional"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Why Computer Science belongs in Algebra",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg End of P1",
+        "script_level.level_keys": [
+          "PDAlg End of P1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Post Survey",
+        "script_level.level_keys": [
+          "PDAlg Post Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Preparing for in-person PD",
+        "lesson_group.key": "",
+        "script.name": "algebraPD1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD2.script_json
+++ b/dashboard/config/scripts_json/algebraPD2.script_json
@@ -1,0 +1,959 @@
+{
+  "script": {
+    "name": "algebraPD2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "key": "Teaching with Puzzles",
+      "name": "Teaching with Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "key": "Teaching with the Design Recipe",
+      "name": "Teaching with the Design Recipe",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "key": "The Design Recipe",
+      "name": "The Design Recipe",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "key": "Lesson Prep",
+      "name": "Lesson Prep",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg P2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg P2 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Cirlces of Eval"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Cirlces of Eval"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg block match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Puzzle Tips"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Puzzle Tips"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Puzzles Pre"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Puzzles Pre"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg DR 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Multi 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg DR Multi 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Text 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg DR Text 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg DR Multi 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Match 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg DR Match 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Video"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "Calc Design Recipe 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "Eval Design Recipe Free Play"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Teacher Plan"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Prep a Lesson"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Prep on Paper"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "PDAlg Prep Sandbox"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      },
+      "level_keys": [
+        "Lesson Prep Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg P2 Welcome",
+        "script_level.level_keys": [
+          "PDAlg P2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Cirlces of Eval",
+        "script_level.level_keys": [
+          "PDAlg Cirlces of Eval"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg block match",
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Puzzle Tips",
+        "script_level.level_keys": [
+          "PDAlg Puzzle Tips"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Puzzles Pre",
+        "script_level.level_keys": [
+          "PDAlg Puzzles Pre"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR 1",
+        "script_level.level_keys": [
+          "PDAlg DR 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Multi 1",
+        "script_level.level_keys": [
+          "PDAlg DR Multi 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Text 1",
+        "script_level.level_keys": [
+          "PDAlg DR Text 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Multi 2",
+        "script_level.level_keys": [
+          "PDAlg DR Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Match 1",
+        "script_level.level_keys": [
+          "PDAlg DR Match 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Video",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 1",
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe Free Play",
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 1",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 2",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 3",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Plan",
+        "script_level.level_keys": [
+          "PDAlg Teacher Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep a Lesson",
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep on Paper",
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep Sandbox",
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson Prep Final",
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD2a.script_json
+++ b/dashboard/config/scripts_json/algebraPD2a.script_json
@@ -1,0 +1,2716 @@
+{
+  "script": {
+    "name": "algebraPD2a",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD2a"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Strings and Images",
+      "name": "Strings and Images",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Defining Variables",
+      "name": "Defining Variables",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Big Game - Variables",
+      "name": "Big Game - Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Rocket-Height",
+      "name": "Rocket-Height",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "The Design Recipe",
+      "name": "The Design Recipe",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Big Game - Animation",
+      "name": "Big Game - Animation",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Booleans",
+      "name": "Booleans",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Sam the Bat",
+      "name": "Sam the Bat",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Big Game - Booleans",
+      "name": "Big Game - Booleans",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Luigi's Pizza",
+      "name": "Luigi's Pizza",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Big Game - Player Movement",
+      "name": "Big Game - Player Movement",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Big Game - Collision Detection",
+      "name": "Big Game - Collision Detection",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "key": "Free Play",
+      "name": "Free Play",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Free Play",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Blocks to Math 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Blocks to Math 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "MSM Defining Vars 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "MSM Defining Vars 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "MSM Defining Vars 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "MSM Defining Vars 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Defining Vars Free Play 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Vars 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Vars 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Vars 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Vars 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Rocket Contract 1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Rocket 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Rocket 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Play Lab Rocket 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Design Recipe .1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Design Recipe 4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Design Recipe Free Play"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Animation 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Animation 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Animation 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Animation 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Booleans Free Play"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Sam the Butterfly 1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Sam the Butterfly 2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Sam the Butterfly 3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Sam the Butterfly 4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Sam the Butterfly 5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Booleans 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Booleans 4"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Booleans 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Booleans 3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Booleans 5"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Luigi's Pizza 1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Luigi's Pizza 2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Luigi's Pizza 3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Luigi's Pizza 4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Player 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Player 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Collision 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Collision 4"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Collision 3"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Big Game Final"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Free Play"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Free Play",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Calc Free Play"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Free Play"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Free Play",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      },
+      "level_keys": [
+        "Eval Free Play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 1",
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 3",
+        "script_level.level_keys": [
+          "Blocks to Math 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 1",
+        "script_level.level_keys": [
+          "MSM Defining Vars 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 2",
+        "script_level.level_keys": [
+          "MSM Defining Vars 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 3",
+        "script_level.level_keys": [
+          "MSM Defining Vars 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MSM Defining Vars 4",
+        "script_level.level_keys": [
+          "MSM Defining Vars 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Defining Vars Free Play 1",
+        "script_level.level_keys": [
+          "Eval Defining Vars Free Play 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 1",
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 2",
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 3",
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 4",
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rocket Contract 1",
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 1",
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 2",
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 2",
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe .1",
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 4",
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe Free Play",
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 1",
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 2",
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 3",
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 4",
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Animation",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 1",
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 3",
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 4",
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 5",
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 6",
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans Free Play",
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 1",
+        "script_level.level_keys": [
+          "Sam the Butterfly 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 2",
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 3",
+        "script_level.level_keys": [
+          "Sam the Butterfly 3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 4",
+        "script_level.level_keys": [
+          "Sam the Butterfly 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 5",
+        "script_level.level_keys": [
+          "Sam the Butterfly 5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Sam the Bat",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 1",
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 4",
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 2",
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 3",
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 5",
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Big Game - Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 1",
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 2",
+        "script_level.level_keys": [
+          "Luigi's Pizza 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 3",
+        "script_level.level_keys": [
+          "Luigi's Pizza 3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 4",
+        "script_level.level_keys": [
+          "Luigi's Pizza 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Luigi's Pizza",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 1",
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 2",
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Player Movement",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 1",
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 4",
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 3",
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Final",
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Big Game - Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Free Play",
+        "script_level.level_keys": [
+          "Calc Free Play"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Free Play",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Free Play",
+        "script_level.level_keys": [
+          "Eval Free Play"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Free Play",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2a"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD2b.script_json
+++ b/dashboard/config/scripts_json/algebraPD2b.script_json
@@ -1,0 +1,3633 @@
+{
+  "script": {
+    "name": "algebraPD2b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD2b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Best Practices for Teaching Computer Science",
+      "name": "Best Practices for Teaching Computer Science",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Strings and Images",
+      "name": "Strings and Images",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Writing Contracts",
+      "name": "Writing Contracts",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Defining Variables",
+      "name": "Defining Variables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Defining Functions",
+      "name": "Defining Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Rocket-Height",
+      "name": "Rocket-Height",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Booleans",
+      "name": "Booleans",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Eval: Conditionals",
+      "name": "Eval: Conditionals",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "key": "Next Steps",
+      "name": "Next Steps",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K5PD tour"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "K5PD tour"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg circles to blocks"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg circles to blocks"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg block match"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Culture"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Culture"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Pair"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "OPD-K5 Pair"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDK5 Pair programming match"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Problem Solving Video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "OPD-K5 Problem Solving Video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Strategy Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Strategy Reflection"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 4"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Math 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Math 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Math 5"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 6"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Math 6"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 7"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Math 7"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Types Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Types Video"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Strings Images 5"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Strings Images 6"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Strings Images 7"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Strings Images 8"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Multi Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts A"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts B"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts C"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts D"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts E"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts F"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Contracts 4 B"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 1.1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 2.1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 4"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Vars 4"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 4"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 5"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 6"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Define Funcs 5"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Calc Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Multi Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Multi Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Multi Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 10"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 11"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "msm variables multi 13"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Video"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 4"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 5"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 6"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 7"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket 8"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 1"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 3"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 4"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 5"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans 6"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Bools 1"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 2"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Bools 2"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Bools 3"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Blocks to Bools 4"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Booleans Free Play"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 3"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 4"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 5"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 6"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 6"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 7"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 7"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Cond 8"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "Eval Cond 8"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg end of P3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg end of P3"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg whats next"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      },
+      "level_keys": [
+        "PDAlg whats next"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "K5PD tour",
+        "script_level.level_keys": [
+          "K5PD tour"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg circles to blocks",
+        "script_level.level_keys": [
+          "PDAlg circles to blocks"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg block match",
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Culture",
+        "script_level.level_keys": [
+          "PDAlg Culture"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Pair",
+        "script_level.level_keys": [
+          "OPD-K5 Pair"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Pair programming match",
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Problem Solving Video",
+        "script_level.level_keys": [
+          "OPD-K5 Problem Solving Video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Strategy Reflection",
+        "script_level.level_keys": [
+          "PDAlg Strategy Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Best Practices for Teaching Computer Science",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 2",
+        "script_level.level_keys": [
+          "Blocks to Math 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 4",
+        "script_level.level_keys": [
+          "Blocks to Math 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 5",
+        "script_level.level_keys": [
+          "Blocks to Math 5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 6",
+        "script_level.level_keys": [
+          "Blocks to Math 6"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 7",
+        "script_level.level_keys": [
+          "Blocks to Math 7"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Types Video",
+        "script_level.level_keys": [
+          "PDAlg Types Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 5",
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 6",
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 7",
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 8",
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Strings Images 1",
+        "script_level.level_keys": [
+          "Multi Strings Images 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts A",
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts B",
+        "script_level.level_keys": [
+          "Eval Contracts B"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts C",
+        "script_level.level_keys": [
+          "Eval Contracts C"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts D",
+        "script_level.level_keys": [
+          "Eval Contracts D"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts E",
+        "script_level.level_keys": [
+          "Eval Contracts E"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts F",
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4",
+        "script_level.level_keys": [
+          "Eval Contracts 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts 4 B",
+        "script_level.level_keys": [
+          "Eval Contracts 4 B"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Writing Contracts",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1",
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1.1",
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 3",
+        "script_level.level_keys": [
+          "Calc Vars 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2",
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2.1",
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 4",
+        "script_level.level_keys": [
+          "Calc Vars 4"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 1",
+        "script_level.level_keys": [
+          "msm variables multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 2",
+        "script_level.level_keys": [
+          "msm variables multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 3",
+        "script_level.level_keys": [
+          "msm variables multi 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 4",
+        "script_level.level_keys": [
+          "msm variables multi 4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 5",
+        "script_level.level_keys": [
+          "msm variables multi 5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 6",
+        "script_level.level_keys": [
+          "msm variables multi 6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 1",
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 2",
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 3",
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 4",
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 5",
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 1",
+        "script_level.level_keys": [
+          "Calc Define Funcs 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 2",
+        "script_level.level_keys": [
+          "Calc Define Funcs 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 3",
+        "script_level.level_keys": [
+          "Calc Define Funcs 3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Define Funcs 4",
+        "script_level.level_keys": [
+          "Calc Define Funcs 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 1",
+        "script_level.level_keys": [
+          "Multi Define Funcs 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 2",
+        "script_level.level_keys": [
+          "Multi Define Funcs 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Define Funcs 3",
+        "script_level.level_keys": [
+          "Multi Define Funcs 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 10",
+        "script_level.level_keys": [
+          "msm variables multi 10"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 11",
+        "script_level.level_keys": [
+          "msm variables multi 11"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "msm variables multi 13",
+        "script_level.level_keys": [
+          "msm variables multi 13"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Defining Functions",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Video",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 4",
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 5",
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 6",
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 7",
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 8",
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Rocket-Height",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 1",
+        "script_level.level_keys": [
+          "Eval Booleans 1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 3",
+        "script_level.level_keys": [
+          "Eval Booleans 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 4",
+        "script_level.level_keys": [
+          "Eval Booleans 4"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 5",
+        "script_level.level_keys": [
+          "Eval Booleans 5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 6",
+        "script_level.level_keys": [
+          "Eval Booleans 6"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 1",
+        "script_level.level_keys": [
+          "Blocks to Bools 1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 2",
+        "script_level.level_keys": [
+          "Blocks to Bools 2"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 3",
+        "script_level.level_keys": [
+          "Blocks to Bools 3"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Bools 4",
+        "script_level.level_keys": [
+          "Blocks to Bools 4"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans Free Play",
+        "script_level.level_keys": [
+          "Eval Booleans Free Play"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Booleans",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 1",
+        "script_level.level_keys": [
+          "Eval Cond 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 2",
+        "script_level.level_keys": [
+          "Eval Cond 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 3",
+        "script_level.level_keys": [
+          "Eval Cond 3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 4",
+        "script_level.level_keys": [
+          "Eval Cond 4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 5",
+        "script_level.level_keys": [
+          "Eval Cond 5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 6",
+        "script_level.level_keys": [
+          "Eval Cond 6"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 7",
+        "script_level.level_keys": [
+          "Eval Cond 7"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Cond 8",
+        "script_level.level_keys": [
+          "Eval Cond 8"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Eval: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg end of P3",
+        "script_level.level_keys": [
+          "PDAlg end of P3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg whats next",
+        "script_level.level_keys": [
+          "PDAlg whats next"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD2b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD3.script_json
+++ b/dashboard/config/scripts_json/algebraPD3.script_json
@@ -1,0 +1,2772 @@
+{
+  "script": {
+    "name": "algebraPD3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Course Overview",
+      "name": "Course Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "Computer Science Pedagogy",
+      "name": "Computer Science Pedagogy",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "Strings and Images",
+      "name": "Strings and Images",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "The Design Recipe",
+      "name": "The Design Recipe",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "The Big Game",
+      "name": "The Big Game",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "key": "Next Steps",
+      "name": "Next Steps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg bootstrap"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg bootstrap"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg first forum"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg first forum"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K5PD tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "K5PD tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg circles to blocks"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg circles to blocks"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg block match"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Scope"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg implementation"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg course goals"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Strategies O"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Pair Programming 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Pair Programming 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Pair programming match"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Problem Solving"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Problem Solving"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Classroom Culture C"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Classroom Culture C"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Classroom Culture 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Classroom Culture 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Strategies F"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Strategies F"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDK5 Teacher Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Teacher Dashboard"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Blocks Video"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 7"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 8"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 9"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Circles of Eval Free Play"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Types Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Types Video"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 6"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 7"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images 8"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Eval Strings Images Free Play"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Video"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Rocket Contract 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Rocket 1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Calc Rocket 2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 4"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 5"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 6"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 7"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket 8"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Play Lab Rocket Free Play"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Big Game"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg Big Game"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Vars 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Vars 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Vars 3"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Vars 4"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Animation 1"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Animation 2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Animation 3"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Animation 4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Booleans 1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Booleans 4"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Booleans 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Booleans 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Booleans 5"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Player 1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 16,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Player 2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 17,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Collision 1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 18,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Collision 4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 19,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Collision 3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 20,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "Big Game Final"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg end of P3"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg end of P3"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg whats next"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      },
+      "level_keys": [
+        "PDAlg whats next"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg bootstrap",
+        "script_level.level_keys": [
+          "PDAlg bootstrap"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg first forum",
+        "script_level.level_keys": [
+          "PDAlg first forum"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K5PD tour",
+        "script_level.level_keys": [
+          "K5PD tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg circles to blocks",
+        "script_level.level_keys": [
+          "PDAlg circles to blocks"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg block match",
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Scope",
+        "script_level.level_keys": [
+          "PDAlg Scope"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg implementation",
+        "script_level.level_keys": [
+          "PDAlg implementation"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg course goals",
+        "script_level.level_keys": [
+          "PDAlg course goals"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Course Overview",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Strategies O",
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Pair Programming 1",
+        "script_level.level_keys": [
+          "PDK5 Pair Programming 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Pair programming match",
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Problem Solving",
+        "script_level.level_keys": [
+          "PDK5 Problem Solving"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Classroom Culture C",
+        "script_level.level_keys": [
+          "PDK5 Classroom Culture C"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Classroom Culture 2",
+        "script_level.level_keys": [
+          "PDAlg Classroom Culture 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Strategies F",
+        "script_level.level_keys": [
+          "PDK5 Strategies F"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Computer Science Pedagogy",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 1",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Teacher Dashboard 2",
+        "script_level.level_keys": [
+          "PDK5 Teacher Dashboard 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Dashboard",
+        "script_level.level_keys": [
+          "PDAlg Teacher Dashboard"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Blocks Video",
+        "script_level.level_keys": [
+          "PDAlg Blocks Video"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 6",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 7",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 8",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 9",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval Free Play",
+        "script_level.level_keys": [
+          "Calc Circles of Eval Free Play"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Types Video",
+        "script_level.level_keys": [
+          "PDAlg Types Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 5",
+        "script_level.level_keys": [
+          "Eval Strings Images 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 6",
+        "script_level.level_keys": [
+          "Eval Strings Images 6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 7",
+        "script_level.level_keys": [
+          "Eval Strings Images 7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 8",
+        "script_level.level_keys": [
+          "Eval Strings Images 8"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images Free Play",
+        "script_level.level_keys": [
+          "Eval Strings Images Free Play"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Strings and Images",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Video",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rocket Contract 1",
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 1",
+        "script_level.level_keys": [
+          "Calc Rocket 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Rocket 2",
+        "script_level.level_keys": [
+          "Calc Rocket 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 2",
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 4",
+        "script_level.level_keys": [
+          "Play Lab Rocket 4"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 5",
+        "script_level.level_keys": [
+          "Play Lab Rocket 5"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 6",
+        "script_level.level_keys": [
+          "Play Lab Rocket 6"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 7",
+        "script_level.level_keys": [
+          "Play Lab Rocket 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 8",
+        "script_level.level_keys": [
+          "Play Lab Rocket 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket Free Play",
+        "script_level.level_keys": [
+          "Play Lab Rocket Free Play"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Big Game",
+        "script_level.level_keys": [
+          "PDAlg Big Game"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 1",
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 2",
+        "script_level.level_keys": [
+          "Big Game Vars 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 3",
+        "script_level.level_keys": [
+          "Big Game Vars 3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 4",
+        "script_level.level_keys": [
+          "Big Game Vars 4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 1",
+        "script_level.level_keys": [
+          "Big Game Animation 1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 2",
+        "script_level.level_keys": [
+          "Big Game Animation 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 3",
+        "script_level.level_keys": [
+          "Big Game Animation 3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Animation 4",
+        "script_level.level_keys": [
+          "Big Game Animation 4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 1",
+        "script_level.level_keys": [
+          "Big Game Booleans 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 4",
+        "script_level.level_keys": [
+          "Big Game Booleans 4"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 2",
+        "script_level.level_keys": [
+          "Big Game Booleans 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 3",
+        "script_level.level_keys": [
+          "Big Game Booleans 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Booleans 5",
+        "script_level.level_keys": [
+          "Big Game Booleans 5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 1",
+        "script_level.level_keys": [
+          "Big Game Player 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Player 2",
+        "script_level.level_keys": [
+          "Big Game Player 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 16,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 1",
+        "script_level.level_keys": [
+          "Big Game Collision 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 17,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 4",
+        "script_level.level_keys": [
+          "Big Game Collision 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 18,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Collision 3",
+        "script_level.level_keys": [
+          "Big Game Collision 3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 19,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Final",
+        "script_level.level_keys": [
+          "Big Game Final"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 20,
+        "lesson.key": "The Big Game",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg end of P3",
+        "script_level.level_keys": [
+          "PDAlg end of P3"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg whats next",
+        "script_level.level_keys": [
+          "PDAlg whats next"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD3a.script_json
+++ b/dashboard/config/scripts_json/algebraPD3a.script_json
@@ -1,0 +1,651 @@
+{
+  "script": {
+    "name": "algebraPD3a",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD3a"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Updates - Tweaks and Polish",
+      "name": "Updates - Tweaks and Polish",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "key": "Updates - The Big Game and Projects",
+      "name": "Updates - The Big Game and Projects",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "key": "Updates - The Design Recipe",
+      "name": "Updates - The Design Recipe",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "key": "Lesson Prep",
+      "name": "Lesson Prep",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Updates Tweaks"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Updates Tweaks"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Updates Space"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Updates Space"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Updates Errors"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Updates Errors"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Updates Cond"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Updates Cond"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Big Game"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Big Game"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Big Game Remix"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Big Game Remix"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Big Game History"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Big Game History"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Projects"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Projects"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Updates"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Updates"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Examples"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Examples"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Required"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Required"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Delete"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Delete"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Prep a Lesson"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Prep on Paper"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "PDAlg Prep Sandbox"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      },
+      "level_keys": [
+        "Lesson Prep Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Updates Tweaks",
+        "script_level.level_keys": [
+          "PDAlg Updates Tweaks"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Updates Space",
+        "script_level.level_keys": [
+          "PDAlg Updates Space"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Updates Errors",
+        "script_level.level_keys": [
+          "PDAlg Updates Errors"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Updates Cond",
+        "script_level.level_keys": [
+          "PDAlg Updates Cond"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Updates - Tweaks and Polish",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Big Game",
+        "script_level.level_keys": [
+          "PDAlg Big Game"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Big Game Remix",
+        "script_level.level_keys": [
+          "PDAlg Big Game Remix"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Big Game History",
+        "script_level.level_keys": [
+          "PDAlg Big Game History"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Projects",
+        "script_level.level_keys": [
+          "PDAlg Projects"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Updates - The Big Game and Projects",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Updates",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Updates"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Examples",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Examples"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Required",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Required"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Delete",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Delete"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Updates - The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep a Lesson",
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep on Paper",
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep Sandbox",
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson Prep Final",
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3a"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD3b.script_json
+++ b/dashboard/config/scripts_json/algebraPD3b.script_json
@@ -1,0 +1,1253 @@
+{
+  "script": {
+    "name": "algebraPD3b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD3b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Teaching Support - Lessons 1-3",
+      "name": "Teaching Support - Lessons 1-3",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Teaching Support - Lessons 4-7",
+      "name": "Teaching Support - Lessons 4-7",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Teaching Support - Lessons 8-12",
+      "name": "Teaching Support - Lessons 8-12",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Teaching Support - Lessons 13-16",
+      "name": "Teaching Support - Lessons 13-16",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Teaching Support - Lessons 17-20",
+      "name": "Teaching Support - Lessons 17-20",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "key": "Close and Next Steps",
+      "name": "Close and Next Steps",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3BWelcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3BWelcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3BAbout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3BAbout"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "OPD-K5 CS Tips"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3BPlanning"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3BPlanning"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3BGo"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3BGo"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons1-3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Lessons1-3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 1-3 Circles"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 1-3 Circles"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 1-3 Circles Practice"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 1-3 Circles Practice"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons4-7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Lessons4-7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 4-7 Contracts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 4-7 Contracts"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 4-7 Contracts Match"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 4-7 Contracts Match"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 4-7 Variables"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 4-7 Variables"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 4-7 Big Game"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 4-7 Big Game"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons8-12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Lessons8-12"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 Design Recipe"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 Design Recipe"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 Examples"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 Examples"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 ex dr 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 ex dr 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 ex dr 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 ex dr 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 Rocket Height"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 Rocket Height"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 8-12 Rocket Height Puzzle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 8-12 Rocket Height Puzzle"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons13-16"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Lessons13-16"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 13-16 Booleans"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 13-16 Booleans"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 13-16 Simple Sam"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 13-16 Simple Sam"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 13-16 Sam Extension"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 13-16 Sam Extension"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 13-16 Sam Extension Puzzle"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 13-16 Sam Extension Puzzle"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons17-20"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Lessons17-20"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 17-20 Luigi Extensions"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 17-20 Luigi Extensions"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 17-20 Luigi Extension Puzzle"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 17-20 Luigi Extension Puzzle"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg phase 3b survey"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg phase 3b survey"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Review"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Review"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B KeepLearning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B KeepLearning"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3B Survey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      },
+      "level_keys": [
+        "PDAlg 3B Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3BWelcome",
+        "script_level.level_keys": [
+          "PDAlg 3BWelcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3BAbout",
+        "script_level.level_keys": [
+          "PDAlg 3BAbout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Tips",
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3BPlanning",
+        "script_level.level_keys": [
+          "PDAlg 3BPlanning"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3BGo",
+        "script_level.level_keys": [
+          "PDAlg 3BGo"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Lessons1-3",
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons1-3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 1-3 Circles",
+        "script_level.level_keys": [
+          "PDAlg 1-3 Circles"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 1-3 Circles Practice",
+        "script_level.level_keys": [
+          "PDAlg 1-3 Circles Practice"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 1-3",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Lessons4-7",
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons4-7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 4-7 Contracts",
+        "script_level.level_keys": [
+          "PDAlg 4-7 Contracts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 4-7 Contracts Match",
+        "script_level.level_keys": [
+          "PDAlg 4-7 Contracts Match"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 4-7 Variables",
+        "script_level.level_keys": [
+          "PDAlg 4-7 Variables"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 4-7 Big Game",
+        "script_level.level_keys": [
+          "PDAlg 4-7 Big Game"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 4-7",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Lessons8-12",
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons8-12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 Design Recipe",
+        "script_level.level_keys": [
+          "PDAlg 8-12 Design Recipe"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 Examples",
+        "script_level.level_keys": [
+          "PDAlg 8-12 Examples"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 ex dr 1",
+        "script_level.level_keys": [
+          "PDAlg 8-12 ex dr 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 ex dr 2",
+        "script_level.level_keys": [
+          "PDAlg 8-12 ex dr 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 Rocket Height",
+        "script_level.level_keys": [
+          "PDAlg 8-12 Rocket Height"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 8-12 Rocket Height Puzzle",
+        "script_level.level_keys": [
+          "PDAlg 8-12 Rocket Height Puzzle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Support - Lessons 8-12",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Lessons13-16",
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons13-16"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 13-16 Booleans",
+        "script_level.level_keys": [
+          "PDAlg 13-16 Booleans"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 13-16 Simple Sam",
+        "script_level.level_keys": [
+          "PDAlg 13-16 Simple Sam"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 13-16 Sam Extension",
+        "script_level.level_keys": [
+          "PDAlg 13-16 Sam Extension"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 13-16 Sam Extension Puzzle",
+        "script_level.level_keys": [
+          "PDAlg 13-16 Sam Extension Puzzle"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Support - Lessons 13-16",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Lessons17-20",
+        "script_level.level_keys": [
+          "PDAlg 3B Lessons17-20"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 17-20 Luigi Extensions",
+        "script_level.level_keys": [
+          "PDAlg 17-20 Luigi Extensions"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 17-20 Luigi Extension Puzzle",
+        "script_level.level_keys": [
+          "PDAlg 17-20 Luigi Extension Puzzle"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg phase 3b survey",
+        "script_level.level_keys": [
+          "PDAlg phase 3b survey"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Support - Lessons 17-20",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Review",
+        "script_level.level_keys": [
+          "PDAlg 3B Review"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B KeepLearning",
+        "script_level.level_keys": [
+          "PDAlg 3B KeepLearning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3B Survey",
+        "script_level.level_keys": [
+          "PDAlg 3B Survey"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Close and Next Steps",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebraPD3c.script_json
+++ b/dashboard/config/scripts_json/algebraPD3c.script_json
@@ -1,0 +1,567 @@
+{
+  "script": {
+    "name": "algebraPD3c",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebraPD3c"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "key": "Sharing Student Work",
+      "name": "Sharing Student Work",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "key": "Planning For the Future",
+      "name": "Planning For the Future",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CWelcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CWelcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CAbout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CAbout"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "OPD-K5 CS Tips"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CPlanning"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CPlanning"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CGo"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CGo"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CGathering"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CGathering"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CSharing"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CSharing"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CShare Forum"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CShare Forum"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CFuture"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CFuture"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CCourseAB"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CCourseAB"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CBootstrap"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CBootstrap"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CElective"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CElective"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CSharePlan"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CSharePlan"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg 3CCongrats"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      },
+      "level_keys": [
+        "PDAlg 3CCongrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CWelcome",
+        "script_level.level_keys": [
+          "PDAlg 3CWelcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CAbout",
+        "script_level.level_keys": [
+          "PDAlg 3CAbout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Tips",
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CPlanning",
+        "script_level.level_keys": [
+          "PDAlg 3CPlanning"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CGo",
+        "script_level.level_keys": [
+          "PDAlg 3CGo"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CGathering",
+        "script_level.level_keys": [
+          "PDAlg 3CGathering"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CSharing",
+        "script_level.level_keys": [
+          "PDAlg 3CSharing"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CShare Forum",
+        "script_level.level_keys": [
+          "PDAlg 3CShare Forum"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Sharing Student Work",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CFuture",
+        "script_level.level_keys": [
+          "PDAlg 3CFuture"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CCourseAB",
+        "script_level.level_keys": [
+          "PDAlg 3CCourseAB"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CBootstrap",
+        "script_level.level_keys": [
+          "PDAlg 3CBootstrap"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CElective",
+        "script_level.level_keys": [
+          "PDAlg 3CElective"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CSharePlan",
+        "script_level.level_keys": [
+          "PDAlg 3CSharePlan"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg 3CCongrats",
+        "script_level.level_keys": [
+          "PDAlg 3CCongrats"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Planning For the Future",
+        "lesson_group.key": "",
+        "script.name": "algebraPD3c"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebrademo.script_json
+++ b/dashboard/config/scripts_json/algebrademo.script_json
@@ -1,0 +1,1224 @@
+{
+  "script": {
+    "name": "algebrademo",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebrademo"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Evaluation Blocks",
+      "name": "Evaluation Blocks",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "key": "Making Pictures",
+      "name": "Making Pictures",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "key": "Defining Variables",
+      "name": "Defining Variables",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "key": "Defining Simple Functions",
+      "name": "Defining Simple Functions",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "key": "The Design Recipe",
+      "name": "The Design Recipe",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Circles of Eval 5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images .1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Strings Images 4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 1.1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 2.1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Calc Vars 4"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Define Funcs 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Define Funcs 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Define Funcs 4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Define Funcs 5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Play Lab Rocket 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Rocket Contract 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Play Lab Rocket 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Play Lab Rocket 3"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Design Recipe .1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      },
+      "level_keys": [
+        "Eval Design Recipe 4"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .1",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 3",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 4",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval 5",
+        "script_level.level_keys": [
+          "Calc Circles of Eval 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Evaluation Blocks",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .1",
+        "script_level.level_keys": [
+          "Eval Strings Images .1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 1",
+        "script_level.level_keys": [
+          "Eval Strings Images 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 2",
+        "script_level.level_keys": [
+          "Eval Strings Images 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 3",
+        "script_level.level_keys": [
+          "Eval Strings Images 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images 4",
+        "script_level.level_keys": [
+          "Eval Strings Images 4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Making Pictures",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1",
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1.1",
+        "script_level.level_keys": [
+          "Calc Vars 1.1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 3",
+        "script_level.level_keys": [
+          "Calc Vars 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2",
+        "script_level.level_keys": [
+          "Calc Vars 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 2.1",
+        "script_level.level_keys": [
+          "Calc Vars 2.1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 4",
+        "script_level.level_keys": [
+          "Calc Vars 4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Defining Variables",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 1",
+        "script_level.level_keys": [
+          "Eval Define Funcs 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 2",
+        "script_level.level_keys": [
+          "Eval Define Funcs 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 3",
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 4",
+        "script_level.level_keys": [
+          "Eval Define Funcs 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 5",
+        "script_level.level_keys": [
+          "Eval Define Funcs 5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Defining Simple Functions",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 1",
+        "script_level.level_keys": [
+          "Play Lab Rocket 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rocket Contract 1",
+        "script_level.level_keys": [
+          "Rocket Contract 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 2",
+        "script_level.level_keys": [
+          "Play Lab Rocket 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Play Lab Rocket 3",
+        "script_level.level_keys": [
+          "Play Lab Rocket 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe .1",
+        "script_level.level_keys": [
+          "Eval Design Recipe .1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 4",
+        "script_level.level_keys": [
+          "Eval Design Recipe 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrademo"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/algebrapdnext.script_json
+++ b/dashboard/config/scripts_json/algebrapdnext.script_json
@@ -1,0 +1,959 @@
+{
+  "script": {
+    "name": "algebrapdnext",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Algebra Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "algebrapdnext"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "key": "Teaching with Puzzles",
+      "name": "Teaching with Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "key": "Teaching with the Design Recipe",
+      "name": "Teaching with the Design Recipe",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "key": "The Design Recipe",
+      "name": "The Design Recipe",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "key": "Teacher Dashboard",
+      "name": "Teacher Dashboard",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "key": "Lesson Prep",
+      "name": "Lesson Prep",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg P2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg P2 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Cirlces of Eval"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Cirlces of Eval"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg block match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Puzzle Tips"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Puzzle Tips"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Puzzles Pre"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Puzzles Pre"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg DR 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Multi 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg DR Multi 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Text 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg DR Text 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg DR Multi 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg DR Match 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg DR Match 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Design Recipe Video"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "Eval Design Recipe 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "Eval Design Recipe 5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "Calc Design Recipe 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "Eval Design Recipe Free Play"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Dashboard 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Dashboard 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Teacher Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Teacher Plan"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Prep a Lesson"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Prep on Paper"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "PDAlg Prep Sandbox"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      },
+      "level_keys": [
+        "Lesson Prep Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDAlg P2 Welcome",
+        "script_level.level_keys": [
+          "PDAlg P2 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Cirlces of Eval",
+        "script_level.level_keys": [
+          "PDAlg Cirlces of Eval"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg block match",
+        "script_level.level_keys": [
+          "PDAlg block match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Puzzle Tips",
+        "script_level.level_keys": [
+          "PDAlg Puzzle Tips"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Puzzles Pre",
+        "script_level.level_keys": [
+          "PDAlg Puzzles Pre"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with Puzzles",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR 1",
+        "script_level.level_keys": [
+          "PDAlg DR 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Multi 1",
+        "script_level.level_keys": [
+          "PDAlg DR Multi 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Text 1",
+        "script_level.level_keys": [
+          "PDAlg DR Text 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Multi 2",
+        "script_level.level_keys": [
+          "PDAlg DR Multi 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg DR Match 1",
+        "script_level.level_keys": [
+          "PDAlg DR Match 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Teaching with the Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Design Recipe Video",
+        "script_level.level_keys": [
+          "PDAlg Design Recipe Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 3",
+        "script_level.level_keys": [
+          "Eval Design Recipe 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe 5",
+        "script_level.level_keys": [
+          "Eval Design Recipe 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Design Recipe 1",
+        "script_level.level_keys": [
+          "Calc Design Recipe 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Design Recipe Free Play",
+        "script_level.level_keys": [
+          "Eval Design Recipe Free Play"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Design Recipe",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 1",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 2",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Dashboard 3",
+        "script_level.level_keys": [
+          "PDAlg Dashboard 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Teacher Plan",
+        "script_level.level_keys": [
+          "PDAlg Teacher Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Teacher Dashboard",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep a Lesson",
+        "script_level.level_keys": [
+          "PDAlg Prep a Lesson"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep on Paper",
+        "script_level.level_keys": [
+          "PDAlg Prep on Paper"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDAlg Prep Sandbox",
+        "script_level.level_keys": [
+          "PDAlg Prep Sandbox"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson Prep Final",
+        "script_level.level_keys": [
+          "Lesson Prep Final"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Prep",
+        "lesson_group.key": "",
+        "script.name": "algebrapdnext"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/allthehiddenthings.script_json
+++ b/dashboard/config/scripts_json/allthehiddenthings.script_json
@@ -1,0 +1,202 @@
+{
+  "script": {
+    "name": "allthehiddenthings",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "allthehiddenthings"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Game Lab",
+      "name": "Game Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Game Lab",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    },
+    {
+      "key": "Contained Levels",
+      "name": "Contained Levels",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Game Lab",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      },
+      "level_keys": [
+        "allthethings_U3 - Simple Drawing - Rectangle Width and Height"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test GameLab Predictive"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      },
+      "level_keys": [
+        "Test GameLab Predictive"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test Contained Multi"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      },
+      "level_keys": [
+        "Test Contained Multi"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PS predictive Applab level test"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      },
+      "level_keys": [
+        "PS predictive Applab level test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "allthethings_U3 - Simple Drawing - Rectangle Width and Height",
+        "script_level.level_keys": [
+          "allthethings_U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Game Lab",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test GameLab Predictive",
+        "script_level.level_keys": [
+          "Test GameLab Predictive"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test Contained Multi",
+        "script_level.level_keys": [
+          "Test Contained Multi"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PS predictive Applab level test",
+        "script_level.level_keys": [
+          "PS predictive Applab level test"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthehiddenthings"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/alltheplcthings.script_json
+++ b/dashboard/config/scripts_json/alltheplcthings.script_json
@@ -1,0 +1,1174 @@
+{
+  "script": {
+    "name": "alltheplcthings",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "All The PLC Things",
+      "peer_reviews_to_complete": 5
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "alltheplcthings"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Teachercon",
+      "name": "Introduction to Teachercon",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 1,4",
+      "name": "Lesson 1,4",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 1,6",
+      "name": "Lesson 1,6",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 1,9",
+      "name": "Lesson 1,9",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 1,10",
+      "name": "Lesson 1,10",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 1,11",
+      "name": "Lesson 1,11",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 2,2",
+      "name": "Lesson 2,2",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 2,3",
+      "name": "Lesson 2,3",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Lesson 2,10",
+      "name": "Lesson 2,10",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Test stage with bubbles",
+      "name": "Test stage with bubbles",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Welcome to TeacherCon!"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Welcome to TeacherCon!"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TeacherCon Agenda"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "TeacherCon Agenda"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TeacherCon Self-Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "TeacherCon Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Lesson Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U1L4 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Lesson Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U1L6 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Lesson Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U1L9 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Lesson Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U1L10 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U1L11 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 Lesson Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U2L2 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Lesson Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U2L3 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Lesson Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "U2L10 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "cspu5_assess1_eventprograms"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "cspu5_assess1_eventprograms"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "cspu5_assess1_elementid"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "cspu5_assess1_elementid"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "cspu5_assess1_debugging"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "cspu5_assess1_debugging"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "cspu5_assess1_codevalues"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "cspu5_assess1_codevalues"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Peer Review Level 1 - Tuesday Report"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Peer Review Level 1 - Tuesday Report"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Peer Review Level 2 - Wednesday Report"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Peer Review Level 2 - Wednesday Report"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Peer Review Level 1 - Tuesday Report"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Peer Review Level 1 - Tuesday Report"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Peer Review Level 2 - Wednesday Report"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      },
+      "level_keys": [
+        "Peer Review Level 2 - Wednesday Report"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Welcome to TeacherCon!",
+        "script_level.level_keys": [
+          "Welcome to TeacherCon!"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TeacherCon Agenda",
+        "script_level.level_keys": [
+          "TeacherCon Agenda"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TeacherCon Self-Assessment",
+        "script_level.level_keys": [
+          "TeacherCon Self-Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L4 Lesson Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L6 Lesson Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L9 Lesson Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L10 Lesson Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L11 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L2 Lesson Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L3 Lesson Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L10 Lesson Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "cspu5_assess1_eventprograms",
+        "script_level.level_keys": [
+          "cspu5_assess1_eventprograms"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "cspu5_assess1_elementid",
+        "script_level.level_keys": [
+          "cspu5_assess1_elementid"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "cspu5_assess1_debugging",
+        "script_level.level_keys": [
+          "cspu5_assess1_debugging"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "cspu5_assess1_codevalues",
+        "script_level.level_keys": [
+          "cspu5_assess1_codevalues"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Test stage with bubbles",
+        "lesson_group.key": "content",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Wednesday Report: Balancing Teachers and Tools in Unit 1",
+        "script_level.level_keys": [
+          "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Peer Review Level 1 - Tuesday Report",
+        "script_level.level_keys": [
+          "Peer Review Level 1 - Tuesday Report"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Peer Review Level 2 - Wednesday Report",
+        "script_level.level_keys": [
+          "Peer Review Level 2 - Wednesday Report"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Peer Review Level 1 - Tuesday Report",
+        "script_level.level_keys": [
+          "Peer Review Level 1 - Tuesday Report"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Peer Review Level 2 - Wednesday Report",
+        "script_level.level_keys": [
+          "Peer Review Level 2 - Wednesday Report"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "alltheplcthings"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/allthesurveys.script_json
+++ b/dashboard/config/scripts_json/allthesurveys.script_json
@@ -1,0 +1,623 @@
+{
+  "script": {
+    "name": "allthesurveys",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "allthesurveys"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP post course survey 2019 staging",
+      "name": "CSP post course survey 2019 staging",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSD post course survey 2019 staging",
+      "name": "CSD post course survey 2019 staging",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSP pre survey 2017 staging",
+      "name": "CSP pre survey 2017 staging",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSD pre survey 2017 staging",
+      "name": "CSD pre survey 2017 staging",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSD/P pulse check survey 2017",
+      "name": "CSD/P pulse check survey 2017",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD/P pulse check survey 2017",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSD mid and post survey 2017 staging",
+      "name": "CSD mid and post survey 2017 staging",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSP mid and post survey 2017 staging",
+      "name": "CSP mid and post survey 2017 staging",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSP post survey 2018 staging",
+      "name": "CSP post survey 2018 staging",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSD post survey 2018 staging",
+      "name": "CSD post survey 2018 staging",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSP pre survey 2018 staging",
+      "name": "CSP pre survey 2018 staging",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP pre survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "CSP mid survey 2018 staging",
+      "name": "CSP mid survey 2018 staging",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP mid survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "key": "Place for testing crazy stuff",
+      "name": "Place for testing crazy stuff",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Place for testing crazy stuff",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "CSD post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csd-post-survey-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "CSP pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-pre-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "CSD pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csd-pre-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "pulse check model"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CSD/P pulse check survey 2017",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CSD mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "CSP mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-post-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-levelgroup"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "CSP post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-levelgroup"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "CSD post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "CSP pre survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-pre-survey-2017-levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "CSP mid survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "csp-post-survey-2017-levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Levelgroup-for-testing-stuff"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Place for testing crazy stuff",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      },
+      "level_keys": [
+        "Levelgroup-for-testing-stuff"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "CSD post course survey 2019 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "CSP pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "CSD pre survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CSD/P pulse check survey 2017",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CSD mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "CSP mid and post survey 2017 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-levelgroup",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-levelgroup"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "CSP post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup-2018-2nd-semester",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "CSD post survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "CSP pre survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "CSP mid survey 2018 staging",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Levelgroup-for-testing-stuff",
+        "script_level.level_keys": [
+          "Levelgroup-for-testing-stuff"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Place for testing crazy stuff",
+        "lesson_group.key": "",
+        "script.name": "allthesurveys"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -1,0 +1,5881 @@
+{
+  "script": {
+    "name": "allthethings",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "allthethings"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Jigsaw",
+      "name": "Jigsaw",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Maze",
+      "name": "Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Bee",
+      "name": "Bee",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "PlayLab",
+      "name": "PlayLab",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Farmer",
+      "name": "Farmer",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Flappy",
+      "name": "Flappy",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Bounce",
+      "name": "Bounce",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Multi",
+      "name": "Multi",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Multi2",
+      "name": "Multi2",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Match",
+      "name": "Match",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Match",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "TextMatch",
+      "name": "TextMatch",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "TextMatch",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "CSinA",
+      "name": "CSinA",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Netsim",
+      "name": "Netsim",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Odometer",
+      "name": "Odometer",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Odometer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Pixelation",
+      "name": "Pixelation",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "AppLab",
+      "name": "AppLab",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Gamelab",
+      "name": "Gamelab",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Online PD",
+      "name": "Online PD",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Online PD",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Markdown Details",
+      "name": "Markdown Details",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Studio",
+      "name": "Studio",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Multi page assessment",
+      "name": "Multi page assessment",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Star wars",
+      "name": "Star wars",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Star wars",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Minecraft",
+      "name": "Minecraft",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Rich long assessment",
+      "name": "Rich long assessment",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rich long assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Free Response",
+      "name": "Free Response",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Sample PLC Assessment",
+      "name": "Sample PLC Assessment",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample PLC Assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Swapped Levels",
+      "name": "Swapped Levels",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Anonymous student survey",
+      "name": "Anonymous student survey",
+      "absolute_position": 30,
+      "lockable": false,
+      "relative_position": 30,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Anonymous student survey",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Anonymous student survey 2",
+      "name": "Anonymous student survey 2",
+      "absolute_position": 31,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Anonymous student survey 2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Public Key Cryptography",
+      "name": "Public Key Cryptography",
+      "absolute_position": 32,
+      "lockable": false,
+      "relative_position": 31,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Cryptography",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Web Lab",
+      "name": "Web Lab",
+      "absolute_position": 33,
+      "lockable": false,
+      "relative_position": 32,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Web Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Single page assessment",
+      "name": "Single page assessment",
+      "absolute_position": 34,
+      "lockable": false,
+      "relative_position": 33,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Single page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Standalone video",
+      "name": "Standalone video",
+      "absolute_position": 35,
+      "lockable": false,
+      "relative_position": 34,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Standalone video",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Curriculum Reference",
+      "name": "Curriculum Reference",
+      "absolute_position": 36,
+      "lockable": false,
+      "relative_position": 35,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Curriculum Reference",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Sprite Lab",
+      "name": "Sprite Lab",
+      "absolute_position": 37,
+      "lockable": false,
+      "relative_position": 36,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Dance Lab",
+      "name": "Dance Lab",
+      "absolute_position": 38,
+      "lockable": false,
+      "relative_position": 37,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Mini Rubric",
+      "name": "Mini Rubric",
+      "absolute_position": 39,
+      "lockable": false,
+      "relative_position": 38,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Pluralsight Test",
+      "name": "Pluralsight Test",
+      "absolute_position": 40,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pluralsight Test",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Externals Optionally Displayed as Unplugged",
+      "name": "Externals Optionally Displayed as Unplugged",
+      "absolute_position": 41,
+      "lockable": false,
+      "relative_position": 39,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Externals Optionally Displayed as Unplugged",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Bubble Choice",
+      "name": "Bubble Choice",
+      "absolute_position": 42,
+      "lockable": false,
+      "relative_position": 40,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bubble Choice",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "Contained Levels",
+      "name": "Contained Levels",
+      "absolute_position": 43,
+      "lockable": false,
+      "relative_position": 41,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "key": "ML Fish",
+      "name": "ML Fish",
+      "absolute_position": 44,
+      "lockable": false,
+      "relative_position": 42,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ML Fish",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "k-1 maze 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "k-1 maze 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Maze 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 Maze 4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "courseC_maze_programming3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-anigif-instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-anigif-instructions"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Artist1 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Artist 1 new"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 4"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Vars 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Auto Open Function Editor"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Auto Open Function Editor"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Angle Helper Test"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Angle Helper Test"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-artist-project-backed"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-artist-project-backed"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Artist Autorun Test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Artist Autorun Test"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Bee 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2A"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 2A"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 5"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Bee Recommended Blocks test"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Bee Recommended Blocks test"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-playlab-project-backed"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-playlab-project-backed"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Encrypted Play Lab Level"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Allthethings Encrypted Play Lab Level"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 While Loops 4"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Farmer for Authored Hint testing"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Farmer for Authored Hint testing"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Farmer for TTS testing"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Farmer for TTS testing"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Happy Maps Multi 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Happy Maps Multi 1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi Horizontal Scroll Test"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Multi Horizontal Scroll Test"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Submittable Multi"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Submittable Multi"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "test questionless single multi"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "test questionless single multi"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose 2 Test"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Multi2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Choose 2 Test"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Match 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Match",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Maze Match 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "TextMatch",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Blocks to Math 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "TextMatch",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "PDK5 Strategies O"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Calc Circles of Eval .2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Strings Images .2"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Contracts F"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Contracts A"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Calc Vars 1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Big Game Vars 1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Define Funcs 3"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Booleans 2"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Sam the Butterfly 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Luigi's Pizza 1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Eval Define Funcs Test"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Eval Define Funcs Test"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U1L4 NetSim SendAB"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 NetSim Classroom Internet"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U2L5 NetSim Classroom Internet"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L7 NetSim Need for Packets"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U2L7 NetSim Need for Packets"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U2L10 NetSim Automatic DNS"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim_Superuser"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "NetSim_Superuser"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Odometer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Odometer"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U1L13 Text Compression"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings: Pixelation - Lesson 14 - Make the Letter A"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings: Pixelation - Lesson 15 - Color Shades 4x4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - AllTheThings 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Pixelation - AllTheThings 4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - AllTheThings 5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Pixelation - AllTheThings 5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Starry Night Starter Code"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U3L07 - Starry Night Starter Code"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - Enchantment Under the Sea"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U3L08 - Enchantment Under the Sea"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings Applab - Turtle move with button"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings Applab - Turtle move with button"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "U3L16 - use images"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab test"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings data blocks test"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings data blocks test"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings design mode elements"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_template_backed1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_template_backed1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_template_backed2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_template_backed2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_moviebot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_moviebot"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab allthethings onRecordEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab allthethings onRecordEvent"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Embedded Video Test"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Embedded Video Test"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test Applab Predictive"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test Applab Predictive"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings level dataTables"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings level dataTables"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab allthethings goals"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 17,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab allthethings goals"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab MapReference"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 18,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab AllTheThings ResourcesTab MapReference"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab ReferenceLinks"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 19,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab AllTheThings ResourcesTab ReferenceLinks"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab AllResources"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 20,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab AllTheThings ResourcesTab AllResources"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings Applab DesignModeDefault"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 21,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings Applab DesignModeDefault"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Applab allthethings Widget Mode"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 22,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Applab allthethings Widget Mode"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab AllTheThings With No Animation Tab"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Gamelab AllTheThings With No Animation Tab"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab AllTheThings With Prepopulated Animation"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Gamelab AllTheThings With Prepopulated Animation"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab AllTheThings Embed Level"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Gamelab AllTheThings Embed Level"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Intro C"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Online PD",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "PDK5 Intro C"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Foundations F"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Online PD",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "PDK5 Foundations F"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test External Markdown"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test External Markdown"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test embedded Blockly in instructions"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test embedded Blockly in instructions"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test embedded K1 Blockly in instructions"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test embedded K1 Blockly in instructions"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Resizing Test"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Resizing Test"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 11"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Multi page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "K-1 Maze 11"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test longassessment levelgroup split new"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Multi page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test longassessment levelgroup split new"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_two_items"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Star wars",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_event_two_items"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Star wars",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_5"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree - allthethings"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Overworld Chop Tree - allthethings"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC Agent Freeplay"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "MC Agent Freeplay"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Craft Aquatic - allthethings"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Craft Aquatic - allthethings"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PS U3 Assessment1 new"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Rich long assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "PS U3 Assessment1 new"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sample Free Response"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Sample Free Response"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sample CSP Assessment"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Sample PLC Assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Sample CSP Assessment"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Maze 1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 1",
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Maze 1",
+        "2-3 Maze 4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Maze 2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 2",
+          "2-3 Maze 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Maze 2",
+        "2-3 Maze 5"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Maze 3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 3",
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Maze 3",
+        "2-3 Maze 6"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Artist 1 new": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Artist 1 new",
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "ramp_video_loopsArtist": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops 2",
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Artist Loops 2",
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Artist 3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 3",
+          "2-3 Artist Loops 4"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "2-3 Artist 3",
+        "2-3 Artist Loops 4"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "4-5 Maze 4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 1",
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 Maze 1",
+        "4-5 Maze 4"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "4-5 Maze 5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 2",
+          "4-5 Maze 5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 Maze 2",
+        "4-5 Maze 5"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "4-5 Maze 6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 3",
+          "4-5 Maze 6"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "4-5 Maze 3",
+        "4-5 Maze 6"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_socialBelonging_intervention": {
+            "active": false,
+            "experiments": [
+              "socialBelongingTest"
+            ]
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control",
+        "csp_socialBelonging_intervention"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test anonymous student survey"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test anonymous student survey"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP pre-assessment survey"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey 2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "CSP pre-assessment survey"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings Modulo Clock"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Cryptography",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings Modulo Clock"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings Public Key Cryptography"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Cryptography",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings Public Key Cryptography"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Web Lab 1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Web Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Web Lab 1"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test longassessment levelgroup new"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Single page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test longassessment levelgroup new"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AllTheThings_StandaloneVideo"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Standalone video",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "AllTheThings_StandaloneVideo"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_curriculum_reference"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Curriculum Reference",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_curriculum_reference"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_map"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Curriculum Reference",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_map"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_fish_tank"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_fish_tank"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings HOC Dance 1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Dance Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings HOC Dance 1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings HOC Dance 10 Measures"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "Dance Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings HOC Dance 10 Measures"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-mini-rubric"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-mini-rubric"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-mini-rubric-weblab"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 2,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-mini-rubric-weblab"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings-mini-rubric-gamelab"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 3,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings-mini-rubric-gamelab"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pluralsight LevelGroup Test"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Pluralsight Test",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Pluralsight LevelGroup Test"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_external_displayed_as_unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Externals Optionally Displayed as Unplugged",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_external_displayed_as_unplugged"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_external_not_displayed_as_unplugged"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Externals Optionally Displayed as Unplugged",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_external_not_displayed_as_unplugged"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_bubble_choice"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "Bubble Choice",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings_bubble_choice"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "contained_single_multi"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "contained_single_multi"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test GameLab Predictive"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test GameLab Predictive"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PS predictive Applab level test"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "PS predictive Applab level test"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "contained_applab_choose2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "contained_applab_choose2"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "contained_csf_multi2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "contained_csf_multi2"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "contained_csf_free_response"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "contained_csf_free_response"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test GameLab Submittable Free Response"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Test GameLab Submittable Free Response"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - The Future of Big Data"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Video - The Future of Big Data"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings HOC ML Fish 1"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "ML Fish",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "allthethings HOC ML Fish 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "k-1 maze 1",
+        "script_level.level_keys": [
+          "k-1 maze 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 3",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 4",
+        "script_level.level_keys": [
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 3",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3",
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-anigif-instructions",
+        "script_level.level_keys": [
+          "allthethings-anigif-instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 1",
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 4",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Vars 2",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 3",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Auto Open Function Editor",
+        "script_level.level_keys": [
+          "Auto Open Function Editor"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Angle Helper Test",
+        "script_level.level_keys": [
+          "Angle Helper Test"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-artist-project-backed",
+        "script_level.level_keys": [
+          "allthethings-artist-project-backed"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Artist Autorun Test",
+        "script_level.level_keys": [
+          "Artist Autorun Test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 1",
+        "script_level.level_keys": [
+          "K-1 Bee 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_1",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 2A",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2A"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 5",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Bee Recommended Blocks test",
+        "script_level.level_keys": [
+          "Bee Recommended Blocks test"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Bee",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_1",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_1",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 1",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 2",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-playlab-project-backed",
+        "script_level.level_keys": [
+          "allthethings-playlab-project-backed"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Encrypted Play Lab Level",
+        "script_level.level_keys": [
+          "Allthethings Encrypted Play Lab Level"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "PlayLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 4",
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Farmer for Authored Hint testing",
+        "script_level.level_keys": [
+          "Farmer for Authored Hint testing"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Farmer for TTS testing",
+        "script_level.level_keys": [
+          "Farmer for TTS testing"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Farmer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Happy Maps Multi 1",
+        "script_level.level_keys": [
+          "K-1 Happy Maps Multi 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi Horizontal Scroll Test",
+        "script_level.level_keys": [
+          "Multi Horizontal Scroll Test"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Submittable Multi",
+        "script_level.level_keys": [
+          "Submittable Multi"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "test questionless single multi",
+        "script_level.level_keys": [
+          "test questionless single multi"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Multi",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose 2 Test",
+        "script_level.level_keys": [
+          "Choose 2 Test"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Multi2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Match 1",
+        "script_level.level_keys": [
+          "K-1 Maze Match 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Match",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Blocks to Math 1",
+        "script_level.level_keys": [
+          "Blocks to Math 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "TextMatch",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Strategies O",
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "TextMatch",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Circles of Eval .2",
+        "script_level.level_keys": [
+          "Calc Circles of Eval .2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Strings Images .2",
+        "script_level.level_keys": [
+          "Eval Strings Images .2"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts F",
+        "script_level.level_keys": [
+          "Eval Contracts F"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Contracts A",
+        "script_level.level_keys": [
+          "Eval Contracts A"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Calc Vars 1",
+        "script_level.level_keys": [
+          "Calc Vars 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Game Vars 1",
+        "script_level.level_keys": [
+          "Big Game Vars 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs 3",
+        "script_level.level_keys": [
+          "Eval Define Funcs 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Booleans 2",
+        "script_level.level_keys": [
+          "Eval Booleans 2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sam the Butterfly 2",
+        "script_level.level_keys": [
+          "Sam the Butterfly 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Luigi's Pizza 1",
+        "script_level.level_keys": [
+          "Luigi's Pizza 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Eval Define Funcs Test",
+        "script_level.level_keys": [
+          "Eval Define Funcs Test"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "CSinA",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 NetSim SendAB",
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 NetSim Classroom Internet",
+        "script_level.level_keys": [
+          "U2L5 NetSim Classroom Internet"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L7 NetSim Need for Packets",
+        "script_level.level_keys": [
+          "U2L7 NetSim Need for Packets"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 NetSim Automatic DNS",
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim_Superuser",
+        "script_level.level_keys": [
+          "NetSim_Superuser"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Netsim",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Odometer",
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Odometer",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Text Compression",
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings: Pixelation - Lesson 14 - Make the Letter A",
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings: Pixelation - Lesson 15 - Color Shades 4x4",
+        "script_level.level_keys": [
+          "AllTheThings: Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - AllTheThings 4",
+        "script_level.level_keys": [
+          "Pixelation - AllTheThings 4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - AllTheThings 5",
+        "script_level.level_keys": [
+          "Pixelation - AllTheThings 5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Pixelation",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Starry Night Starter Code",
+        "script_level.level_keys": [
+          "U3L07 - Starry Night Starter Code"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - Enchantment Under the Sea",
+        "script_level.level_keys": [
+          "U3L08 - Enchantment Under the Sea"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings Applab - Turtle move with button",
+        "script_level.level_keys": [
+          "AllTheThings Applab - Turtle move with button"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - use images",
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab test",
+        "script_level.level_keys": [
+          "Applab test"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings data blocks test",
+        "script_level.level_keys": [
+          "allthethings data blocks test"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings design mode elements",
+        "script_level.level_keys": [
+          "allthethings design mode elements"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_template_backed1",
+        "script_level.level_keys": [
+          "allthethings_template_backed1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_template_backed2",
+        "script_level.level_keys": [
+          "allthethings_template_backed2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_moviebot",
+        "script_level.level_keys": [
+          "allthethings_moviebot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab allthethings onRecordEvent",
+        "script_level.level_keys": [
+          "Applab allthethings onRecordEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Embedded Video Test",
+        "script_level.level_keys": [
+          "Embedded Video Test"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test Applab Predictive",
+        "script_level.level_keys": [
+          "Test Applab Predictive"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings level dataTables",
+        "script_level.level_keys": [
+          "allthethings level dataTables"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab allthethings goals",
+        "script_level.level_keys": [
+          "Applab allthethings goals"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 17,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab AllTheThings ResourcesTab MapReference",
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab MapReference"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 18,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab AllTheThings ResourcesTab ReferenceLinks",
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab ReferenceLinks"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 19,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab AllTheThings ResourcesTab AllResources",
+        "script_level.level_keys": [
+          "Applab AllTheThings ResourcesTab AllResources"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 20,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings Applab DesignModeDefault",
+        "script_level.level_keys": [
+          "AllTheThings Applab DesignModeDefault"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 21,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Applab allthethings Widget Mode",
+        "script_level.level_keys": [
+          "Applab allthethings Widget Mode"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 22,
+        "lesson.key": "AppLab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab AllTheThings With No Animation Tab",
+        "script_level.level_keys": [
+          "Gamelab AllTheThings With No Animation Tab"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab AllTheThings With Prepopulated Animation",
+        "script_level.level_keys": [
+          "Gamelab AllTheThings With Prepopulated Animation"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab AllTheThings Embed Level",
+        "script_level.level_keys": [
+          "Gamelab AllTheThings Embed Level"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Gamelab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Intro C",
+        "script_level.level_keys": [
+          "PDK5 Intro C"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Online PD",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Foundations F",
+        "script_level.level_keys": [
+          "PDK5 Foundations F"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Online PD",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test External Markdown",
+        "script_level.level_keys": [
+          "Test External Markdown"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test embedded Blockly in instructions",
+        "script_level.level_keys": [
+          "Test embedded Blockly in instructions"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test embedded K1 Blockly in instructions",
+        "script_level.level_keys": [
+          "Test embedded K1 Blockly in instructions"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Markdown Details",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Resizing Test",
+        "script_level.level_keys": [
+          "Resizing Test"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 11",
+        "script_level.level_keys": [
+          "K-1 Maze 11"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Multi page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test longassessment levelgroup split new",
+        "script_level.level_keys": [
+          "Test longassessment levelgroup split new"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Multi page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_event_two_items",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_two_items"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Star wars",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_5",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Star wars",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree - allthethings",
+        "script_level.level_keys": [
+          "Overworld Chop Tree - allthethings"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC Agent Freeplay",
+        "script_level.level_keys": [
+          "MC Agent Freeplay"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Craft Aquatic - allthethings",
+        "script_level.level_keys": [
+          "Craft Aquatic - allthethings"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PS U3 Assessment1 new",
+        "script_level.level_keys": [
+          "PS U3 Assessment1 new"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Rich long assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sample Free Response",
+        "script_level.level_keys": [
+          "Sample Free Response"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Free Response",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sample CSP Assessment",
+        "script_level.level_keys": [
+          "Sample CSP Assessment"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Sample PLC Assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1",
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 4",
+        "script_level.level_keys": [
+          "2-3 Maze 1",
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 2",
+        "script_level.level_keys": [
+          "2-3 Maze 2",
+          "2-3 Maze 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 5",
+        "script_level.level_keys": [
+          "2-3 Maze 2",
+          "2-3 Maze 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 3",
+        "script_level.level_keys": [
+          "2-3 Maze 3",
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 6",
+        "script_level.level_keys": [
+          "2-3 Maze 3",
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "2-3 Artist Loops 2",
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops 2",
+        "script_level.level_keys": [
+          "2-3 Artist Loops 2",
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3",
+        "script_level.level_keys": [
+          "2-3 Artist 3",
+          "2-3 Artist Loops 4"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops 4",
+        "script_level.level_keys": [
+          "2-3 Artist 3",
+          "2-3 Artist Loops 4"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 1",
+        "script_level.level_keys": [
+          "4-5 Maze 1",
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 4",
+        "script_level.level_keys": [
+          "4-5 Maze 1",
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 2",
+        "script_level.level_keys": [
+          "4-5 Maze 2",
+          "4-5 Maze 5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 5",
+        "script_level.level_keys": [
+          "4-5 Maze 2",
+          "4-5 Maze 5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 3",
+        "script_level.level_keys": [
+          "4-5 Maze 3",
+          "4-5 Maze 6"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 6",
+        "script_level.level_keys": [
+          "4-5 Maze 3",
+          "4-5 Maze 6"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_intervention",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Swapped Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test anonymous student survey",
+        "script_level.level_keys": [
+          "Test anonymous student survey"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP pre-assessment survey",
+        "script_level.level_keys": [
+          "CSP pre-assessment survey"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey 2",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings Modulo Clock",
+        "script_level.level_keys": [
+          "AllTheThings Modulo Clock"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Cryptography",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings Public Key Cryptography",
+        "script_level.level_keys": [
+          "AllTheThings Public Key Cryptography"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Cryptography",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Web Lab 1",
+        "script_level.level_keys": [
+          "Web Lab 1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Web Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test longassessment levelgroup new",
+        "script_level.level_keys": [
+          "Test longassessment levelgroup new"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Single page assessment",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AllTheThings_StandaloneVideo",
+        "script_level.level_keys": [
+          "AllTheThings_StandaloneVideo"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Standalone video",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_curriculum_reference",
+        "script_level.level_keys": [
+          "allthethings_curriculum_reference"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Curriculum Reference",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_map",
+        "script_level.level_keys": [
+          "allthethings_map"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Curriculum Reference",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_fish_tank",
+        "script_level.level_keys": [
+          "allthethings_fish_tank"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings HOC Dance 1",
+        "script_level.level_keys": [
+          "allthethings HOC Dance 1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Dance Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings HOC Dance 10 Measures",
+        "script_level.level_keys": [
+          "allthethings HOC Dance 10 Measures"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "Dance Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-mini-rubric",
+        "script_level.level_keys": [
+          "allthethings-mini-rubric"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-mini-rubric-weblab",
+        "script_level.level_keys": [
+          "allthethings-mini-rubric-weblab"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 2,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings-mini-rubric-gamelab",
+        "script_level.level_keys": [
+          "allthethings-mini-rubric-gamelab"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 3,
+        "lesson.key": "Mini Rubric",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pluralsight LevelGroup Test",
+        "script_level.level_keys": [
+          "Pluralsight LevelGroup Test"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Pluralsight Test",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_external_displayed_as_unplugged",
+        "script_level.level_keys": [
+          "allthethings_external_displayed_as_unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Externals Optionally Displayed as Unplugged",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_external_not_displayed_as_unplugged",
+        "script_level.level_keys": [
+          "allthethings_external_not_displayed_as_unplugged"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Externals Optionally Displayed as Unplugged",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_bubble_choice",
+        "script_level.level_keys": [
+          "allthethings_bubble_choice"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "Bubble Choice",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "contained_single_multi",
+        "script_level.level_keys": [
+          "contained_single_multi"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test GameLab Predictive",
+        "script_level.level_keys": [
+          "Test GameLab Predictive"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PS predictive Applab level test",
+        "script_level.level_keys": [
+          "PS predictive Applab level test"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "contained_applab_choose2",
+        "script_level.level_keys": [
+          "contained_applab_choose2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "contained_csf_multi2",
+        "script_level.level_keys": [
+          "contained_csf_multi2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "contained_csf_free_response",
+        "script_level.level_keys": [
+          "contained_csf_free_response"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Test GameLab Submittable Free Response",
+        "script_level.level_keys": [
+          "Test GameLab Submittable Free Response"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - The Future of Big Data",
+        "script_level.level_keys": [
+          "Video - The Future of Big Data"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Contained Levels",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings HOC ML Fish 1",
+        "script_level.level_keys": [
+          "allthethings HOC ML Fish 1"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "ML Fish",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/allthettsthings.script_json
+++ b/dashboard/config/scripts_json/allthettsthings.script_json
@@ -1,0 +1,189 @@
+{
+  "script": {
+    "name": "allthettsthings",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "allthettsthings"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "TTS",
+      "name": "TTS",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_ttscsf contained"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      },
+      "level_keys": [
+        "allthethings_ttscsf contained"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_ttscsd"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      },
+      "level_keys": [
+        "allthethings_ttscsd"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_ttscsp contained"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      },
+      "level_keys": [
+        "allthethings_ttscsp contained"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "allthethings_ttscsp"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      },
+      "level_keys": [
+        "allthethings_ttscsp"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "allthethings_ttscsf contained",
+        "script_level.level_keys": [
+          "allthethings_ttscsf contained"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_ttscsd",
+        "script_level.level_keys": [
+          "allthethings_ttscsd"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_ttscsp contained",
+        "script_level.level_keys": [
+          "allthethings_ttscsp contained"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "allthethings_ttscsp",
+        "script_level.level_keys": [
+          "allthethings_ttscsp"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "TTS",
+        "lesson_group.key": "",
+        "script.name": "allthettsthings"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/andrea-test.script_json
+++ b/dashboard/config/scripts_json/andrea-test.script_json
@@ -1,0 +1,302 @@
+{
+  "script": {
+    "name": "andrea-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "Andrea Test",
+      "peer_reviews_to_complete": 1,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "andrea-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "key": "Part 1",
+      "name": "Part 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Part 1",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "key": "Part 2",
+      "name": "Part 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Part 2",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "key": "part 3",
+      "name": "part 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "part 3",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "What is Deeper Learning"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "andrea_test1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "andrea-test"
+      },
+      "level_keys": [
+        "andrea_test1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "President Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "andrea-test2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Part 1",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      },
+      "level_keys": [
+        "andrea-test2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Vice President Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "andrea-test3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Part 1",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      },
+      "level_keys": [
+        "andrea-test3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "andrea_test1",
+          "andrea-test2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Part 2",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      },
+      "level_keys": [
+        "andrea_test1",
+        "andrea-test2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sandwich"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp-hold1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "part 3",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      },
+      "level_keys": [
+        "dlp-hold1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "andrea_test1",
+        "script_level.level_keys": [
+          "andrea_test1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "andrea-test2",
+        "script_level.level_keys": [
+          "andrea-test2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Part 1",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "andrea-test3",
+        "script_level.level_keys": [
+          "andrea-test3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Part 1",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "andrea_test1",
+        "script_level.level_keys": [
+          "andrea_test1",
+          "andrea-test2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Part 2",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "andrea-test2",
+        "script_level.level_keys": [
+          "andrea_test1",
+          "andrea-test2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Part 2",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp-hold1",
+        "script_level.level_keys": [
+          "dlp-hold1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "part 3",
+        "lesson_group.key": "content",
+        "script.name": "andrea-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/applab-1hour.script_json
+++ b/dashboard/config/scripts_json/applab-1hour.script_json
@@ -1,0 +1,643 @@
+{
+  "script": {
+    "name": "applab-1hour",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "applab-1hour"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Room Escape",
+      "name": "Room Escape",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Escape Room Example"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Escape Room Example"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Design Mode"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Overview: Design Mode"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Images"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Overview: Images"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: onEvent"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Overview: onEvent"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: setPosition"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Overview: setPosition"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 3-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 3-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 4"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: If Statements"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Overview: If Statements"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 5"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 9-2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 9-2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 10"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Room Escape Workshop - 10 - 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Room Escape Workshop - 10 - 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Final Room Escape App"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      },
+      "level_keys": [
+        "Final Room Escape App"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Escape Room Example",
+        "script_level.level_keys": [
+          "Escape Room Example"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Design Mode",
+        "script_level.level_keys": [
+          "Overview: Design Mode"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Images",
+        "script_level.level_keys": [
+          "Overview: Images"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 1",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 3",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: onEvent",
+        "script_level.level_keys": [
+          "Overview: onEvent"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: setPosition",
+        "script_level.level_keys": [
+          "Overview: setPosition"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 3-2",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 3-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 4",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: If Statements",
+        "script_level.level_keys": [
+          "Overview: If Statements"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 5",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 7",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 8",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 9-2",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 9-2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 10",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Room Escape Workshop - 10 - 2",
+        "script_level.level_keys": [
+          "Room Escape Workshop - 10 - 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Final Room Escape App",
+        "script_level.level_keys": [
+          "Final Room Escape App"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Room Escape",
+        "lesson_group.key": "",
+        "script.name": "applab-1hour"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/applab-2hour.script_json
+++ b/dashboard/config/scripts_json/applab-2hour.script_json
@@ -1,0 +1,1290 @@
+{
+  "script": {
+    "name": "applab-2hour",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "applab-2hour"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "key": "Event Driven Programming",
+      "name": "Event Driven Programming",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "key": "Basic App Functionality",
+      "name": "Basic App Functionality",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "key": "Getters and Setters",
+      "name": "Getters and Setters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Building a UI with Design Mode"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "Building a UI with Design Mode"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 15"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 15"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choosing Good IDs"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "Choosing Good IDs"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Text"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Input Widgets"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Input Widgets"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 21"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode Icons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode Icons"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 18"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 18"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Responding to User Input"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "Responding to User Input"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 16"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 16"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 17"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 17"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi-Screen Apps"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "Multi-Screen Apps"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 19"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 19"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 20"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 20"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 Connecting Screens"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens Getting Back"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 Connecting Screens Getting Back"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality visible"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU4 Functionality visible"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSD - Getters and Setters"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setScreen"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setScreen"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setText"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - hide show"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getText"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getText"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - dropdown setText"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - dropdown setText"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - get set with text input"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - get set with text input"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber practice"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getNumber practice"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: getText vs getNumber"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSD: getText vs getNumber"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getNumber"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: setProperty"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSD: setProperty"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty first level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty first level"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty Image"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty Image"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Building a UI with Design Mode",
+        "script_level.level_keys": [
+          "Building a UI with Design Mode"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 15",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 15"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 4",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choosing Good IDs",
+        "script_level.level_keys": [
+          "Choosing Good IDs"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Text",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Input Widgets",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Input Widgets"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 21",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode Icons",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode Icons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 18",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 18"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Responding to User Input",
+        "script_level.level_keys": [
+          "Responding to User Input"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 16",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 16"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 3",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 17",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 17"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi-Screen Apps",
+        "script_level.level_keys": [
+          "Multi-Screen Apps"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 19",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 19"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 20",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 20"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Connecting Screens",
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Connecting Screens Getting Back",
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens Getting Back"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality visible",
+        "script_level.level_keys": [
+          "CSDU4 Functionality visible"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD - Getters and Setters",
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setScreen",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setScreen"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - hide show",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getText"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - dropdown setText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - dropdown setText"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - get set with text input",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - get set with text input"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getNumber practice",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber practice"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: getText vs getNumber",
+        "script_level.level_keys": [
+          "CSD: getText vs getNumber"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getNumber",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: setProperty",
+        "script_level.level_keys": [
+          "CSD: setProperty"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty first level",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty first level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty Image",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty Image"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "",
+        "script.name": "applab-2hour"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/applab-intro-staging.script_json
+++ b/dashboard/config/scripts_json/applab-intro-staging.script_json
@@ -1,0 +1,4467 @@
+{
+  "script": {
+    "name": "applab-intro-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "applab-intro-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to AppLab - Choose Your Own Adventure",
+      "name": "Intro to AppLab - Choose Your Own Adventure",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Choose Your Own Adventure 2",
+      "name": "Intro to AppLab - Choose Your Own Adventure 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Your First App",
+      "name": "Intro to AppLab - Your First App",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Your First App 2",
+      "name": "Intro to AppLab - Your First App 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Your First App 3",
+      "name": "Intro to AppLab - Your First App 3",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Your First App 4",
+      "name": "Intro to AppLab - Your First App 4",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to AppLab - Getting Started",
+      "name": "Intro to AppLab - Getting Started",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "key": "Intro to App Lab",
+      "name": "Intro to App Lab",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome to App Lab!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Try App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Try App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Screen"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Add Screen"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Button"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Add Button"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Event"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Add Event"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Sound"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Add Sound"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Adventure!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Building a Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Building a Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Adventure!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Build Your Adventure"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Build Your Adventure"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Go Further!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Go Further"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 1 - Go Further"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building - Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Try App"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Try App"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome to App Lab!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC Intro to App Lab Example"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "HOC Intro to App Lab Example"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome to App Lab!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC Intro to App Lab Brainstorm"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "HOC Intro to App Lab Brainstorm"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome to App Lab!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Try Cat Commander"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Try Cat Commander"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Design your Start Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit startScreen"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Edit startScreen"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Design your Start Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit startScreen2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Edit startScreen2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Learn App Lab Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Learn App Lab Video"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit place1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Edit place1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit place1 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - Edit place1 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add Button"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add Button"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add onEvent"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add onEvent"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add more buttons"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add more buttons"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Screens and Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add more buttons 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add more buttons 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Go Further - Images and Sound"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add images"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add images"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Go Further - Images and Sound"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add sound"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - add sound"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish and Share"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 2 - finish and share"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 2 - finish and share"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent mouseOut"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - onEvent mouseOut"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Screen Color"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Text"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - Change Text"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Text 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Full Text"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - Full Text"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Two Buttons"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - Change Two Buttons"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent intro"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent before"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - onEvent before"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent mouseOver"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - onEvent mouseOver"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - playSound"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - playSound"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - stopSound"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - stopSound"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Create and Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 3 - thisOrThat"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 3 - thisOrThat"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video Welcome"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video Welcome"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video setProperty"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video setProperty"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Screen Color"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Text"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Change Text"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Full Text"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Full Text"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Text 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Two Buttons"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Change Two Buttons"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video using onEvent"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent intro"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent before"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - onEvent before"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - playSound"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - playSound"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - stopSound"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - stopSound"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create and Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video share thisThat"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video share thisThat"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create and Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - thisOrThat"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - thisOrThat"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Sneak Peak of What Comes Next"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video sneak designMode"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video sneak designMode"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Sneak Peak of What Comes Next"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - thisOrThat design"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - thisOrThat design"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Welcome"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Welcome to App Lab"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Video Welcome to App Lab"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video setProperty"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video setProperty"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Change Screen Color"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Change Text 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Colors and Size"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Full Text"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Full Text"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video using onEvent"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - onEvent intro"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Videos Sound"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Video Videos Sound"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - playSound"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - playSound"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - rate it app"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - rate it app"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Intro Design Mode"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Video Intro Design Mode"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - addButton"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - addButton"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - setScreen"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - setScreen"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Share and Keep Going"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Share Keep Going"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - Video Share Keep Going"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Share and Keep Going"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - share keep going"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - share keep going"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Share and Keep Going"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 5 - go further"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 5 - go further"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Welcome SetProperty"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Welcome SetProperty"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Change Screen Color"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Change Text 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Full Text"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Full Text"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video using onEvent"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - onEvent intro"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Images and Sounds"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - playSound"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - playSound"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Design Mode and Screens"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Design Mode and Screens"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - thisOrThatAddButton"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - thisOrThatAddScreen"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - thisOrThatSetScreen"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Keep Going"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Keep Going"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - thisOrThatPersonalize"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - animalSoundBoard"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - animalSoundBoard"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - quizApp"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - quizApp"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - blankApp"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 18,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - blankApp"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Welcome SetProperty"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Welcome SetProperty"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Full Text"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 4 - Video using onEvent"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Images and Sounds"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - playSound"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Design Mode and Screens"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Design Mode and Screens"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddButton"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddScreen"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatSetScreen"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Keep Going"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 6 - Video Keep Going"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatPersonalize"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Getting Started"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Getting Started"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Full Text"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Make It Interactive"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Make It Interactive"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Images and Sounds"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - playSound"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Design Mode"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Design Mode"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddButton"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddScreen"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatSetScreen"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Share Your App"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Share Your App"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 15,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatPersonalize"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Welcome",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Try App",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Try App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Add Screen",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Screen"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Add Button",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Button"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Add Event",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Event"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Add Sound",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Add Sound"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Building a Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Building a Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Build Your Adventure",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Build Your Adventure"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 1 - Go Further",
+        "script_level.level_keys": [
+          "AppLab Intro 1 - Go Further"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Try App",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Try App"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC Intro to App Lab Example",
+        "script_level.level_keys": [
+          "HOC Intro to App Lab Example"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC Intro to App Lab Brainstorm",
+        "script_level.level_keys": [
+          "HOC Intro to App Lab Brainstorm"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Try Cat Commander",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Try Cat Commander"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Edit startScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit startScreen"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Edit startScreen2",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit startScreen2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Learn App Lab Video",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Learn App Lab Video"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Edit place1",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit place1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - Edit place1 2",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - Edit place1 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add Button",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add Button"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add onEvent",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add onEvent"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add more buttons",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add more buttons"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add more buttons 2",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add more buttons 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add images",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add images"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - add sound",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - add sound"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 2 - finish and share",
+        "script_level.level_keys": [
+          "AppLab Intro 2 - finish and share"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - onEvent mouseOut",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent mouseOut"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Choose Your Own Adventure 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Screen Color"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - Change Text",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Text"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Text 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Full Text"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - Change Two Buttons",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - Change Two Buttons"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent intro"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - onEvent before",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent before"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - onEvent mouseOver",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - onEvent mouseOver"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - playSound"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - stopSound",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - stopSound"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 3 - thisOrThat",
+        "script_level.level_keys": [
+          "AppLab Intro 3 - thisOrThat"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video Welcome",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video Welcome"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video setProperty",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video setProperty"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Screen Color"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Change Text",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Text"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Full Text"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Text 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Change Two Buttons",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Change Two Buttons"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video using onEvent",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent intro"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - onEvent before",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent before"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - playSound"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - stopSound",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - stopSound"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video share thisThat",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video share thisThat"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - thisOrThat",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - thisOrThat"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video sneak designMode",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video sneak designMode"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - thisOrThat design",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - thisOrThat design"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 2",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Video Welcome to App Lab",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Welcome to App Lab"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video setProperty",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video setProperty"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Change Screen Color"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Change Text 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Full Text"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video using onEvent",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - onEvent intro"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Video Videos Sound",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Videos Sound"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - playSound"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - rate it app",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - rate it app"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Video Intro Design Mode",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Intro Design Mode"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - addButton",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - addButton"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - setScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - setScreen"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - Video Share Keep Going",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - Video Share Keep Going"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - share keep going",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - share keep going"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 5 - go further",
+        "script_level.level_keys": [
+          "AppLab Intro 5 - go further"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 3",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Welcome SetProperty",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Welcome SetProperty"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Change Screen Color"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Change Text 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Full Text"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video using onEvent",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - onEvent intro"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Images and Sounds",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - playSound"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Design Mode and Screens",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Design Mode and Screens"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - thisOrThatAddButton",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - thisOrThatAddScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - thisOrThatSetScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Keep Going",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Keep Going"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - thisOrThatPersonalize",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - animalSoundBoard",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - animalSoundBoard"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 16,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - quizApp",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - quizApp"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 17,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - blankApp",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - blankApp"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 18,
+        "lesson.key": "Intro to AppLab - Your First App 4",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Welcome SetProperty",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Welcome SetProperty"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 4 - Video using onEvent",
+        "script_level.level_keys": [
+          "AppLab Intro 4 - Video using onEvent"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Images and Sounds",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 8,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 9,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Design Mode and Screens",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Design Mode and Screens"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 10,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddButton",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 11,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 12,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatSetScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 13,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 6 - Video Keep Going",
+        "script_level.level_keys": [
+          "AppLab Intro 6 - Video Keep Going"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 14,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatPersonalize",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 15,
+        "lesson.key": "Intro to AppLab - Getting Started",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Getting Started",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Getting Started"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Make It Interactive",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Make It Interactive"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Images and Sounds",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Design Mode",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Design Mode"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddButton",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatSetScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Share Your App",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Share Your App"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatPersonalize",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 15,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/applab-intro.script_json
+++ b/dashboard/config/scripts_json/applab-intro.script_json
@@ -1,0 +1,591 @@
+{
+  "script": {
+    "name": "applab-intro",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "student_detail_progress_view": true,
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "applab-intro"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to App Lab",
+      "name": "Intro to App Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Getting Started"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Getting Started"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Screen Color"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Change Text 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - Full Text"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Make It Interactive"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Make It Interactive"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent intro"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - onEvent twoButtons"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Images and Sounds"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - playSound"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Design Mode"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Design Mode"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddButton"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatAddScreen"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatSetScreen"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Share Your App"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "App Lab Intro 8 - Video Share Your App"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      },
+      "level_keys": [
+        "AppLab Intro 7 - thisOrThatPersonalize"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Getting Started",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Getting Started"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Screen Color",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Screen Color"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Change Text 2",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Change Text 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - Full Text",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - Full Text"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Make It Interactive",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Make It Interactive"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent intro",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent intro"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - onEvent twoButtons",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - onEvent twoButtons"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Images and Sounds",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Images and Sounds"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - playSound",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - playSound"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Design Mode",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Design Mode"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddButton",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddButton"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatAddScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatAddScreen"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatSetScreen",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatSetScreen"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "App Lab Intro 8 - Video Share Your App",
+        "script_level.level_keys": [
+          "App Lab Intro 8 - Video Share Your App"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AppLab Intro 7 - thisOrThatPersonalize",
+        "script_level.level_keys": [
+          "AppLab Intro 7 - thisOrThatPersonalize"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "applab-intro"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/aquatic.script_json
+++ b/dashboard/config/scripts_json/aquatic.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "aquatic",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "aquatic"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Aquatic",
+      "name": "Aquatic",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_7a"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_9b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC 2018 Level_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      },
+      "level_keys": [
+        "HOC 2018 Level_12"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_1",
+        "script_level.level_keys": [
+          "HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_2",
+        "script_level.level_keys": [
+          "HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_3",
+        "script_level.level_keys": [
+          "HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_4",
+        "script_level.level_keys": [
+          "HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_5",
+        "script_level.level_keys": [
+          "HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_6",
+        "script_level.level_keys": [
+          "HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_7a",
+        "script_level.level_keys": [
+          "HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_8",
+        "script_level.level_keys": [
+          "HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_9b",
+        "script_level.level_keys": [
+          "HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_10",
+        "script_level.level_keys": [
+          "HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_11",
+        "script_level.level_keys": [
+          "HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC 2018 Level_12",
+        "script_level.level_keys": [
+          "HOC 2018 Level_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Aquatic",
+        "lesson_group.key": "",
+        "script.name": "aquatic"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/artist-and-bb8.script_json
+++ b/dashboard/config/scripts_json/artist-and-bb8.script_json
@@ -1,0 +1,4893 @@
+{
+  "script": {
+    "name": "artist-and-bb8",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "artist-and-bb8"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming with BB-8",
+      "name": "Programming with BB-8",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "Loops with BB-8",
+      "name": "Loops with BB-8",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "C9 Artist Loops",
+      "name": "C9 Artist Loops",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "D7 to Laurel",
+      "name": "D7 to Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "D6 Frozen Artist",
+      "name": "D6 Frozen Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "F5 Minecraft",
+      "name": "F5 Minecraft",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "F7 add Conditionals",
+      "name": "F7 add Conditionals",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "D13 no If/While",
+      "name": "D13 no If/While",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "Bounce",
+      "name": "Bounce",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "NewBounce",
+      "name": "NewBounce",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "key": "F PlayLab Variables",
+      "name": "F PlayLab Variables",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loop1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_video_debugging"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging7"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging7"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_collector_debugging10_predict1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_IceAgeIntro"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_video_IceAgeIntro"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_2"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_3"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_4"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_4"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_iceAgeRepeat"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_video_iceAgeRepeat"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_5"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_IceAgeEvents"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_video_IceAgeEvents"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_6"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_6"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_7"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_8"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_9"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_10"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 13,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_10"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_11"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 14,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseF_IceAge_11"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events1s"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events2s"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events5s"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events6s"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events7s"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events10s"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events11s"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "courseD_bounce_events12s"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars1"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_video_PlayLab_vars"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_video_PlayLab_vars"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars3"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars4"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars5"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars6"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars7"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars8"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars9"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      },
+      "level_keys": [
+        "CourseF_PlayLab_vars10"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Programming with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Loops with BB-8",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1",
+        "script_level.level_keys": [
+          "courseC_artist_loop1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "C9 Artist Loops",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging",
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging7",
+        "script_level.level_keys": [
+          "courseD_collector_debugging7"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging10_predict1",
+        "script_level.level_keys": [
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "D7 to Laurel",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "D6 Frozen Artist",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "F5 Minecraft",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "F7 add Conditionals",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "D13 no If/While",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_IceAgeIntro",
+        "script_level.level_keys": [
+          "courseF_video_IceAgeIntro"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_1",
+        "script_level.level_keys": [
+          "courseF_IceAge_1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_2",
+        "script_level.level_keys": [
+          "courseF_IceAge_2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_3",
+        "script_level.level_keys": [
+          "courseF_IceAge_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_4",
+        "script_level.level_keys": [
+          "courseF_IceAge_4"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_iceAgeRepeat",
+        "script_level.level_keys": [
+          "courseF_video_iceAgeRepeat"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_5",
+        "script_level.level_keys": [
+          "courseF_IceAge_5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_IceAgeEvents",
+        "script_level.level_keys": [
+          "courseF_video_IceAgeEvents"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_6",
+        "script_level.level_keys": [
+          "courseF_IceAge_6"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_7",
+        "script_level.level_keys": [
+          "courseF_IceAge_7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_8",
+        "script_level.level_keys": [
+          "courseF_IceAge_8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_9",
+        "script_level.level_keys": [
+          "courseF_IceAge_9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_10",
+        "script_level.level_keys": [
+          "courseF_IceAge_10"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 13,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_11",
+        "script_level.level_keys": [
+          "courseF_IceAge_11"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 14,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s",
+        "script_level.level_keys": [
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s",
+        "script_level.level_keys": [
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s",
+        "script_level.level_keys": [
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s",
+        "script_level.level_keys": [
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s",
+        "script_level.level_keys": [
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s",
+        "script_level.level_keys": [
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s",
+        "script_level.level_keys": [
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s",
+        "script_level.level_keys": [
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "NewBounce",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars1",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_video_PlayLab_vars",
+        "script_level.level_keys": [
+          "CourseF_video_PlayLab_vars"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars2",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars3",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars4",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars5",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars6",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars7",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars8",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars9",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_PlayLab_vars10",
+        "script_level.level_keys": [
+          "CourseF_PlayLab_vars10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "F PlayLab Variables",
+        "lesson_group.key": "",
+        "script.name": "artist-and-bb8"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/artist.script_json
+++ b/dashboard/config/scripts_json/artist.script_json
@@ -1,0 +1,399 @@
+{
+  "script": {
+    "name": "artist",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "artist"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_5.5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_5.5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      },
+      "level_keys": [
+        "Standalone_Artist_9"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_1",
+        "script_level.level_keys": [
+          "Standalone_Artist_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_2",
+        "script_level.level_keys": [
+          "Standalone_Artist_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_3",
+        "script_level.level_keys": [
+          "Standalone_Artist_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_4",
+        "script_level.level_keys": [
+          "Standalone_Artist_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_5",
+        "script_level.level_keys": [
+          "Standalone_Artist_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_5.5",
+        "script_level.level_keys": [
+          "Standalone_Artist_5.5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_6",
+        "script_level.level_keys": [
+          "Standalone_Artist_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_7",
+        "script_level.level_keys": [
+          "Standalone_Artist_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_8",
+        "script_level.level_keys": [
+          "Standalone_Artist_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Standalone_Artist_9",
+        "script_level.level_keys": [
+          "Standalone_Artist_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "artist"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/artistExemplar.script_json
+++ b/dashboard/config/scripts_json/artistExemplar.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "artistExemplar",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "artistExemplar"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist Exemplar",
+      "name": "Artist Exemplar",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aEstory1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aEstory1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE3alternate"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE3alternate"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE3alternateB"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE3alternateB"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aE8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aE8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "aEfreeplay"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      },
+      "level_keys": [
+        "aEfreeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "aEstory1",
+        "script_level.level_keys": [
+          "aEstory1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE1",
+        "script_level.level_keys": [
+          "aE1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE2",
+        "script_level.level_keys": [
+          "aE2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE3",
+        "script_level.level_keys": [
+          "aE3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE3alternate",
+        "script_level.level_keys": [
+          "aE3alternate"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE3alternateB",
+        "script_level.level_keys": [
+          "aE3alternateB"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE4",
+        "script_level.level_keys": [
+          "aE4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE5",
+        "script_level.level_keys": [
+          "aE5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE6",
+        "script_level.level_keys": [
+          "aE6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE7",
+        "script_level.level_keys": [
+          "aE7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aE8",
+        "script_level.level_keys": [
+          "aE8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "aEfreeplay",
+        "script_level.level_keys": [
+          "aEfreeplay"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist Exemplar",
+        "lesson_group.key": "",
+        "script.name": "artistExemplar"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/asUnplugged.script_json
+++ b/dashboard/config/scripts_json/asUnplugged.script_json
@@ -1,0 +1,475 @@
+{
+  "script": {
+    "name": "asUnplugged",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "asUnplugged"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Happy Maps",
+      "name": "Happy Maps",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Move it, Move it",
+      "name": "Move it, Move it",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "key": "Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "UnplugHappyMaps"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MoveIt"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "MoveIt"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "BinaryBracelets"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "UnplugHappyMaps",
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MoveIt",
+        "script_level.level_keys": [
+          "MoveIt"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets",
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "asUnplugged"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/aws-demo.script_json
+++ b/dashboard/config/scripts_json/aws-demo.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "aws-demo",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "aws-demo"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "new stage",
+      "name": "new stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AWS Demo"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      },
+      "level_keys": [
+        "AWS Demo"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AWS applab"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      },
+      "level_keys": [
+        "AWS applab"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AWS link"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      },
+      "level_keys": [
+        "AWS link"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "AWS Demo",
+        "script_level.level_keys": [
+          "AWS Demo"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AWS applab",
+        "script_level.level_keys": [
+          "AWS applab"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AWS link",
+        "script_level.level_keys": [
+          "AWS link"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "aws-demo"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/basketball.script_json
+++ b/dashboard/config/scripts_json/basketball.script_json
@@ -1,0 +1,329 @@
+{
+  "script": {
+    "name": "basketball",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "basketball"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bounce",
+      "name": "Bounce",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1_basketball"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_1_basketball"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2_basketball"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_2_basketball"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5_basketball"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_5_basketball"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6_basketball"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_6_basketball"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7_basketball"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_7_basketball"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10_basketball"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_10_basketball"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11_basketball"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_11_basketball"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12_basketball"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      },
+      "level_keys": [
+        "bounce_12_basketball"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "bounce_1_basketball",
+        "script_level.level_keys": [
+          "bounce_1_basketball"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2_basketball",
+        "script_level.level_keys": [
+          "bounce_2_basketball"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5_basketball",
+        "script_level.level_keys": [
+          "bounce_5_basketball"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6_basketball",
+        "script_level.level_keys": [
+          "bounce_6_basketball"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7_basketball",
+        "script_level.level_keys": [
+          "bounce_7_basketball"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10_basketball",
+        "script_level.level_keys": [
+          "bounce_10_basketball"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11_basketball",
+        "script_level.level_keys": [
+          "bounce_11_basketball"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12_basketball",
+        "script_level.level_keys": [
+          "bounce_12_basketball"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "basketball"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/code-break-staging.script_json
+++ b/dashboard/config/scripts_json/code-break-staging.script_json
@@ -1,0 +1,4597 @@
+{
+  "script": {
+    "name": "code-break-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "code-break-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms with Hill Harper",
+      "name": "Algorithms with Hill Harper",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Prototypes with Mark Cuban & Lyndsey Scott",
+      "name": "Prototypes with Mark Cuban & Lyndsey Scott",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+      "name": "Encryption with Ashton Kutcher & Mia Gil Epner",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Digital Information with Mike Krieger & Alice Keeler",
+      "name": "Digital Information with Mike Krieger & Alice Keeler",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Simulations & Data with Bill Gates",
+      "name": "Simulations & Data with Bill Gates",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "name": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Conditionals with Sal Khan & Flo Vaughn",
+      "name": "Conditionals with Sal Khan & Flo Vaughn",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "name": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Events with Macklemore & Scott Forstall",
+      "name": "Events with Macklemore & Scott Forstall",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "AI with Kat Graham & Cody Simpson",
+      "name": "AI with Kat Graham & Cody Simpson",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "name": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+      "name": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode Placeholder"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 1 Instructions"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E01 Practice"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 1 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E01 Challenges"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Share"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 1 Share"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 2 Placeholder"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 2 Instructions"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 2 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E02 Challenges"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Share"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 2 Share"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Placeholder"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 3 Instructions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E03 Practice"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Video"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 3 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E03 Int Challenge"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Share"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 3 Share"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 4 Placeholder"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 4 Instructions"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E04 Practice"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Challenge Instructions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 4 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E04 Challenges"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Share"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 4 Share"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 5"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 5 Placeholder"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Instructions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 5 Instructions"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Practice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E05 Practice"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 5 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E05 Challenges"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Share"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 5 Share"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 6"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 6 Placeholder"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Instructions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 6 Instructions"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak e05 Practice Web lab"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak e05 Practice Web lab"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 6 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E06 Challenges"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E06 Challenges"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Share"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 6 Share"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 7"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 7 Placeholder"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Instructions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 7 Instructions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "App Lab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E7 Practice Magic 8 Ball"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E7 Practice Magic 8 Ball"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 7 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E07 Challenges"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E07 Challenges"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Share"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 21,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 7 Share"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 8 Placeholder"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Instructions"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 8 Instructions"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 8 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E08 Challenges"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E08 Challenges"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Share"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 8 Share"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 9"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 9 Placeholder"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Instructions"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 9 Instructions"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 9 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E09 Challenges"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E09 Challenges"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Share"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 9 Share"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 10"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 10 Placeholder"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 10 Instructions"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Societal_Implications"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 10 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Share"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 12,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 10 Share"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 11"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 11 Placeholder"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 11 Instructions"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 11 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E11 Challenges"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E11 Challenges"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Share"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 17,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 11 Share"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 12"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 12 Placeholder"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 12 Instructions"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike2"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 12 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Challenges"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "CodeBreak E12 Challenges"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Share"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      },
+      "level_keys": [
+        "Episode 12 Share"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Share",
+        "script_level.level_keys": [
+          "Episode 1 Share"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 2 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Share",
+        "script_level.level_keys": [
+          "Episode 2 Share"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Video",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Int Challenge",
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Share",
+        "script_level.level_keys": [
+          "Episode 3 Share"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 4 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Challenge Instructions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Share",
+        "script_level.level_keys": [
+          "Episode 4 Share"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 5 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Instructions",
+        "script_level.level_keys": [
+          "Episode 5 Instructions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E05 Practice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Share",
+        "script_level.level_keys": [
+          "Episode 5 Share"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 6 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Instructions",
+        "script_level.level_keys": [
+          "Episode 6 Instructions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak e05 Practice Web lab",
+        "script_level.level_keys": [
+          "CodeBreak e05 Practice Web lab"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E06 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E06 Challenges"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Share",
+        "script_level.level_keys": [
+          "Episode 6 Share"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 7 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Instructions",
+        "script_level.level_keys": [
+          "Episode 7 Instructions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E7 Practice Magic 8 Ball",
+        "script_level.level_keys": [
+          "CodeBreak E7 Practice Magic 8 Ball"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E07 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E07 Challenges"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Share",
+        "script_level.level_keys": [
+          "Episode 7 Share"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 21,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 8 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Instructions",
+        "script_level.level_keys": [
+          "Episode 8 Instructions"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E08 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E08 Challenges"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Share",
+        "script_level.level_keys": [
+          "Episode 8 Share"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 9 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Instructions",
+        "script_level.level_keys": [
+          "Episode 9 Instructions"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E09 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E09 Challenges"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Share",
+        "script_level.level_keys": [
+          "Episode 9 Share"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 10 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Short",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Societal_Implications",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Long",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Share",
+        "script_level.level_keys": [
+          "Episode 10 Share"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 12,
+        "lesson.key": "AI with Kat Graham & Cody Simpson",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 11 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E11 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E11 Challenges"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Share",
+        "script_level.level_keys": [
+          "Episode 11 Share"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 17,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 12 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike2",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E12 Challenges"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Share",
+        "script_level.level_keys": [
+          "Episode 12 Share"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/code-break-younger-staging.script_json
+++ b/dashboard/config/scripts_json/code-break-younger-staging.script_json
@@ -1,0 +1,4006 @@
+{
+  "script": {
+    "name": "code-break-younger-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "code-break-younger-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Episode 1 - Algorithms with Hill Harper",
+      "name": "Episode 1 - Algorithms with Hill Harper",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "name": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "name": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "name": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Episode 5 - Simulations & Data with Bill Gates",
+      "name": "Episode 5 - Simulations & Data with Bill Gates",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "name": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Conditionals with Sal Khan and Flo Vaughn",
+      "name": "Conditionals with Sal Khan and Flo Vaughn",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "name": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Events with Macklemore & Scott Forstall",
+      "name": "Events with Macklemore & Scott Forstall",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "name": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+      "name": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode Placeholder"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 1 Instructions"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E01 Practice"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 1 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E01 Challenges"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Share"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 1 Share"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 2 Placeholder"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 2 Instructions"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 2 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E02 Challenges"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Share"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 2 Share"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Placeholder"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 3 Instructions"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E03 Practice"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Video"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 3 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E03 Int Challenge"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Share"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 3 Share"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 4 Placeholder"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 4 Instructions"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E04 Practice"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Challenge Instructions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 4 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E04 Challenges"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Share"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 4 Share"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 5"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 5 Placeholder"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Instructions - Younger"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 5 Instructions - Younger"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Beg Practice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E05 Beg Practice"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions Younger"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 5 Challenge Instructions Younger"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges Younger"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E05 Challenges Younger"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Share"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 5 Share"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 6"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 6 Placeholder"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Instructions younger"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 6 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 6 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Share"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 6 Share"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 7"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 7 Placeholder"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Instructions - younger"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 7 Instructions - younger"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions - younger"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 7 Challenge Instructions - younger"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Share"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 7 Share"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 8 Placeholder"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Instructions younger"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 8 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 8 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E08 Beg Challenge 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E08 Beg Challenge 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Share"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 8 Share"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 9"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 9 Placeholder"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Instructions younger"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 9 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 9 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Dance Party Challenge"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Dance Party Challenge"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Share"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 17,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 9 Share"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 11"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 11 Placeholder"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 11 Instructions"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 11 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E11 Beg Challeng"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E11 Beg Challeng"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Share"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 17,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 11 Share"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 12"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak Episode 12 Placeholder"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 12 Instructions"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike2"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 12 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Work!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Share"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      },
+      "level_keys": [
+        "Episode 12 Share"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Share",
+        "script_level.level_keys": [
+          "Episode 1 Share"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 2 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Share",
+        "script_level.level_keys": [
+          "Episode 2 Share"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Video",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Int Challenge",
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Share",
+        "script_level.level_keys": [
+          "Episode 3 Share"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 4 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Challenge Instructions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Share",
+        "script_level.level_keys": [
+          "Episode 4 Share"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 5 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Instructions - Younger",
+        "script_level.level_keys": [
+          "Episode 5 Instructions - Younger"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Beg Practice",
+        "script_level.level_keys": [
+          "CodeBreak E05 Beg Practice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Challenge Instructions Younger",
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions Younger"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Challenges Younger",
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges Younger"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Share",
+        "script_level.level_keys": [
+          "Episode 5 Share"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 6 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 6 Instructions younger"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Share",
+        "script_level.level_keys": [
+          "Episode 6 Share"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 7 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Instructions - younger",
+        "script_level.level_keys": [
+          "Episode 7 Instructions - younger"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Challenge Instructions - younger",
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions - younger"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Share",
+        "script_level.level_keys": [
+          "Episode 7 Share"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 8 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 8 Instructions younger"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E08 Beg Challenge 2",
+        "script_level.level_keys": [
+          "CodeBreak E08 Beg Challenge 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Share",
+        "script_level.level_keys": [
+          "Episode 8 Share"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 9 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 9 Instructions younger"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Dance Party Challenge",
+        "script_level.level_keys": [
+          "CodeBreak Dance Party Challenge"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Share",
+        "script_level.level_keys": [
+          "Episode 9 Share"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 17,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 11 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E11 Beg Challeng",
+        "script_level.level_keys": [
+          "CodeBreak E11 Beg Challeng"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Share",
+        "script_level.level_keys": [
+          "Episode 11 Share"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 17,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 12 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike2",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Share",
+        "script_level.level_keys": [
+          "Episode 12 Share"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia Mineya",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/code-break-younger.script_json
+++ b/dashboard/config/scripts_json/code-break-younger.script_json
@@ -1,0 +1,3954 @@
+{
+  "script": {
+    "name": "code-break-younger",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "code-break-younger"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Episode 1 - Algorithms with Hill Harper",
+      "name": "Episode 1 - Algorithms with Hill Harper",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "name": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "name": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+        "visible_after": "2020-04-08 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "name": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+        "visible_after": "2020-04-15 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Episode 5 - Simulations & Data with Bill Gates",
+      "name": "Episode 5 - Simulations & Data with Bill Gates",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+        "visible_after": "2020-04-22 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "name": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Conditionals with Sal Khan and Flo Vaughn",
+      "name": "Conditionals with Sal Khan and Flo Vaughn",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "name": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Events with Macklemore & Scott Forstall",
+      "name": "Events with Macklemore & Scott Forstall",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "AI with Kat Graham & Kate Park",
+      "name": "AI with Kat Graham & Kate Park",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+        "visible_after": "2020-05-27 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "name": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+      "name": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode Placeholder"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 1 Instructions"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E01 Practice"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 1 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E01 Challenges"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 2 Placeholder"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Practice Younger"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E02 Practice Younger"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Younger Challenge Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E02 Younger Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Younger Challenges"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E02 Younger Challenges"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Placeholder"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 3 Instructions"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E03 Practice"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Video"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Younger Challenge Instructions"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 3 Younger Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 4 Placeholder"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 4 Instructions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E04 Practice"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges - Younger"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E04 Challenges - Younger"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 5"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 5 Placeholder"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Instructions - Younger"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 5 Instructions - Younger"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Beg Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E05 Beg Practice"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions Younger"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 5 Challenge Instructions Younger"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges Younger"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E05 Challenges Younger"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 6"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 6 Placeholder"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Instructions younger"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 6 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 6 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 7"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 7 Placeholder"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Instructions - younger"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 7 Instructions - younger"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions - younger"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 7 Challenge Instructions - younger"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 8 Placeholder"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Instructions younger"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 8 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 8 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E08 Beg Challenge 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E08 Beg Challenge 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 9"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 9 Placeholder"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Instructions younger"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 9 Instructions younger"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 9 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Dance Party Challenge"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Dance Party Challenge"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 10"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 10 Placeholder"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 10 Instructions"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Societal_Implications"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 10 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 11"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 11 Placeholder"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 11 Instructions"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 11 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E11 Beg Challeng"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E11 Beg Challeng"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 12"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak Episode 12 Placeholder"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 12 Instructions"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike2"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "Episode 12 Challenge Instructions younger"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 2 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Practice Younger",
+        "script_level.level_keys": [
+          "CodeBreak E02 Practice Younger"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Younger Challenge Instructions",
+        "script_level.level_keys": [
+          "CodeBreak E02 Younger Challenge Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Younger Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E02 Younger Challenges"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Video",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Younger Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Younger Challenge Instructions"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 4 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Challenges - Younger",
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges - Younger"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 5 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Instructions - Younger",
+        "script_level.level_keys": [
+          "Episode 5 Instructions - Younger"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Beg Practice",
+        "script_level.level_keys": [
+          "CodeBreak E05 Beg Practice"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Challenge Instructions Younger",
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions Younger"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Challenges Younger",
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges Younger"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 6 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 6 Instructions younger"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 7 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Instructions - younger",
+        "script_level.level_keys": [
+          "Episode 7 Instructions - younger"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Challenge Instructions - younger",
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions - younger"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan and Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 8 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 8 Instructions younger"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E08 Beg Challenge 2",
+        "script_level.level_keys": [
+          "CodeBreak E08 Beg Challenge 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 9 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Instructions younger",
+        "script_level.level_keys": [
+          "Episode 9 Instructions younger"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Dance Party Challenge",
+        "script_level.level_keys": [
+          "CodeBreak Dance Party Challenge"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 10 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Short",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Societal_Implications",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Long",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 11 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E11 Beg Challeng",
+        "script_level.level_keys": [
+          "CodeBreak E11 Beg Challeng"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 12 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike2",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Challenge Instructions younger",
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions younger"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break-younger"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/code-break.script_json
+++ b/dashboard/config/scripts_json/code-break.script_json
@@ -1,0 +1,4134 @@
+{
+  "script": {
+    "name": "code-break",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "code-break"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Episode 1 - Algorithms with Hill Harper",
+      "name": "Episode 1 - Algorithms with Hill Harper",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "name": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "name": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+        "visible_after": "2020-04-08 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "name": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+        "visible_after": "2020-04-15 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Episode 5 - Simulations & Data with Bill Gates",
+      "name": "Episode 5 - Simulations & Data with Bill Gates",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+        "visible_after": "2020-04-22 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "name": "The Internet with Keegan-Michael Key & Vint Cerf",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Conditionals with Sal Khan & Flo Vaughn",
+      "name": "Conditionals with Sal Khan & Flo Vaughn",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "name": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Events with Macklemore & Scott Forstall",
+      "name": "Events with Macklemore & Scott Forstall",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "AI with Kat Graham & Kate Park",
+      "name": "AI with Kat Graham & Kate Park",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+        "visible_after": "2020-05-27 08:00:00 -0700"
+      },
+      "seeding_key": {
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "name": "Abstraction with Susan Wojcicki & China Anne McClain",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+      "name": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode Placeholder"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 1 Instructions"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E01 Practice"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 1 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E01 Challenges"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 2 Placeholder"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 2 Instructions"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 2 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E02 Challenges"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Placeholder"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 3 Instructions"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E03 Practice"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 3 Video"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 3 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E03 Int Challenge"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 4 Placeholder"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 4 Instructions"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E04 Practice"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E04 Challenges"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 5"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 5 Placeholder"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Instructions"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 5 Instructions"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Practice"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E05 Practice"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 5 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E05 Challenges"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 6"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 6 Placeholder"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Instructions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 6 Instructions"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak e05 Practice Web lab"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak e05 Practice Web lab"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 6 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E06 Challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E06 Challenges"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 7"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 7 Placeholder"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Instructions"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 7 Instructions"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else with Bee Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "App Lab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E7 Practice Magic 8 Ball"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E7 Practice Magic 8 Ball"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 7 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E07 Challenges"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E07 Challenges"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 8 Placeholder"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Instructions"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 8 Instructions"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables with Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 8 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E08 Challenges"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E08 Challenges"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 9"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 9 Placeholder"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Instructions"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 9 Instructions"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 9 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E09 Challenges"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E09 Challenges"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 10"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 10 Placeholder"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 10 Instructions"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Societal_Implications"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 10 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 11"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 11 Placeholder"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 11 Instructions"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 11 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E11 Challenges"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E11 Challenges"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Break: Episode 12"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak Episode 12 Placeholder"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 12 Instructions"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E12 Practice Mike2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "Episode 12 Challenge Instructions"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CodeBreak E12 Challenges"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      },
+      "level_keys": [
+        "CodeBreak E12 Challenges"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode Placeholder"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Instructions"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E01 Practice"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 1 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 1 Challenge Instructions"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E01 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E01 Challenges"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Episode 1 - Algorithms with Hill Harper",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 2 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 2 Placeholder"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Instructions"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 2 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 2 Challenge Instructions"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E02 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E02 Challenges"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Placeholder"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Instructions"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E03 Practice"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 3 Video",
+        "script_level.level_keys": [
+          "CodeBreak Episode 3 Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 3 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 3 Challenge Instructions"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E03 Int Challenge",
+        "script_level.level_keys": [
+          "CodeBreak E03 Int Challenge"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 4 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 4 Placeholder"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 4 Instructions",
+        "script_level.level_keys": [
+          "Episode 4 Instructions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E04 Practice"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E04 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E04 Challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Episode 4 - Digital Information with Mike Krieger & Alice Keeler",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 5 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 5 Placeholder"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Instructions",
+        "script_level.level_keys": [
+          "Episode 5 Instructions"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Practice",
+        "script_level.level_keys": [
+          "CodeBreak E05 Practice"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 5 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 5 Challenge Instructions"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E05 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E05 Challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Episode 5 - Simulations & Data with Bill Gates",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 6 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 6 Placeholder"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Instructions",
+        "script_level.level_keys": [
+          "Episode 6 Instructions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak e05 Practice Web lab",
+        "script_level.level_keys": [
+          "CodeBreak e05 Practice Web lab"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 6 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 6 Challenge Instructions"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E06 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E06 Challenges"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "The Internet with Keegan-Michael Key & Vint Cerf",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 7 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 7 Placeholder"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Instructions",
+        "script_level.level_keys": [
+          "Episode 7 Instructions"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E7 Practice Magic 8 Ball",
+        "script_level.level_keys": [
+          "CodeBreak E7 Practice Magic 8 Ball"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 7 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 7 Challenge Instructions"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E07 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E07 Challenges"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals with Sal Khan & Flo Vaughn",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 8 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 8 Placeholder"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Instructions",
+        "script_level.level_keys": [
+          "Episode 8 Instructions"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 8 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 8 Challenge Instructions"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E08 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E08 Challenges"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Variables with Yara Shahidi & Fuzzy Khosrowshahi",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 9 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 9 Placeholder"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Instructions",
+        "script_level.level_keys": [
+          "Episode 9 Instructions"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 9 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 9 Challenge Instructions"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 15,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E09 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E09 Challenges"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 16,
+        "lesson.key": "Events with Macklemore & Scott Forstall",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 10 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 10 Placeholder"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Instructions"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Short",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Societal_Implications",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Long",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 10 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 10 Challenge Instructions"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "AI with Kat Graham & Kate Park",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 11 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 11 Placeholder"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Instructions"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 11 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 11 Challenge Instructions"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 15,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E11 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E11 Challenges"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 16,
+        "lesson.key": "Abstraction with Susan Wojcicki & China Anne McClain",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak Episode 12 Placeholder",
+        "script_level.level_keys": [
+          "CodeBreak Episode 12 Placeholder"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Instructions"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Practice Mike2",
+        "script_level.level_keys": [
+          "CodeBreak E12 Practice Mike2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Episode 12 Challenge Instructions",
+        "script_level.level_keys": [
+          "Episode 12 Challenge Instructions"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CodeBreak E12 Challenges",
+        "script_level.level_keys": [
+          "CodeBreak E12 Challenges"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Hardware with Aloe Blacc, Bret Taylor, & Paola Mejia",
+        "lesson_group.key": "",
+        "script.name": "code-break"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/colehoc17.script_json
+++ b/dashboard/config/scripts_json/colehoc17.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "colehoc17",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "colehoc17"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/colehoc2017.script_json
+++ b/dashboard/config/scripts_json/colehoc2017.script_json
@@ -1,0 +1,538 @@
+{
+  "script": {
+    "name": "colehoc2017",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "colehoc2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "colehoc2017 stage",
+      "name": "colehoc2017 stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_Cole"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_Cole"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_08_RY"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_08_RY"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_Cole"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_Cole"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_11_Cole"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_11_Cole"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_12_Cole"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_12_Cole"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_13_Cole"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      },
+      "level_keys": [
+        "MC_HOC_2017_13_Cole"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_Cole"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_08_RY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_08_RY"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_Cole"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_11_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_11_Cole"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_12_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_12_Cole"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_13_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_13_Cole"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "colehoc2017 stage",
+        "lesson_group.key": "",
+        "script.name": "colehoc2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course-e-2018.script_json
+++ b/dashboard/config/scripts_json/course-e-2018.script_json
@@ -1,0 +1,6884 @@
+{
+  "script": {
+    "name": "course-e-2018",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course-e-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_e_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course E (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "csf_e_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course E Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Algorithms: Dice Race",
+      "name": "Algorithms: Dice Race",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions in Harvester",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Internet",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "comment_intro_maze_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "DiceRace_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseC_video_angles_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_unplugged_privateInformation_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "SongwritingParameters_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions1_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions4_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions6_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions6_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions1_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions1_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions2_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions2_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions3_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions3_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions4_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions4_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions5_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions5_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions6_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions6_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions7_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions7_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions8_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions8_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions9_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions9_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions10_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions10_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions11_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions4b_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions5c_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions6c_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7b_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8b_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9b_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10b_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept5_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold1_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold2_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold3_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold4_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold5_2018"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold6_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseE_playLab_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "courseF_video_csMatters_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Geometric Sun_2018"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Robot Doodle_2018"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Alien Defender_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Alien Defender_2018"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Find the Wizard_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Find the Wizard_2018"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Begin planning your project_2018"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Play Lab Project_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Course E: Play Lab Project_2018"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Course E: Artist Project_2018"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Prepare for your presentation_2018"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Internet_2018"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      },
+      "level_keys": [
+        "Crowdsourcing_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comment_intro_maze_2018",
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DiceRace_2018",
+        "script_level.level_keys": [
+          "DiceRace_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseE_video_ramp1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8_2018",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles_2018",
+        "script_level.level_keys": [
+          "courseC_video_angles_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9_2018",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2018",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2018",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_2018",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_privateInformation_2018",
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters_2018",
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions1_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist_2018",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions4_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions6_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions6_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions1_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee_2018",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions2_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions3_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions3_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions4_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions4_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions5_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions5_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions_2018",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions6_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions6_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions7_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions7_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions8_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions8_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions9_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions9_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions10_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions10_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions11_predict1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions4b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions5c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions6c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2018",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold1_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold2_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold3_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold4_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold5_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold6_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters_2018",
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun_2018",
+        "script_level.level_keys": [
+          "Geometric Sun_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle_2018",
+        "script_level.level_keys": [
+          "Robot Doodle_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Alien Defender_2018",
+        "script_level.level_keys": [
+          "Alien Defender_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Find the Wizard_2018",
+        "script_level.level_keys": [
+          "Find the Wizard_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018",
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Play Lab Project_2018",
+        "script_level.level_keys": [
+          "Course E: Play Lab Project_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project_2018",
+        "script_level.level_keys": [
+          "Course E: Artist Project_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation_2018",
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet_2018",
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing_2018",
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "course-e-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course-f-2018.script_json
+++ b/dashboard/config/scripts_json/course-f-2018.script_json
@@ -1,0 +1,8524 @@
+{
+  "script": {
+    "name": "course-f-2018",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course-f-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_f_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course F (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "csf_f_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course F Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Algorithms: Tangrams",
+      "name": "Algorithms: Tangrams",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft",
+      "name": "Conditionals in Minecraft",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Songwriting with Parameters",
+      "name": "Songwriting with Parameters",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "comment_intro_maze_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseE_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro2_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles2_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseC_video_angles2_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_unplugged_powerOfWords_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_hello1_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_hello2_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_flag_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_move_to_flag_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_actor_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_move_to_actor_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_repeat_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_repeat_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_click_hello_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_click_hello_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_move_events_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_sound_and_points_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_throw_hearts_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_throw_hearts_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_free_play_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "iceage_free_play_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Tree_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Trees_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Place Wall_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Plant Crops_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Underground Mining Coal_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Underground Iron_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Underground If Statements_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "EnvelopeVariables_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "ForLoopFun_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3_2018"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4_2018"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5_2018"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2018"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8_2018"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10_2018"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee_2018"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions2_2018"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions3_2018"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a_2018"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions4_2018"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a_2018"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions_2018"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions6_2018"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functionsPre7_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions7_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a_2018"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1_2018"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_2018"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist_2018"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3_2018"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4_2018"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5_2018"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6_2018"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7_2018"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8_2018"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9_2018"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1_2018"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2_2018"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3_2018"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4_2018"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5_2018"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6_2018"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7_2018"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8_2018"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "courseF_video_csMatters_2018"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "InspirationalArtwork_2018"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "FoodFight_2018"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Guess The Number_2018"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure_2018"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Begin planning your project_2018"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project_2018"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project_2018"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise_2018"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise_2018"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      },
+      "level_keys": [
+        "Prepare for your presentation_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comment_intro_maze_2018",
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseE_video_ramp1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8_2018",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro2_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8_2018",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles2_2018",
+        "script_level.level_keys": [
+          "courseC_video_angles2_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9_2018",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_unplugged_powerOfWords_2018",
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1_2018",
+        "script_level.level_keys": [
+          "iceage_hello1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2_2018",
+        "script_level.level_keys": [
+          "iceage_hello2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag_2018",
+        "script_level.level_keys": [
+          "iceage_move_to_flag_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor_2018",
+        "script_level.level_keys": [
+          "iceage_move_to_actor_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat_2018",
+        "script_level.level_keys": [
+          "iceage_repeat_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello_2018",
+        "script_level.level_keys": [
+          "iceage_click_hello_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events_2018",
+        "script_level.level_keys": [
+          "iceage_move_events_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points_2018",
+        "script_level.level_keys": [
+          "iceage_sound_and_points_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age_2018",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts_2018",
+        "script_level.level_keys": [
+          "iceage_throw_hearts_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play_2018",
+        "script_level.level_keys": [
+          "iceage_free_play_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep_2018",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree_2018",
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep_2018",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees_2018",
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall_2018",
+        "script_level.level_keys": [
+          "Overworld Place Wall_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen_2018",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops_2018",
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters_2018",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal_2018",
+        "script_level.level_keys": [
+          "Underground Mining Coal_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron_2018",
+        "script_level.level_keys": [
+          "Underground Iron_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava_2018",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements_2018",
+        "script_level.level_keys": [
+          "Underground If Statements_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart_2018",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20_2018",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables_2018",
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2018",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2018",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant_2018",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun_2018",
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2018",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2018",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10_2018",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee_2018",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions2_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions3_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions4_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions_2018",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions6_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functionsPre7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions7_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters_2018",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist_2018",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters_2018",
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork_2018",
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight_2018",
+        "script_level.level_keys": [
+          "FoodFight_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number_2018",
+        "script_level.level_keys": [
+          "Guess The Number_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure_2018",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018",
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project_2018",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise_2018",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation_2018",
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "course-f-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course1.script_json
+++ b/dashboard/config/scripts_json/course1.script_json
@@ -1,0 +1,5897 @@
+{
+  "script": {
+    "name": "course1",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://code.org/curriculum/course1/{LESSON}/Teacher",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Happy Maps",
+      "name": "Happy Maps",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Move it, Move it",
+      "name": "Move it, Move it",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Jigsaw: Learn to drag and drop",
+      "name": "Jigsaw: Learn to drag and drop",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Maze: Sequence",
+      "name": "Maze: Sequence",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Maze: Debugging",
+      "name": "Maze: Debugging",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Bee: Sequence",
+      "name": "Bee: Sequence",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Artist: Sequence",
+      "name": "Artist: Sequence",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Artist: Shapes",
+      "name": "Artist: Shapes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Spelling Bee",
+      "name": "Spelling Bee",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Maze: Loops",
+      "name": "Maze: Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Bee: Loops",
+      "name": "Bee: Loops",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Studio: Create a Story",
+      "name": "Play Lab: Create a Story",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Going Places Safely",
+      "name": "Going Places Safely",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "key": "Artist: Loops",
+      "name": "Artist: Loops",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "UnplugHappyMaps"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Happy Maps Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Happy Maps Multi 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MoveIt"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "MoveIt"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Move It Multi 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Move It Multi 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 11,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 12,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:13"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "k-1 maze 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "k-1 maze 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 4"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 5"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 6"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 8"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 8"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 9"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 9"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 10"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 10"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze 11"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze 11"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Sequence Assessment 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Sequence Assessment 1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Sequence Assessment 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Sequence Assessment 2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Multiple Choice 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Multiple Choice 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Match 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Match 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 3"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 4"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 5"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 5"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 7"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 7"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 8"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 8"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 9"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 9"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 10"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 10"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 maze debug 11"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 maze debug 11"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Debugging Multi 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Debugging Multi 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Plant a Seed Multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Plant a Seed Multi 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Plant a Seed Multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Plant a Seed Multi 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 3"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 6"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 7"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 7"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 11"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 11"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Puzzle 12"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Puzzle 12"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 13"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 13"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 14"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 14"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 15"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 15"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 1 Multi 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 1 Multi 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee 1 Multi 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee 1 Multi 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 3"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 4"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 4"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 5"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 6"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 6"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 9"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 9"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist1 10"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist1 10"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 artist 1 level 9"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 artist 1 level 9"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 artist 1 level 10"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 artist 1 level 10"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist 1 Multi 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist 1 Multi 1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist 1 Multi 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist 1 Multi 2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_artist_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Building a Foundation Assessment"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Building a Foundation Assessment"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 5"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 6"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 6"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2_7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2_7"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 Assessment1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 Assessment1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist 2 Match 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist 2 Match 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist2 Free Draw"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist2 Free Draw"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_1"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_2"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_3"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_4"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_6"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_9"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_13"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_15"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_16"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_20"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_20"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Word Search Multi 1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Word Search Multi 1"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Word Search Multi 3"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Word Search Multi 3"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Getting Loopy Multi 1"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 3"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 5"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 6"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 6"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 7"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 7"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 8"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 8"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 10"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 10"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 11"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 11"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops 12"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops 12"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops Assessment 1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops Assessment 2"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops Assessment 2"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops Multi 1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops Multi 1"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Maze Loops Multi 2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Maze Loops Multi 2"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 1"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 2"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 3"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 3"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 4"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 4"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 5"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 5"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 6"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 6"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 7"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 7"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 8"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 8"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 9"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 9"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 10"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 10"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 11"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 11"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops 12"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops 12"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Bee Loops Match 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Bee Loops Match 1"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge3"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_collector_loops_challenge3"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge4"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_collector_loops_challenge4"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Big Event Match 1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Big Event Match 1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_1"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_2"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_3"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_3"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_4"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_5"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:k1_6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "blockly:Studio:k1_6"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_playlab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_playlab_events_challenge2"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "GoingPlacesSafely"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Keep it Private Multi 1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Keep it Private Multi 1"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 1"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 1"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 2"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 3"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 3"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 4"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 4"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 5"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 6"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 6"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 7"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 7"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 8"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 8"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops 9"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops 9"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Artist Loops Free Play"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "K-1 Artist Loops Free Play"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge3"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_artist_loops_challenge3"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge4"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      },
+      "level_keys": [
+        "course1_artist_loops_challenge4"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "UnplugHappyMaps",
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Happy Maps Multi 1",
+        "script_level.level_keys": [
+          "K-1 Happy Maps Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MoveIt",
+        "script_level.level_keys": [
+          "MoveIt"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Move It Multi 1",
+        "script_level.level_keys": [
+          "K-1 Move It Multi 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Move it, Move it",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 10,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 11,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:13",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 12,
+        "lesson.key": "Jigsaw: Learn to drag and drop",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "k-1 maze 1",
+        "script_level.level_keys": [
+          "k-1 maze 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 2",
+        "script_level.level_keys": [
+          "K-1 Maze 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 3",
+        "script_level.level_keys": [
+          "K-1 Maze 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 4",
+        "script_level.level_keys": [
+          "K-1 Maze 4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 5",
+        "script_level.level_keys": [
+          "K-1 Maze 5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 7",
+        "script_level.level_keys": [
+          "K-1 Maze 7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 6",
+        "script_level.level_keys": [
+          "K-1 Maze 6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 8",
+        "script_level.level_keys": [
+          "K-1 Maze 8"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 9",
+        "script_level.level_keys": [
+          "K-1 Maze 9"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 10",
+        "script_level.level_keys": [
+          "K-1 Maze 10"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze 11",
+        "script_level.level_keys": [
+          "K-1 Maze 11"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Sequence Assessment 1",
+        "script_level.level_keys": [
+          "K-1 Maze Sequence Assessment 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Sequence Assessment 2",
+        "script_level.level_keys": [
+          "K-1 Maze Sequence Assessment 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Multiple Choice 2",
+        "script_level.level_keys": [
+          "K-1 Maze Multiple Choice 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Match 1",
+        "script_level.level_keys": [
+          "K-1 Maze Match 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "course1_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "course1_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 1",
+        "script_level.level_keys": [
+          "K-1 maze debug 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 2",
+        "script_level.level_keys": [
+          "K-1 maze debug 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 3",
+        "script_level.level_keys": [
+          "K-1 maze debug 3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 4",
+        "script_level.level_keys": [
+          "K-1 maze debug 4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 5",
+        "script_level.level_keys": [
+          "K-1 maze debug 5"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 6",
+        "script_level.level_keys": [
+          "K-1 maze debug 6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 7",
+        "script_level.level_keys": [
+          "K-1 maze debug 7"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 8",
+        "script_level.level_keys": [
+          "K-1 maze debug 8"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 9",
+        "script_level.level_keys": [
+          "K-1 maze debug 9"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 10",
+        "script_level.level_keys": [
+          "K-1 maze debug 10"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 maze debug 11",
+        "script_level.level_keys": [
+          "K-1 maze debug 11"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Debugging Multi 1",
+        "script_level.level_keys": [
+          "K-1 Maze Debugging Multi 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "course1_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "course1_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Plant a Seed Multi 1",
+        "script_level.level_keys": [
+          "K-1 Plant a Seed Multi 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Plant a Seed Multi 2",
+        "script_level.level_keys": [
+          "K-1 Plant a Seed Multi 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 1",
+        "script_level.level_keys": [
+          "K-1 Bee 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 2",
+        "script_level.level_keys": [
+          "K-1 Bee 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 3",
+        "script_level.level_keys": [
+          "K-1 Bee 3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 4",
+        "script_level.level_keys": [
+          "K-1 Bee 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 5",
+        "script_level.level_keys": [
+          "K-1 Bee 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 6",
+        "script_level.level_keys": [
+          "K-1 Bee 6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 7",
+        "script_level.level_keys": [
+          "K-1 Bee 7"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 9",
+        "script_level.level_keys": [
+          "K-1 Bee 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 11",
+        "script_level.level_keys": [
+          "K-1 Bee 11"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Puzzle 12",
+        "script_level.level_keys": [
+          "K-1 Bee Puzzle 12"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 13",
+        "script_level.level_keys": [
+          "K-1 Bee 13"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 14",
+        "script_level.level_keys": [
+          "K-1 Bee 14"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 15",
+        "script_level.level_keys": [
+          "K-1 Bee 15"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 1 Multi 1",
+        "script_level.level_keys": [
+          "K-1 Bee 1 Multi 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee 1 Multi 2",
+        "script_level.level_keys": [
+          "K-1 Bee 1 Multi 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 1",
+        "script_level.level_keys": [
+          "K-1 Artist1 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 2",
+        "script_level.level_keys": [
+          "K-1 Artist1 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 3",
+        "script_level.level_keys": [
+          "K-1 Artist1 3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 4",
+        "script_level.level_keys": [
+          "K-1 Artist1 4"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 5",
+        "script_level.level_keys": [
+          "K-1 Artist1 5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 6",
+        "script_level.level_keys": [
+          "K-1 Artist1 6"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 9",
+        "script_level.level_keys": [
+          "K-1 Artist1 9"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist1 10",
+        "script_level.level_keys": [
+          "K-1 Artist1 10"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 artist 1 level 9",
+        "script_level.level_keys": [
+          "K-1 artist 1 level 9"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 artist 1 level 10",
+        "script_level.level_keys": [
+          "K-1 artist 1 level 10"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist 1 Multi 1",
+        "script_level.level_keys": [
+          "K-1 Artist 1 Multi 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist 1 Multi 2",
+        "script_level.level_keys": [
+          "K-1 Artist 1 Multi 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_artist_loops_challenge2",
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Building a Foundation Assessment",
+        "script_level.level_keys": [
+          "K-1 Building a Foundation Assessment"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 1",
+        "script_level.level_keys": [
+          "K-1 Artist2 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 2",
+        "script_level.level_keys": [
+          "K-1 Artist2 2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 3",
+        "script_level.level_keys": [
+          "K-1 Artist2 3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 4",
+        "script_level.level_keys": [
+          "K-1 Artist2 4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 5",
+        "script_level.level_keys": [
+          "K-1 Artist2 5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 6",
+        "script_level.level_keys": [
+          "K-1 Artist2 6"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2_7",
+        "script_level.level_keys": [
+          "K-1 Artist2_7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 Assessment1",
+        "script_level.level_keys": [
+          "K-1 Artist2 Assessment1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist 2 Match 2",
+        "script_level.level_keys": [
+          "K-1 Artist 2 Match 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist2 Free Draw",
+        "script_level.level_keys": [
+          "K-1 Artist2 Free Draw"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Shapes",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_1",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_2",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_3",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_4",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_6",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_9",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_13",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_15",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_16",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_20",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_20"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Word Search Multi 1",
+        "script_level.level_keys": [
+          "K-1 Word Search Multi 1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Word Search Multi 3",
+        "script_level.level_keys": [
+          "K-1 Word Search Multi 3"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Getting Loopy Multi 1",
+        "script_level.level_keys": [
+          "K-1 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 1",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 2",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 3",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 5",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 6",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 6"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 7",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 7"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 8",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 8"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 10",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 10"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 11",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 11"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops 12",
+        "script_level.level_keys": [
+          "K-1 Maze Loops 12"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops Assessment 1",
+        "script_level.level_keys": [
+          "K-1 Maze Loops Assessment 1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops Assessment 2",
+        "script_level.level_keys": [
+          "K-1 Maze Loops Assessment 2"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops Multi 1",
+        "script_level.level_keys": [
+          "K-1 Maze Loops Multi 1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Maze Loops Multi 2",
+        "script_level.level_keys": [
+          "K-1 Maze Loops Multi 2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 1",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 2",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 3",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 3"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 4",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 4"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 5",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 5"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 6",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 6"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 7",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 7"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 8",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 8"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 9",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 9"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 10",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 10"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 11",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 11"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops 12",
+        "script_level.level_keys": [
+          "K-1 Bee Loops 12"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Bee Loops Match 1",
+        "script_level.level_keys": [
+          "K-1 Bee Loops Match 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_collector_loops_challenge3",
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge3"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_collector_loops_challenge4",
+        "script_level.level_keys": [
+          "course1_collector_loops_challenge4"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Big Event Match 1",
+        "script_level.level_keys": [
+          "K-1 Big Event Match 1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_1",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_2",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_3",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_3"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_4",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_5",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:k1_6",
+        "script_level.level_keys": [
+          "blockly:Studio:k1_6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "course1_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "course1_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoingPlacesSafely",
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Keep it Private Multi 1",
+        "script_level.level_keys": [
+          "K-1 Keep it Private Multi 1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 1",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 1"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 2",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 3",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 3"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 4",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 4"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 5",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 6",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 6"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 7",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 7"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 8",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 8"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops 9",
+        "script_level.level_keys": [
+          "K-1 Artist Loops 9"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Artist Loops Free Play",
+        "script_level.level_keys": [
+          "K-1 Artist Loops Free Play"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_artist_loops_challenge3",
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge3"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course1_artist_loops_challenge4",
+        "script_level.level_keys": [
+          "course1_artist_loops_challenge4"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course2.script_json
+++ b/dashboard/config/scripts_json/course2.script_json
@@ -1,0 +1,6353 @@
+{
+  "script": {
+    "name": "course2",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://code.org/curriculum/course2/{LESSON}/Teacher",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Paper Planes",
+      "name": "Real-life Algorithms: Paper Planes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Maze: Sequence",
+      "name": "Maze: Sequence",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Artist: Sequence",
+      "name": "Artist: Sequence",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Maze: Loops",
+      "name": "Maze: Loops",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Artist: Loops",
+      "name": "Artist: Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Bee: Loops",
+      "name": "Bee: Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Relay programming",
+      "name": "Relay programming",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Bee: Debugging",
+      "name": "Bee: Debugging",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Artist: Debugging",
+      "name": "Artist: Debugging",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Bee: Conditionals",
+      "name": "Bee: Conditionals",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Flappy",
+      "name": "Flappy",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Studio: Create a Story",
+      "name": "Play Lab: Create a Story",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Your Digital Footprint",
+      "name": "Your Digital Footprint",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "key": "Artist: Nested Loops",
+      "name": "Artist: Nested Loops",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Graph Paper Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Graph Paper Multi 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Graph Paper Match 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Graph Paper Match 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "PaperPlanes"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Algorithms Multi 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Algorithms Multi 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Algorithms Multi 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Algorithms Multi 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 6"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 10"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Multi 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Multi 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Match 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Match 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_maze_programming_challenge1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_maze_programming_challenge2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 1 new"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 2 new"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 2 new"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 3new"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 3new"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 3.4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 3.4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 6"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 6"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "2-3 Artist 9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 9 NEW",
+          "2-3 Artist 9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 9 NEW",
+        "2-3 Artist 9"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Free Play"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Assessment 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Assessment 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist match 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 artist match 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_artist_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Getting Loopy Multi 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 12"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 12"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 13"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 13"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 15"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 16 before"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 16 before"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze 16"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze 16"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 17"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 17"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 18"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 18"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 19"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 19"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 20"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 20"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops 21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops 21"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Maze Loops Assessment 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Maze Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 maze multi 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 maze multi 1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 maze match 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 maze match 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_maze_loops_challenge1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_maze_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 2"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "4-5 Artist 3.5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "4-5 Artist 4"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 11"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 11"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist 12"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist 12"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 10"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 11"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 11"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 12"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 12"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 13"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 13"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 14"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 14"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 15"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Loops New 15"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops match 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 artist loops match 1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops multi 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 artist loops multi 2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist loops multi 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 artist loops multi 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 1A"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 1A"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2A"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 2A"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3A"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 3A"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3B"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 3B"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 7"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 7"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 4A"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 4A"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 3"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 4"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 5"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 6"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 13"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 13"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 bee loops multi 1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 bee loops multi 1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_harvester_loops_challenge1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_harvester_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 16,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_harvester_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "RelayProgramming"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Relay Programming Multi 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Relay Programming Multi 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Relay Programming Multi 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Relay Programming Multi 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 3"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 4"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 4"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 5"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 5"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 6"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 6"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 7"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 7"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 8"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 8"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 9"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 9"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 10"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging 10"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Debugging Assessment 1"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_collector_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_collector_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 1"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 2"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 3"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 5"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 6"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 7"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 8"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 8"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 9"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 9"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 10"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 10"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 11"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging 11"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Debugging Assessment 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Debugging Assessment 1"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist debug multi 1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 artist debug multi 1"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Conditionals Multi 1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Conditionals Multi 1"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 2"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 3"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 5"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 6"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 7"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 8"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 9"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 9"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 11"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 11"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 12"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 12"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 13"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 13"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 14"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 14"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 15"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals 15"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Bee Conditionals Assessment 1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 bee conditionals multi 1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 bee conditionals multi 3"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 16,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_bee_conditionals_challenge2"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 17,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_bee_conditionals_challenge1"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "BinaryBracelets"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Binary Match 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Binary Match 1"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Big Event Match 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Big Event Match 1"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_2"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_3"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_3"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_4"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_4"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_5"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_5"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_6"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_6"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_7"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_7"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_8"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_8"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_9"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_9"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_10"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_10"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c2_11"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "blockly:Studio:c2_11"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "DigitalFootprint"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "K-1 Digital Footprint Multi 1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "K-1 Digital Footprint Multi 1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 1"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 2"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 3"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 4"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 5"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 6"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 7"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 7"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 8"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 8"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 9"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 9"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 10"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 11"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 11"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 12"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops 12"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops Free Play"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "2-3 Artist Nested Loops Free Play"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_artist_nestedLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      },
+      "level_keys": [
+        "course2_artist_nestedLoops_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Graph Paper Multi 1",
+        "script_level.level_keys": [
+          "2-3 Graph Paper Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Graph Paper Match 1",
+        "script_level.level_keys": [
+          "2-3 Graph Paper Match 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PaperPlanes",
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Algorithms Multi 1",
+        "script_level.level_keys": [
+          "2-3 Algorithms Multi 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Algorithms Multi 2",
+        "script_level.level_keys": [
+          "2-3 Algorithms Multi 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 1",
+        "script_level.level_keys": [
+          "2-3 Maze 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 2",
+        "script_level.level_keys": [
+          "2-3 Maze 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 3",
+        "script_level.level_keys": [
+          "2-3 Maze 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 4",
+        "script_level.level_keys": [
+          "2-3 Maze 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 6",
+        "script_level.level_keys": [
+          "2-3 Maze 6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 7",
+        "script_level.level_keys": [
+          "2-3 Maze 7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 8",
+        "script_level.level_keys": [
+          "2-3 Maze 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 9",
+        "script_level.level_keys": [
+          "2-3 Maze 9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 10",
+        "script_level.level_keys": [
+          "2-3 Maze 10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Multi 2",
+        "script_level.level_keys": [
+          "2-3 Maze Multi 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Match 2",
+        "script_level.level_keys": [
+          "2-3 Maze Match 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_maze_programming_challenge1",
+        "script_level.level_keys": [
+          "course2_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_maze_programming_challenge2",
+        "script_level.level_keys": [
+          "course2_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 1 new",
+        "script_level.level_keys": [
+          "2-3 Artist 1 new"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 2 new",
+        "script_level.level_keys": [
+          "2-3 Artist 2 new"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3new",
+        "script_level.level_keys": [
+          "2-3 Artist 3new"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 3.4",
+        "script_level.level_keys": [
+          "2-3 Artist 3.4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 4",
+        "script_level.level_keys": [
+          "2-3 Artist 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 6",
+        "script_level.level_keys": [
+          "2-3 Artist 6"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 9 NEW",
+        "script_level.level_keys": [
+          "2-3 Artist 9 NEW",
+          "2-3 Artist 9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 9",
+        "script_level.level_keys": [
+          "2-3 Artist 9 NEW",
+          "2-3 Artist 9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 7",
+        "script_level.level_keys": [
+          "2-3 Artist 7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 8",
+        "script_level.level_keys": [
+          "2-3 Artist 8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Free Play"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Artist Assessment 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist match 1",
+        "script_level.level_keys": [
+          "2-3 artist match 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "course2_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_prog_challenge2",
+        "script_level.level_keys": [
+          "course2_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Sequence",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Getting Loopy Multi 1",
+        "script_level.level_keys": [
+          "2-3 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 1",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 12",
+        "script_level.level_keys": [
+          "2-3 Maze 12"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 13",
+        "script_level.level_keys": [
+          "2-3 Maze 13"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 15",
+        "script_level.level_keys": [
+          "2-3 Maze 15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 16 before",
+        "script_level.level_keys": [
+          "2-3 Maze 16 before"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze 16",
+        "script_level.level_keys": [
+          "2-3 Maze 16"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 17",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 17"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 18",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 18"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 19",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 19"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 20",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 20"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops 21",
+        "script_level.level_keys": [
+          "2-3 Maze Loops 21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Maze Loops Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Maze Loops Assessment 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 maze multi 1",
+        "script_level.level_keys": [
+          "2-3 maze multi 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 maze match 1",
+        "script_level.level_keys": [
+          "2-3 maze match 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_maze_loops_challenge1",
+        "script_level.level_keys": [
+          "course2_maze_loops_challenge1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "course2_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Maze: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 1",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 2",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 3.5",
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 4",
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 11",
+        "script_level.level_keys": [
+          "2-3 Artist 11"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist 12",
+        "script_level.level_keys": [
+          "2-3 Artist 12"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 9",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 10",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 11",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 11"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 12",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 12"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 13",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 13"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 14",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 14"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Loops New 15",
+        "script_level.level_keys": [
+          "2-3 Artist Loops New 15"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops match 1",
+        "script_level.level_keys": [
+          "2-3 artist loops match 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops multi 2",
+        "script_level.level_keys": [
+          "2-3 artist loops multi 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist loops multi 1",
+        "script_level.level_keys": [
+          "2-3 artist loops multi 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 1A",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 1A"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 2A",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2A"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 3A",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3A"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 3B",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3B"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 7",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 7"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 4A",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 4A"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 1",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 2",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 3",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 4",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 5",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 6",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 13",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 13"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 bee loops multi 1",
+        "script_level.level_keys": [
+          "2-3 bee loops multi 1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_harvester_loops_challenge1",
+        "script_level.level_keys": [
+          "course2_harvester_loops_challenge1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_harvester_loops_challenge2",
+        "script_level.level_keys": [
+          "course2_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 16,
+        "lesson.key": "Bee: Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming",
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Relay Programming Multi 1",
+        "script_level.level_keys": [
+          "2-3 Relay Programming Multi 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Relay Programming Multi 2",
+        "script_level.level_keys": [
+          "2-3 Relay Programming Multi 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Relay programming",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 1",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 2",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 3",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 4",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 4"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 5",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 5"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 6",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 6"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 7",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 7"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 8",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 8"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 9",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 9"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging 10",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging 10"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Debugging Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_collector_prog_challenge1",
+        "script_level.level_keys": [
+          "course2_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_collector_prog_challenge2",
+        "script_level.level_keys": [
+          "course2_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 1",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 2",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 3",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 5",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 6",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 7",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 8",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 8"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 9",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 9"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 10",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 10"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging 11",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging 11"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Debugging Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Artist Debugging Assessment 1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist debug multi 1",
+        "script_level.level_keys": [
+          "2-3 artist debug multi 1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Conditionals Multi 1",
+        "script_level.level_keys": [
+          "2-3 Conditionals Multi 1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 2",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 3",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 5",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 6",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 7",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 8",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 9",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 9"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 11",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 11"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 12",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 12"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 13",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 13"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 14",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 14"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals 15",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals 15"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Conditionals Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 bee conditionals multi 1",
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 bee conditionals multi 3",
+        "script_level.level_keys": [
+          "2-3 bee conditionals multi 3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_bee_conditionals_challenge2",
+        "script_level.level_keys": [
+          "course2_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 16,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_bee_conditionals_challenge1",
+        "script_level.level_keys": [
+          "course2_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 17,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets",
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Binary Match 1",
+        "script_level.level_keys": [
+          "2-3 Binary Match 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Big Event Match 1",
+        "script_level.level_keys": [
+          "2-3 Big Event Match 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "The Big Event",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Flappy",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_1",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_2",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_3",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_3"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_4",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_4"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_5",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_5"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_6",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_6"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_7",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_7"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_8",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_8"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_9",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_9"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_10",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_10"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c2_11",
+        "script_level.level_keys": [
+          "blockly:Studio:c2_11"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint",
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "K-1 Digital Footprint Multi 1",
+        "script_level.level_keys": [
+          "K-1 Digital Footprint Multi 1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 1",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 2",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 3",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 4",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 5",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 6",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 7",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 7"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 8",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 8"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 9",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 9"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 10",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 11",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 11"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops 12",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops 12"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Nested Loops Free Play",
+        "script_level.level_keys": [
+          "2-3 Artist Nested Loops Free Play"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_nestedLoops_challenge1",
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_nestedLoops_challenge2",
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course3.script_json
+++ b/dashboard/config/scripts_json/course3.script_json
@@ -1,0 +1,7129 @@
+{
+  "script": {
+    "name": "course3",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://code.org/curriculum/course3/{LESSON}/Teacher",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Computational Thinking",
+      "name": "Computational Thinking",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Maze",
+      "name": "Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Functional Suncatchers",
+      "name": "Functional Suncatchers",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Artist: Functions",
+      "name": "Artist: Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Bee: Functions",
+      "name": "Bee: Functions",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Bee: Conditionals",
+      "name": "Bee: Conditionals",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Maze: Conditionals",
+      "name": "Maze: Conditionals",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Dice Race",
+      "name": "Dice Race",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Artist: Nested Loops",
+      "name": "Artist: Nested Loops",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Farmer: While Loops",
+      "name": "Farmer: While Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Bee: Nested Loops",
+      "name": "Bee: Nested Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Bee: Debugging",
+      "name": "Bee: Debugging",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Bounce",
+      "name": "Bounce",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Studio: Create a Story",
+      "name": "Play Lab: Create a Story",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Studio: Create a Game",
+      "name": "Play Lab: Create a Game",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Internet",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "key": "Artist: Patterns",
+      "name": "Artist: Patterns",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ComputationalThinking"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "ComputationalThinking"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Computational Thinking Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Computational Thinking Multi 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Computational Thinking Match 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Computational Thinking Match 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze 12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze 12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 maze match 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 maze match 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 maze multi 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 15,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 maze multi 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 16,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 17,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 3.5"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 4"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 6"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 7"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 8"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 9"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist 11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist 11"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Assessment 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Assessment 1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 artist multi 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 artist multi 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 artist multi 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 artist multi 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Free Draw 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Free Draw 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FunctionalSuncatchers"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "FunctionalSuncatchers"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Suncatchers Multi 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Suncatchers Multi 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Suncatchers Match 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Suncatchers Match 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 11"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11.5"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 11.5"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 12"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Artist Functions 10"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Artist Functions 10"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 artist functions multi 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 artist functions multi 1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_artist_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_artist_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 2"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 6"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions 10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions 10"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions Assessment 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions Assessment 1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Functions Assessment 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Functions Assessment 2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 4"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 5"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 6"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 7"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals 8"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Conditionals Assessment 1"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 bee conditionals multi 1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 3"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 4"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 4"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 5"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 5"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 6"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 6"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 7"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 8"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 8"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 10"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals 10"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Maze Conditionals Assessment 1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 maze conditionals multi 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 maze conditionals multi 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_maze_until_challenge1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_maze_until_challenge1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_farmer_until_challenge2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Songwriting Multi 1"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Songwriting Multi 1"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Algorithms Match 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Algorithms Match 1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Algorithms Multi 1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Algorithms Multi 1"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 6"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 6"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 9"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 3"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 3"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 5"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 7"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 11"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 11"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 8"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 8"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops 12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops 12"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Nested Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 artist loops multi 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 artist loops multi 1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course2_artist_nestedLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course2_artist_nestedLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 1"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 2"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 3"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 4"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 5"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 6"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 6"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 7"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 7"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops 8"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops 8"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 While Loops Assessment 1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 While Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge3"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_bee_functions_challenge3"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge4"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_bee_functions_challenge4"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 1"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 2"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 3"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 3"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 5"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 5"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 4"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 8"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 8"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 7"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 7"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops 10"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Loops 10"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 9"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops 9"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Rows"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops Rows"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Bee Loops Assessment 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "2-3 Bee Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Nested Loops Assessment 1"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 bee loops multi 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 bee loops multi 1"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_bee_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_collector_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 1"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 3"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 3"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 4"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 4"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 5"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 5"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 6"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 6"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 7"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 7"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 8"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 8"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 9"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 9"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 10"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 10"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 11"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging 11"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Bee Debugging Assessment 1"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 bee debug multi 1"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 bee debug multi 1"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_1"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_2"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_3"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_4"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_5"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_story_6"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playLab_challenge1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "course3_playLab_challenge1"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_1"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_2"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_3"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_4"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_5"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_6"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_7"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "blockly:Studio:c3_game_7"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Internet Multi 1"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Internet Multi 1"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Internet Multi 2"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Internet Multi 2"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "Crowdsourcing"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Crowdsourcing Multi 1"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Crowdsourcing Multi 1"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Crowdsourcing Multi 2"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Crowdsourcing Multi 2"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalCitizenship"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "DigitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Digital Footprint Multi 1"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Digital Footprint Multi 1"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 1"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 1"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 2"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 3"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 3"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 4"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 4"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 5"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 5"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 6"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 7"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 7"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 8"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 8"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 9"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 9"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 9.5"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 9.5"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 10"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 10"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 11"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 11"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 12"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 12"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 13"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns 13"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Artist Patterns Free Play"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      },
+      "level_keys": [
+        "4-5 Artist Patterns Free Play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ComputationalThinking",
+        "script_level.level_keys": [
+          "ComputationalThinking"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Computational Thinking Multi 1",
+        "script_level.level_keys": [
+          "4-5 Computational Thinking Multi 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Computational Thinking Match 1",
+        "script_level.level_keys": [
+          "4-5 Computational Thinking Match 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 1",
+        "script_level.level_keys": [
+          "4-5 Maze 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 2",
+        "script_level.level_keys": [
+          "4-5 Maze 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 3",
+        "script_level.level_keys": [
+          "4-5 Maze 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 4",
+        "script_level.level_keys": [
+          "4-5 Maze 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 5",
+        "script_level.level_keys": [
+          "4-5 Maze 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 6",
+        "script_level.level_keys": [
+          "4-5 Maze 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 7",
+        "script_level.level_keys": [
+          "4-5 Maze 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 8",
+        "script_level.level_keys": [
+          "4-5 Maze 8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 9",
+        "script_level.level_keys": [
+          "4-5 Maze 9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 10",
+        "script_level.level_keys": [
+          "4-5 Maze 10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 11",
+        "script_level.level_keys": [
+          "4-5 Maze 11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze 12",
+        "script_level.level_keys": [
+          "4-5 Maze 12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Maze Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 maze match 1",
+        "script_level.level_keys": [
+          "4-5 maze match 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 maze multi 1",
+        "script_level.level_keys": [
+          "4-5 maze multi 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 15,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "course3_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 16,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "course3_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 17,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 1",
+        "script_level.level_keys": [
+          "4-5 Artist 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 2",
+        "script_level.level_keys": [
+          "4-5 Artist 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 3",
+        "script_level.level_keys": [
+          "4-5 Artist 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 3.5",
+        "script_level.level_keys": [
+          "4-5 Artist 3.5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 4",
+        "script_level.level_keys": [
+          "4-5 Artist 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 5",
+        "script_level.level_keys": [
+          "4-5 Artist 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 6",
+        "script_level.level_keys": [
+          "4-5 Artist 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 7",
+        "script_level.level_keys": [
+          "4-5 Artist 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 8",
+        "script_level.level_keys": [
+          "4-5 Artist 8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 9",
+        "script_level.level_keys": [
+          "4-5 Artist 9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist 11",
+        "script_level.level_keys": [
+          "4-5 Artist 11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Artist Assessment 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 artist multi 1",
+        "script_level.level_keys": [
+          "4-5 artist multi 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 artist multi 2",
+        "script_level.level_keys": [
+          "4-5 artist multi 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Free Draw 1",
+        "script_level.level_keys": [
+          "4-5 Artist Free Draw 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FunctionalSuncatchers",
+        "script_level.level_keys": [
+          "FunctionalSuncatchers"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Suncatchers Multi 1",
+        "script_level.level_keys": [
+          "4-5 Suncatchers Multi 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Suncatchers Match 1",
+        "script_level.level_keys": [
+          "4-5 Suncatchers Match 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Functional Suncatchers",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 1",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 2",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 3",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 4",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 11",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 11.5",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 11.5"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 12",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 12"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 9",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Artist Functions 10",
+        "script_level.level_keys": [
+          "2-3 Artist Functions 10"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 artist functions multi 1",
+        "script_level.level_keys": [
+          "2-3 artist functions multi 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_artist_functions_challenge1",
+        "script_level.level_keys": [
+          "course3_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_artist_functions_challenge2",
+        "script_level.level_keys": [
+          "course3_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 3",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 1",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 2",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 4",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 5",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 6",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 8",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 9",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions 10",
+        "script_level.level_keys": [
+          "2-3 Bee Functions 10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Functions Assessment 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Functions Assessment 2",
+        "script_level.level_keys": [
+          "2-3 Bee Functions Assessment 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Functions",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 1",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 2",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 3",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 4",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 5",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 6",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 7",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals 8",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals 8"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Conditionals Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Bee Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 bee conditionals multi 1",
+        "script_level.level_keys": [
+          "4-5 bee conditionals multi 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "course3_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "course3_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 1",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 2",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 3",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 4",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 4"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 5",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 5"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 6",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 6"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 7",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 7"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 8",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 8"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 9",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals 10",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals 10"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Maze Conditionals Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Maze Conditionals Assessment 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 maze conditionals multi 1",
+        "script_level.level_keys": [
+          "4-5 maze conditionals multi 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_maze_until_challenge1",
+        "script_level.level_keys": [
+          "course3_maze_until_challenge1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_farmer_until_challenge2",
+        "script_level.level_keys": [
+          "course3_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 14,
+        "lesson.key": "Maze: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Songwriting Multi 1",
+        "script_level.level_keys": [
+          "4-5 Songwriting Multi 1"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Songwriting",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Algorithms Match 1",
+        "script_level.level_keys": [
+          "4-5 Algorithms Match 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Algorithms Multi 1",
+        "script_level.level_keys": [
+          "4-5 Algorithms Multi 1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Dice Race",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 1",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 2",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 6",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 6"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 9",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 3",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 3"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 5",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 7",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 11",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 11"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 8",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 8"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops 12",
+        "script_level.level_keys": [
+          "4-5 Nested Loops 12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Nested Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 artist loops multi 1",
+        "script_level.level_keys": [
+          "4-5 artist loops multi 1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_nestedLoops_challenge1",
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_artist_nestedLoops_challenge2",
+        "script_level.level_keys": [
+          "course2_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 1",
+        "script_level.level_keys": [
+          "4-5 While Loops 1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 2",
+        "script_level.level_keys": [
+          "4-5 While Loops 2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 3",
+        "script_level.level_keys": [
+          "4-5 While Loops 3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 4",
+        "script_level.level_keys": [
+          "4-5 While Loops 4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 5",
+        "script_level.level_keys": [
+          "4-5 While Loops 5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 6",
+        "script_level.level_keys": [
+          "4-5 While Loops 6"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 7",
+        "script_level.level_keys": [
+          "4-5 While Loops 7"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops 8",
+        "script_level.level_keys": [
+          "4-5 While Loops 8"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 While Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 While Loops Assessment 1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_bee_functions_challenge3",
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge3"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_bee_functions_challenge4",
+        "script_level.level_keys": [
+          "course3_bee_functions_challenge4"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Farmer: While Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 1",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 2",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 3",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 3"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 5",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 5"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 4",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 8",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 8"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 7",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 7"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops 10",
+        "script_level.level_keys": [
+          "2-3 Bee Loops 10"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops 9",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops 9"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops Rows",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Rows"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Bee Loops Assessment 1",
+        "script_level.level_keys": [
+          "2-3 Bee Loops Assessment 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Nested Loops Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Bee Nested Loops Assessment 1"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 bee loops multi 1",
+        "script_level.level_keys": [
+          "4-5 bee loops multi 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_bee_debugging_challenge1",
+        "script_level.level_keys": [
+          "course3_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 14,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_collector_debugging_challenge2",
+        "script_level.level_keys": [
+          "course3_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 15,
+        "lesson.key": "Bee: Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 1",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 2",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 3",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 3"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 4",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 4"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 5",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 5"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 6",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 6"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 7",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 7"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 8",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 8"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 9",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 9"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 10",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 10"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging 11",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging 11"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Bee Debugging Assessment 1",
+        "script_level.level_keys": [
+          "4-5 Bee Debugging Assessment 1"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 bee debug multi 1",
+        "script_level.level_keys": [
+          "4-5 bee debug multi 1"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Debugging",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_1",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_2",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_3",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_4",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_5",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_story_6",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_story_6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playLab_challenge1",
+        "script_level.level_keys": [
+          "course3_playLab_challenge1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Story",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_1",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_2",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_3",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_4",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_5",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_6",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:c3_game_7",
+        "script_level.level_keys": [
+          "blockly:Studio:c3_game_7"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Studio: Create a Game",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Internet Multi 1",
+        "script_level.level_keys": [
+          "4-5 Internet Multi 1"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Internet Multi 2",
+        "script_level.level_keys": [
+          "4-5 Internet Multi 2"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing",
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Crowdsourcing Multi 1",
+        "script_level.level_keys": [
+          "4-5 Crowdsourcing Multi 1"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Crowdsourcing Multi 2",
+        "script_level.level_keys": [
+          "4-5 Crowdsourcing Multi 2"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalCitizenship",
+        "script_level.level_keys": [
+          "DigitalCitizenship"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Digital Footprint Multi 1",
+        "script_level.level_keys": [
+          "4-5 Digital Footprint Multi 1"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 1",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 1"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 2",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 3",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 3"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 4",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 4"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 5",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 5"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 6",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 7",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 7"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 8",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 8"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 9",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 9"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 9.5",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 9.5"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 10",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 10"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 11",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 11"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 12",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 12"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns 13",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns 13"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Artist Patterns Free Play",
+        "script_level.level_keys": [
+          "4-5 Artist Patterns Free Play"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Patterns",
+        "lesson_group.key": "",
+        "script.name": "course3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/course4.script_json
+++ b/dashboard/config/scripts_json/course4.script_json
@@ -1,0 +1,6612 @@
+{
+  "script": {
+    "name": "course4",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://code.org/curriculum/course4/{LESSON}/Teacher",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "course4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unplugged: Tangrams",
+      "name": "Unplugged: Tangrams",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Maze and Bee",
+      "name": "Maze and Bee",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Unplugged: Envelope Variables",
+      "name": "Unplugged: Envelope Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Unplugged: Madlibs",
+      "name": "Unplugged: Madlibs",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Madlibs",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist: Variables",
+      "name": "Artist: Variables",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Play Lab: Variables",
+      "name": "Play Lab: Variables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Unplugged: For Loop Fun",
+      "name": "Unplugged: For Loop Fun",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Bee: For Loops",
+      "name": "Bee: For Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist: For Loops",
+      "name": "Artist: For Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Play Lab: For Loops",
+      "name": "Play Lab: For Loops",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist: Functions",
+      "name": "Artist: Functions",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Unplugged: Songwriting with Parameters",
+      "name": "Unplugged: Songwriting with Parameters",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Songwriting with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist: Functions with Parameters",
+      "name": "Artist: Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Play Lab: Functions with Parameters",
+      "name": "Play Lab: Functions with Parameters",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Bee: Functions with Parameters",
+      "name": "Bee: Functions with Parameters",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Unplugged: Binary",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Artist Binary",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Super Challenge - Variables",
+      "name": "Super Challenge - Variables",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Super Challenge - For Loops",
+      "name": "Super Challenge - For Loops",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Super Challenge - Functions and Parameters",
+      "name": "Super Challenge - Functions and Parameters",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "key": "Extreme Challenge - Comprehensive",
+      "name": "Extreme Challenge - Comprehensive",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Maze 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Maze 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Maze 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Maze 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Maze 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Maze 4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Maze 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Maze 5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Loops 5 NEW"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Loops 5 NEW"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Loops 5a NEW"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Loops 5a NEW"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_collector_nested_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 8"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 8a"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 8a"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 10"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 10"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 11"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 11"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 12"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 12"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 13"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 13"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MadGlibs"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Madlibs",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "MadGlibs"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Vars 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Vars 4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Vars 6"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 4"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 6"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 7"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 12"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Vars 12"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 8"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 11"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 11"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 12"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 12"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 13"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 13"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 14"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 14"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Inspire"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Inspire"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 20"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist 20"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 17,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 2"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 3"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 4"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 5"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 6"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 7"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 7"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 9"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 9"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_playlab_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 4 4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 4 4"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 5"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 6"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 6"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 9"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 10a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Bee For Loops 10a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_bee_for_challenge1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_bee_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 3"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 8"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 8"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 14"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 14"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 6a"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 6a"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 11"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 11"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 11a"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 11a"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops Challenge"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops Challenge"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops inspire"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops inspire"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 15"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist For Loops 15"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 3"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 4b"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Playlab For Loops 4b"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 5b"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Playlab For Loops 5b"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 6b"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Playlab For Loops 6b"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loop Freeplay"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Playlab For Loop Freeplay"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 3"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 4"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 4"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 7"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 8"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 9"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 11"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 11"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 12"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 12"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 13"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 13"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Functions challenge"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Functions challenge"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Functions Inspiration"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Functions Inspiration"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 14"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Functions 14"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_concept_challenge2"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Songwriting with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 1"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 3"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 5"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 6"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 7"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 7"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 8"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 8"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 9"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 9"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 10"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 10"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 11"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 11"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 12"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 12"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 12a"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 12a"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 13"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 13"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 14"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 14"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params inspire"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params inspire"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 15"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 17,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Artist Params 15"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 18,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 2"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 3"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 4"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 5"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 5"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 6"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 6"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 7"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 7"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 8"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 8"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 9"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 9"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 10"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 10"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NEW Course 4 Play Lab Params 11"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 11,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "NEW Course 4 Play Lab Params 11"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 1"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 2"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 3"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 3"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 4"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 4"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 5"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 5"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 6"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 6"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 7"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 7"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee Params 8"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Bee Params 8"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_bee_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_bee_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "BinaryImages"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary pre1"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary pre1"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 1"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 1"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 2"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 2"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 3"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 3"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 4"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 4"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 5"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 5"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 6"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 6"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 7"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 7"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2a"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary Free Play 2a"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2b"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary Free Play 2b"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary Free Play 2"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_binary_challenge1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_binary_challenge1"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course4_artist_binary_challenge2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "course4_artist_binary_challenge2"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 3"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 5"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 4"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 1"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 1"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 2"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 2"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCV 6"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCV 6"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 1b"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 1b"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 1a"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 1a"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 1"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 2"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 3"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 3"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 4"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 6,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 4"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 6"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 7,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 6"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCFL 7"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 8,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCFL 7"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCF 1b"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCF 1b"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCF 1a"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCF 1a"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCF 1"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCF 1"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCF 2"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCF 2"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 SCF 3"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 SCF 3"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 EC 1a"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 EC 1a"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 EC 1b"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 EC 1b"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 EC 2a"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 EC 2a"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 EC 2c"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 EC 2c"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 EC 2b"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      },
+      "level_keys": [
+        "Course 4 EC 2b"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Maze 2",
+        "script_level.level_keys": [
+          "Course 4 Maze 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Maze 3",
+        "script_level.level_keys": [
+          "Course 4 Maze 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Maze 4",
+        "script_level.level_keys": [
+          "Course 4 Maze 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Maze 5",
+        "script_level.level_keys": [
+          "Course 4 Maze 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Loops 5 NEW",
+        "script_level.level_keys": [
+          "Course 4 Bee Loops 5 NEW"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Loops 5a NEW",
+        "script_level.level_keys": [
+          "Course 4 Bee Loops 5a NEW"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 1",
+        "script_level.level_keys": [
+          "Course 4 Bee 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 3",
+        "script_level.level_keys": [
+          "Course 4 Bee 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 2",
+        "script_level.level_keys": [
+          "Course 4 Bee 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "course4_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_collector_nested_loops_challenge2",
+        "script_level.level_keys": [
+          "course4_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Maze and Bee",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 1",
+        "script_level.level_keys": [
+          "Course 4 Artist 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 2",
+        "script_level.level_keys": [
+          "Course 4 Artist 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 3",
+        "script_level.level_keys": [
+          "Course 4 Artist 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 4",
+        "script_level.level_keys": [
+          "Course 4 Artist 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 5",
+        "script_level.level_keys": [
+          "Course 4 Artist 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 6",
+        "script_level.level_keys": [
+          "Course 4 Artist 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 7",
+        "script_level.level_keys": [
+          "Course 4 Artist 7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 8",
+        "script_level.level_keys": [
+          "Course 4 Artist 8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 8a",
+        "script_level.level_keys": [
+          "Course 4 Artist 8a"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 9",
+        "script_level.level_keys": [
+          "Course 4 Artist 9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 10",
+        "script_level.level_keys": [
+          "Course 4 Artist 10"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 11",
+        "script_level.level_keys": [
+          "Course 4 Artist 11"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 12",
+        "script_level.level_keys": [
+          "Course 4 Artist 12"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 13",
+        "script_level.level_keys": [
+          "Course 4 Artist 13"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MadGlibs",
+        "script_level.level_keys": [
+          "MadGlibs"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Madlibs",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 1",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Vars 2",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Vars 4",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Vars 6",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 6",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 7",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Vars 12",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Vars 12"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 8",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 11",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 11"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 12",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 12"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 13",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 13"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 14",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 14"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Inspire",
+        "script_level.level_keys": [
+          "Course 4 Artist Inspire"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 20",
+        "script_level.level_keys": [
+          "Course 4 Artist 20"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_variables_challenge1",
+        "script_level.level_keys": [
+          "course4_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 17,
+        "lesson.key": "Artist: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 1",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 2",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 3",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 3"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 4",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 5",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 6",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 7",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 7"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 9",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 9"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_playlab_variables_challenge1",
+        "script_level.level_keys": [
+          "course4_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 1",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 2",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 3",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 4",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 4 4",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 4 4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 5",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 6",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 6"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 8",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 7",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 9",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Bee For Loops 10a",
+        "script_level.level_keys": [
+          "NEW Course 4 Bee For Loops 10a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_bee_for_challenge1",
+        "script_level.level_keys": [
+          "course4_bee_for_challenge1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Bee: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 1",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 2",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 3",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 4",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 8",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 8"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 14",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 14"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 6a",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 6a"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 11",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 11"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 11a",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 11a"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops Challenge",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops Challenge"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops inspire",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops inspire"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist For Loops 15",
+        "script_level.level_keys": [
+          "Course 4 Artist For Loops 15"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Artist: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 1",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 2",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 3",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Playlab For Loops 4b",
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 4b"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Playlab For Loops 5b",
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 5b"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Playlab For Loops 6b",
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loops 6b"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Playlab For Loop Freeplay",
+        "script_level.level_keys": [
+          "Course 4 Playlab For Loop Freeplay"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 1",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 2",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 3",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 4",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 4"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 7",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 8",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 9",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 11",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 11"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 12",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 12"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 13",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 13"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Functions challenge",
+        "script_level.level_keys": [
+          "Course 4 Artist Functions challenge"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Functions Inspiration",
+        "script_level.level_keys": [
+          "Course 4 Artist Functions Inspiration"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Functions 14",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Functions 14"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_concept_challenge2",
+        "script_level.level_keys": [
+          "course4_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_functions_challenge2",
+        "script_level.level_keys": [
+          "course4_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Functions",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Songwriting with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 1",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 2",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 3",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 4",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 5",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 6",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 7",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 7"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 8",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 8"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 9",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 9"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 10",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 10"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 11",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 11"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 12",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 12"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 12a",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 12a"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 13,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 13",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 13"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 14,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 14",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 14"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 15,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params inspire",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params inspire"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 16,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Artist Params 15",
+        "script_level.level_keys": [
+          "NEW Course 4 Artist Params 15"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 17,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_fwp_challenge1",
+        "script_level.level_keys": [
+          "course4_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 18,
+        "lesson.key": "Artist: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 1",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 2",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 3",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 4",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 5",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 5"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 6",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 6"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 7",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 7"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 8",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 8"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 9",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 9"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 10",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 10"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NEW Course 4 Play Lab Params 11",
+        "script_level.level_keys": [
+          "NEW Course 4 Play Lab Params 11"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 11,
+        "lesson.key": "Play Lab: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 1",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 2",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 3",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 3"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 4",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 4"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 5",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 5"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 6",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 6"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 7",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 7"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee Params 8",
+        "script_level.level_keys": [
+          "Course 4 Bee Params 8"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_bee_fwp_challenge1",
+        "script_level.level_keys": [
+          "course4_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_bee_fwp_challenge2",
+        "script_level.level_keys": [
+          "course4_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages",
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary pre1",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary pre1"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 1",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 1"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 2"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 3",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 3"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 4"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 5",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 5"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 6",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 6"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 7",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 7"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary Free Play 2a",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2a"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary Free Play 2b",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2b"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary Free Play 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_binary_challenge1",
+        "script_level.level_keys": [
+          "course4_artist_binary_challenge1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course4_artist_binary_challenge2",
+        "script_level.level_keys": [
+          "course4_artist_binary_challenge2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 3",
+        "script_level.level_keys": [
+          "Course 4 SCV 3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 5",
+        "script_level.level_keys": [
+          "Course 4 SCV 5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 4",
+        "script_level.level_keys": [
+          "Course 4 SCV 4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 1",
+        "script_level.level_keys": [
+          "Course 4 SCV 1"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 2",
+        "script_level.level_keys": [
+          "Course 4 SCV 2"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCV 6",
+        "script_level.level_keys": [
+          "Course 4 SCV 6"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Super Challenge - Variables",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 1b",
+        "script_level.level_keys": [
+          "Course 4 SCFL 1b"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 1a",
+        "script_level.level_keys": [
+          "Course 4 SCFL 1a"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 1",
+        "script_level.level_keys": [
+          "Course 4 SCFL 1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 2",
+        "script_level.level_keys": [
+          "Course 4 SCFL 2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 3",
+        "script_level.level_keys": [
+          "Course 4 SCFL 3"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 4",
+        "script_level.level_keys": [
+          "Course 4 SCFL 4"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 6,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 6",
+        "script_level.level_keys": [
+          "Course 4 SCFL 6"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 7,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCFL 7",
+        "script_level.level_keys": [
+          "Course 4 SCFL 7"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 8,
+        "lesson.key": "Super Challenge - For Loops",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCF 1b",
+        "script_level.level_keys": [
+          "Course 4 SCF 1b"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 1,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCF 1a",
+        "script_level.level_keys": [
+          "Course 4 SCF 1a"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 2,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCF 1",
+        "script_level.level_keys": [
+          "Course 4 SCF 1"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 3,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCF 2",
+        "script_level.level_keys": [
+          "Course 4 SCF 2"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 4,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 SCF 3",
+        "script_level.level_keys": [
+          "Course 4 SCF 3"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 5,
+        "lesson.key": "Super Challenge - Functions and Parameters",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 EC 1a",
+        "script_level.level_keys": [
+          "Course 4 EC 1a"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 EC 1b",
+        "script_level.level_keys": [
+          "Course 4 EC 1b"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 EC 2a",
+        "script_level.level_keys": [
+          "Course 4 EC 2a"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 EC 2c",
+        "script_level.level_keys": [
+          "Course 4 EC 2c"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 EC 2b",
+        "script_level.level_keys": [
+          "Course 4 EC 2b"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Extreme Challenge - Comprehensive",
+        "lesson_group.key": "",
+        "script.name": "course4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursea-2017.script_json
+++ b/dashboard/config/scripts_json/coursea-2017.script_json
@@ -1,0 +1,2963 @@
+{
+  "script": {
+    "name": "coursea-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/coursea/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "ar-SA",
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN",
+        "zh-TW"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "coursea-2017",
+    "family_name": "coursea",
+    "seeding_key": {
+      "script.name": "coursea-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Marbles",
+      "name": "Persistence: Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Sequencing with Drag and Drop",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Programming: Happy Maps",
+      "name": "Programming: Happy Maps",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Going Places Safely",
+      "name": "Digital Citizenship: Going Places Safely",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Loops: Happy Loops",
+      "name": "Loops: Happy Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops in Collector",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_video_Stevie"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "UnplugHappyMaps"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_debug1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_video_debug1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq9"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq11"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq12"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq13"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "GoingPlacesSafely"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_unplugged_loops"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_unplugged_loops"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops10"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops10"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops11"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops11"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops12"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2kp"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge2kp"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_video_loops1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops10"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops11"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops12"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_video_events"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events4"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events5"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events6"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events6"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events7"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playLab_events7"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie",
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "UnplugHappyMaps",
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1",
+        "script_level.level_keys": [
+          "courseA_maze_seq1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_debug1",
+        "script_level.level_keys": [
+          "courseA_video_debug1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq2",
+        "script_level.level_keys": [
+          "courseA_maze_seq2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq3",
+        "script_level.level_keys": [
+          "courseA_maze_seq3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq4",
+        "script_level.level_keys": [
+          "courseA_maze_seq4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5",
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6",
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq7",
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8",
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq9",
+        "script_level.level_keys": [
+          "courseA_maze_seq9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10",
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11",
+        "script_level.level_keys": [
+          "courseA_maze_seq11"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12",
+        "script_level.level_keys": [
+          "courseA_maze_seq12"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13",
+        "script_level.level_keys": [
+          "courseA_maze_seq13"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoingPlacesSafely",
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_unplugged_loops",
+        "script_level.level_keys": [
+          "courseA_unplugged_loops"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops1",
+        "script_level.level_keys": [
+          "courseA_collector_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops2",
+        "script_level.level_keys": [
+          "courseA_collector_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops3",
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops4",
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops5",
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops6",
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops7",
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops8",
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops9",
+        "script_level.level_keys": [
+          "courseA_collector_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops10",
+        "script_level.level_keys": [
+          "courseA_collector_loops10"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops11",
+        "script_level.level_keys": [
+          "courseA_collector_loops11"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops12",
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge2kp",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2kp"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops1",
+        "script_level.level_keys": [
+          "courseA_artist_loops1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2",
+        "script_level.level_keys": [
+          "courseA_artist_loops2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3",
+        "script_level.level_keys": [
+          "courseA_artist_loops3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1",
+        "script_level.level_keys": [
+          "courseA_video_loops1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4",
+        "script_level.level_keys": [
+          "courseA_artist_loops4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5",
+        "script_level.level_keys": [
+          "courseA_artist_loops5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6",
+        "script_level.level_keys": [
+          "courseA_artist_loops6"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7",
+        "script_level.level_keys": [
+          "courseA_artist_loops7"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8",
+        "script_level.level_keys": [
+          "courseA_artist_loops8"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9",
+        "script_level.level_keys": [
+          "courseA_artist_loops9"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10",
+        "script_level.level_keys": [
+          "courseA_artist_loops10"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11",
+        "script_level.level_keys": [
+          "courseA_artist_loops11"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12",
+        "script_level.level_keys": [
+          "courseA_artist_loops12"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2a",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events",
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1",
+        "script_level.level_keys": [
+          "courseA_playLab_events1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2",
+        "script_level.level_keys": [
+          "courseA_playLab_events2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3",
+        "script_level.level_keys": [
+          "courseA_playLab_events3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4",
+        "script_level.level_keys": [
+          "courseA_playLab_events4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5",
+        "script_level.level_keys": [
+          "courseA_playLab_events5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events6",
+        "script_level.level_keys": [
+          "courseA_playLab_events6"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events7",
+        "script_level.level_keys": [
+          "courseA_playLab_events7"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursea-2018.script_json
+++ b/dashboard/config/scripts_json/coursea-2018.script_json
@@ -1,0 +1,3631 @@
+{
+  "script": {
+    "name": "coursea-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/coursea/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/coursea/"
+        ],
+        [
+          "teacherForum",
+          "http://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/coursea/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/coursea/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursea",
+    "seeding_key": {
+      "script.name": "coursea-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Big Project",
+      "name": "Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Sequencing in Maze",
+      "name": "Sequencing with Angry Birds",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Programming: Happy Maps",
+      "name": "Happy Maps",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Programming in Harvester",
+      "name": "Programming with Harvester",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Going Places Safely",
+      "name": "Going Places Safely",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Loops: Happy Loops",
+      "name": "Happy Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Loops with Harvester",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Ocean Scene with Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event Jr.",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "On the Move with Events",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_video_Stevie_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "PlantASeed_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursea_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "coursea_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp3a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_ramp3a_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp3b_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_ramp3b_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp4a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_ramp4a_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "UnplugHappyMaps_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "UnplugHappyMaps_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq3"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq4"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq5"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq5"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq6"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq6"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq7"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq7"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq8"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq8"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq9"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq9"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq10"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq10"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq12"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq11"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq11"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq13"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_seq13"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoingPlacesSafely_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "GoingPlacesSafely_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_unplugged_loops_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_unplugged_loops_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops_video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops_video"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops3"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops4"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5b"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops9"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops9"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops10"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops10"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops11"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_harvester_loops11"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops2_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops3_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops4_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops5_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops6_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops7_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops8_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops9_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops10_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops11_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops12_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops12_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2kp_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge2kp_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_video_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops12_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "BigEvent_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_video_events_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events1_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events2_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events3_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events4_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events5_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events6_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playLab_events7_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted_2018",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie_2018",
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed_2018",
+        "script_level.level_keys": [
+          "PlantASeed_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2018",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursea_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "coursea_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseA_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp3a_2018",
+        "script_level.level_keys": [
+          "courseA_maze_ramp3a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp3b_2018",
+        "script_level.level_keys": [
+          "courseA_maze_ramp3b_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp4a_2018",
+        "script_level.level_keys": [
+          "courseA_maze_ramp4a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseA_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "UnplugHappyMaps_2018",
+        "script_level.level_keys": [
+          "UnplugHappyMaps_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2018",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2018",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_intro",
+        "script_level.level_keys": [
+          "courseA_harvester_intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq1",
+        "script_level.level_keys": [
+          "courseA_harvester_seq1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq2",
+        "script_level.level_keys": [
+          "courseA_harvester_seq2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq3",
+        "script_level.level_keys": [
+          "courseA_harvester_seq3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq4",
+        "script_level.level_keys": [
+          "courseA_harvester_seq4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq5",
+        "script_level.level_keys": [
+          "courseA_harvester_seq5"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq6",
+        "script_level.level_keys": [
+          "courseA_harvester_seq6"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq7",
+        "script_level.level_keys": [
+          "courseA_harvester_seq7"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq8",
+        "script_level.level_keys": [
+          "courseA_harvester_seq8"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq9",
+        "script_level.level_keys": [
+          "courseA_harvester_seq9"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq10",
+        "script_level.level_keys": [
+          "courseA_harvester_seq10"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq12",
+        "script_level.level_keys": [
+          "courseA_harvester_seq12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq11",
+        "script_level.level_keys": [
+          "courseA_harvester_seq11"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq13",
+        "script_level.level_keys": [
+          "courseA_harvester_seq13"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoingPlacesSafely_2018",
+        "script_level.level_keys": [
+          "GoingPlacesSafely_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_unplugged_loops_2018",
+        "script_level.level_keys": [
+          "courseA_unplugged_loops_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops1",
+        "script_level.level_keys": [
+          "courseA_harvester_loops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops2",
+        "script_level.level_keys": [
+          "courseA_harvester_loops2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops_video",
+        "script_level.level_keys": [
+          "courseA_harvester_loops_video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops3",
+        "script_level.level_keys": [
+          "courseA_harvester_loops3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops4",
+        "script_level.level_keys": [
+          "courseA_harvester_loops4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5a",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5b",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops6",
+        "script_level.level_keys": [
+          "courseA_harvester_loops6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops7",
+        "script_level.level_keys": [
+          "courseA_harvester_loops7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops9",
+        "script_level.level_keys": [
+          "courseA_harvester_loops9"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops10",
+        "script_level.level_keys": [
+          "courseA_harvester_loops10"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops11",
+        "script_level.level_keys": [
+          "courseA_harvester_loops11"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2018",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops1_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops2_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops2_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2018",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops3_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops3_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops4_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops4_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops5_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops5_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops6_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops6_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops7_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops7_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops8_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops8_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops9_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops9_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops10_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops10_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops11_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops11_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops12_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops12_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge2kp_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2kp_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2018",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops1_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1_2018",
+        "script_level.level_keys": [
+          "courseA_video_loops1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2018",
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2018",
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events6_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events7_2018",
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2_2018",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1_2018",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursea-2020.script_json
+++ b/dashboard/config/scripts_json/coursea-2020.script_json
@@ -1,6 +1,6 @@
 {
   "script": {
-    "name": "coursea-2019",
+    "name": "coursea-2020",
     "wrapup_video_id": null,
     "hidden": false,
     "login_required": false,
@@ -12,12 +12,17 @@
         "artist_k1"
       ],
       "lesson_extras_available": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursea/{LESSON}",
-      "version_year": "2019",
-      "supported_locales": [
-        "cs-CZ",
-        "sk-SK"
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/coursea/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course A!",
+          "link": "https://curriculum.code.org/csf-20/coursea",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
       ],
+      "version_year": "2020",
       "curriculum_umbrella": "CSF",
       "has_lesson_plan": true,
       "is_stable": true,
@@ -26,7 +31,7 @@
       "teacher_resources": [
         [
           "lessonPlans",
-          "https://curriculum.code.org/csf-19/coursea/"
+          "https://curriculum.code.org/csf-20/coursea/"
         ],
         [
           "teacherForum",
@@ -34,22 +39,22 @@
         ],
         [
           "vocabulary",
-          "https://curriculum.code.org/csf-19/coursea/vocab/"
+          "https://curriculum.code.org/csf-20/coursea/vocab/"
         ],
         [
           "standardMappings",
-          "https://curriculum.code.org/csf-19/coursea/standards/"
+          "https://curriculum.code.org/csf-20/coursea/standards/"
         ],
         [
           "curriculumGuide",
-          "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
         ]
       ]
     },
     "new_name": null,
     "family_name": "coursea",
     "seeding_key": {
-      "script.name": "coursea-2019"
+      "script.name": "coursea-2020"
     }
   },
   "lesson_groups": [
@@ -62,7 +67,7 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -74,7 +79,7 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -86,7 +91,7 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -98,23 +103,23 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     }
   ],
   "lessons": [
     {
-      "key": "Going Places Safely",
-      "name": "Going Places Safely",
+      "key": "Safety in My Online Neighborhood",
+      "name": "Safety in My Online Neighborhood",
       "absolute_position": 1,
       "lockable": false,
       "relative_position": 1,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Safety in My Online Neighborhood",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -128,7 +133,7 @@
       "seeding_key": {
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -142,7 +147,7 @@
       "seeding_key": {
         "lesson.key": "Programming: Happy Maps",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -156,7 +161,7 @@
       "seeding_key": {
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -170,7 +175,7 @@
       "seeding_key": {
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -184,7 +189,7 @@
       "seeding_key": {
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -198,7 +203,7 @@
       "seeding_key": {
         "lesson.key": "Loops: Happy Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -212,7 +217,7 @@
       "seeding_key": {
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -226,7 +231,7 @@
       "seeding_key": {
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -240,7 +245,7 @@
       "seeding_key": {
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -254,7 +259,7 @@
       "seeding_key": {
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -268,7 +273,7 @@
       "seeding_key": {
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     }
   ],
@@ -283,16 +288,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "GoingPlacesSafely-unplugged"
+          "csf_safety_in_my_online_neighborhood"
         ],
         "script_level.chapter": 1,
         "script_level.position": 1,
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Safety in My Online Neighborhood",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "GoingPlacesSafely-unplugged"
+        "csf_safety_in_my_online_neighborhood"
       ]
     },
     {
@@ -312,7 +317,7 @@
         "script_level.position": 1,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:1"
@@ -335,7 +340,7 @@
         "script_level.position": 2,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:2"
@@ -358,7 +363,7 @@
         "script_level.position": 3,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:3"
@@ -381,7 +386,7 @@
         "script_level.position": 4,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:4"
@@ -404,7 +409,7 @@
         "script_level.position": 5,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:5"
@@ -427,7 +432,7 @@
         "script_level.position": 6,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:6"
@@ -450,7 +455,7 @@
         "script_level.position": 7,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:7"
@@ -473,7 +478,7 @@
         "script_level.position": 8,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:8"
@@ -496,7 +501,7 @@
         "script_level.position": 9,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:9"
@@ -519,7 +524,7 @@
         "script_level.position": 10,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:10"
@@ -542,7 +547,7 @@
         "script_level.position": 11,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:11"
@@ -565,7 +570,7 @@
         "script_level.position": 12,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
         "blockly:Jigsaw:12"
@@ -581,16 +586,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "HappyMaps-Unplugged"
+          "HappyMaps-Unplugged_2020"
         ],
         "script_level.chapter": 14,
         "script_level.position": 1,
         "lesson.key": "Programming: Happy Maps",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "HappyMaps-Unplugged"
+        "HappyMaps-Unplugged_2020"
       ]
     },
     {
@@ -604,16 +609,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseAB_video_NewIntro_2019"
+          "courseAB_video_NewIntro_2020"
         ],
         "script_level.chapter": 15,
         "script_level.position": 1,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseAB_video_NewIntro_2019"
+        "courseAB_video_NewIntro_2020"
       ]
     },
     {
@@ -627,16 +632,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp1_2019"
+          "courseB_Scrat_ramp1_2020"
         ],
         "script_level.chapter": 16,
         "script_level.position": 2,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp1_2019"
+        "courseB_Scrat_ramp1_2020"
       ]
     },
     {
@@ -650,16 +655,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp2_2019"
+          "courseB_Scrat_ramp2_2020"
         ],
         "script_level.chapter": 17,
         "script_level.position": 3,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp2_2019"
+        "courseB_Scrat_ramp2_2020"
       ]
     },
     {
@@ -673,16 +678,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3a_2019"
+          "courseB_Scrat_ramp3a_2020"
         ],
         "script_level.chapter": 18,
         "script_level.position": 4,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp3a_2019"
+        "courseB_Scrat_ramp3a_2020"
       ]
     },
     {
@@ -696,16 +701,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3b_2019"
+          "courseB_Scrat_ramp3b_2020"
         ],
         "script_level.chapter": 19,
         "script_level.position": 5,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp3b_2019"
+        "courseB_Scrat_ramp3b_2020"
       ]
     },
     {
@@ -719,16 +724,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp4a_2019"
+          "courseB_Scrat_ramp4a_2020"
         ],
         "script_level.chapter": 20,
         "script_level.position": 6,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp4a_2019"
+        "courseB_Scrat_ramp4a_2020"
       ]
     },
     {
@@ -742,16 +747,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp5a_2019"
+          "courseB_Scrat_ramp5a_2020"
         ],
         "script_level.chapter": 21,
         "script_level.position": 7,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_Scrat_ramp5a_2019"
+        "courseB_Scrat_ramp5a_2020"
       ]
     },
     {
@@ -765,16 +770,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "elementary_video_pairProgramming_2019"
+          "elementary_video_pairProgramming_2020"
         ],
         "script_level.chapter": 22,
         "script_level.position": 1,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "elementary_video_pairProgramming_2019"
+        "elementary_video_pairProgramming_2020"
       ]
     },
     {
@@ -788,16 +793,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq1_2019"
+          "courseB_maze_seq1_2020"
         ],
         "script_level.chapter": 23,
         "script_level.position": 2,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq1_2019"
+        "courseB_maze_seq1_2020"
       ]
     },
     {
@@ -811,16 +816,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq4_2019"
+          "courseB_maze_seq4_2020"
         ],
         "script_level.chapter": 24,
         "script_level.position": 3,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq4_2019"
+        "courseB_maze_seq4_2020"
       ]
     },
     {
@@ -834,16 +839,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq5_2019"
+          "courseB_maze_seq5_2020"
         ],
         "script_level.chapter": 25,
         "script_level.position": 4,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq5_2019"
+        "courseB_maze_seq5_2020"
       ]
     },
     {
@@ -857,16 +862,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq6_2019"
+          "courseB_maze_seq6_2020"
         ],
         "script_level.chapter": 26,
         "script_level.position": 5,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq6_2019"
+        "courseB_maze_seq6_2020"
       ]
     },
     {
@@ -880,16 +885,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseAB_video_debugging_2019"
+          "courseAB_video_debugging_2020"
         ],
         "script_level.chapter": 27,
         "script_level.position": 6,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseAB_video_debugging_2019"
+        "courseAB_video_debugging_2020"
       ]
     },
     {
@@ -903,16 +908,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq7_2019"
+          "courseB_maze_seq7_2020"
         ],
         "script_level.chapter": 28,
         "script_level.position": 7,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq7_2019"
+        "courseB_maze_seq7_2020"
       ]
     },
     {
@@ -926,16 +931,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq8_2019"
+          "courseB_maze_seq8_2020"
         ],
         "script_level.chapter": 29,
         "script_level.position": 8,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq8_2019"
+        "courseB_maze_seq8_2020"
       ]
     },
     {
@@ -950,16 +955,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq9_2019"
+          "courseB_maze_seq9_2020"
         ],
         "script_level.chapter": 30,
         "script_level.position": 9,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq9_2019"
+        "courseB_maze_seq9_2020"
       ]
     },
     {
@@ -973,16 +978,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq10_2019"
+          "courseB_maze_seq10_2020"
         ],
         "script_level.chapter": 31,
         "script_level.position": 10,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq10_2019"
+        "courseB_maze_seq10_2020"
       ]
     },
     {
@@ -996,16 +1001,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq11_2019"
+          "courseB_maze_seq11_2020"
         ],
         "script_level.chapter": 32,
         "script_level.position": 11,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq11_2019"
+        "courseB_maze_seq11_2020"
       ]
     },
     {
@@ -1019,16 +1024,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq12_2019"
+          "courseB_maze_seq12_2020"
         ],
         "script_level.chapter": 33,
         "script_level.position": 12,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq12_2019"
+        "courseB_maze_seq12_2020"
       ]
     },
     {
@@ -1041,16 +1046,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge1_2019"
+          "courseB_maze_seq_challenge1_2020"
         ],
         "script_level.chapter": 34,
         "script_level.position": 13,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq_challenge1_2019"
+        "courseB_maze_seq_challenge1_2020"
       ]
     },
     {
@@ -1063,16 +1068,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge2_2019"
+          "courseB_maze_seq_challenge2_2020"
         ],
         "script_level.chapter": 35,
         "script_level.position": 14,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_maze_seq_challenge2_2019"
+        "courseB_maze_seq_challenge2_2020"
       ]
     },
     {
@@ -1086,16 +1091,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "bb8_skinOverview_K-1_video_2019"
+          "bb8_skinOverview_K-1_video_2020"
         ],
         "script_level.chapter": 36,
         "script_level.position": 1,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "bb8_skinOverview_K-1_video_2019"
+        "bb8_skinOverview_K-1_video_2020"
       ]
     },
     {
@@ -1109,16 +1114,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog1_2019"
+          "courseB_starWars_prog1_2020"
         ],
         "script_level.chapter": 37,
         "script_level.position": 2,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog1_2019"
+        "courseB_starWars_prog1_2020"
       ]
     },
     {
@@ -1132,16 +1137,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog2_2019"
+          "courseB_starWars_prog2_2020"
         ],
         "script_level.chapter": 38,
         "script_level.position": 3,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog2_2019"
+        "courseB_starWars_prog2_2020"
       ]
     },
     {
@@ -1155,16 +1160,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog3_2019"
+          "courseB_starWars_prog3_2020"
         ],
         "script_level.chapter": 39,
         "script_level.position": 4,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog3_2019"
+        "courseB_starWars_prog3_2020"
       ]
     },
     {
@@ -1178,16 +1183,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog4_2019"
+          "courseB_starWars_prog4_2020"
         ],
         "script_level.chapter": 40,
         "script_level.position": 5,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog4_2019"
+        "courseB_starWars_prog4_2020"
       ]
     },
     {
@@ -1201,16 +1206,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog5_2019"
+          "courseB_starWars_prog5_2020"
         ],
         "script_level.chapter": 41,
         "script_level.position": 6,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog5_2019"
+        "courseB_starWars_prog5_2020"
       ]
     },
     {
@@ -1224,16 +1229,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog6_2019"
+          "courseB_starWars_prog6_2020"
         ],
         "script_level.chapter": 42,
         "script_level.position": 7,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog6_2019"
+        "courseB_starWars_prog6_2020"
       ]
     },
     {
@@ -1247,16 +1252,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog7_2019"
+          "courseB_starWars_prog7_2020"
         ],
         "script_level.chapter": 43,
         "script_level.position": 8,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog7_2019"
+        "courseB_starWars_prog7_2020"
       ]
     },
     {
@@ -1271,16 +1276,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog8_2019"
+          "courseB_starWars_prog8_2020"
         ],
         "script_level.chapter": 44,
         "script_level.position": 9,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog8_2019"
+        "courseB_starWars_prog8_2020"
       ]
     },
     {
@@ -1294,16 +1299,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog9_2019"
+          "courseB_starWars_prog9_2020"
         ],
         "script_level.chapter": 45,
         "script_level.position": 10,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog9_2019"
+        "courseB_starWars_prog9_2020"
       ]
     },
     {
@@ -1317,16 +1322,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog10_2019"
+          "courseB_starWars_prog10_2020"
         ],
         "script_level.chapter": 46,
         "script_level.position": 11,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog10_2019"
+        "courseB_starWars_prog10_2020"
       ]
     },
     {
@@ -1340,16 +1345,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog11_2019"
+          "courseB_starWars_prog11_2020"
         ],
         "script_level.chapter": 47,
         "script_level.position": 12,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_starWars_prog11_2019"
+        "courseB_starWars_prog11_2020"
       ]
     },
     {
@@ -1362,16 +1367,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "HappyLoops-Unplugged"
+          "HappyLoops-Unplugged_2020"
         ],
         "script_level.chapter": 48,
         "script_level.position": 1,
         "lesson.key": "Loops: Happy Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "HappyLoops-Unplugged"
+        "HappyLoops-Unplugged_2020"
       ]
     },
     {
@@ -1385,16 +1390,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops1_2019"
+          "courseB_iceage_loops1_2020"
         ],
         "script_level.chapter": 49,
         "script_level.position": 1,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops1_2019"
+        "courseB_iceage_loops1_2020"
       ]
     },
     {
@@ -1408,16 +1413,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops2_2019"
+          "courseB_iceage_loops2_2020"
         ],
         "script_level.chapter": 50,
         "script_level.position": 2,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops2_2019"
+        "courseB_iceage_loops2_2020"
       ]
     },
     {
@@ -1431,16 +1436,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops_video_2019"
+          "courseB_iceage_loops_video_2020"
         ],
         "script_level.chapter": 51,
         "script_level.position": 3,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops_video_2019"
+        "courseB_iceage_loops_video_2020"
       ]
     },
     {
@@ -1454,16 +1459,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops3_2019"
+          "courseB_iceage_loops3_2020"
         ],
         "script_level.chapter": 52,
         "script_level.position": 4,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops3_2019"
+        "courseB_iceage_loops3_2020"
       ]
     },
     {
@@ -1477,16 +1482,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops4_2019"
+          "courseB_iceage_loops4_2020"
         ],
         "script_level.chapter": 53,
         "script_level.position": 5,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops4_2019"
+        "courseB_iceage_loops4_2020"
       ]
     },
     {
@@ -1500,16 +1505,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops6_2019"
+          "courseB_iceage_loops6_2020"
         ],
         "script_level.chapter": 54,
         "script_level.position": 6,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops6_2019"
+        "courseB_iceage_loops6_2020"
       ]
     },
     {
@@ -1523,16 +1528,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops7_2019"
+          "courseB_iceage_loops7_2020"
         ],
         "script_level.chapter": 55,
         "script_level.position": 7,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops7_2019"
+        "courseB_iceage_loops7_2020"
       ]
     },
     {
@@ -1546,16 +1551,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops8_2019"
+          "courseB_iceage_loops8_2020"
         ],
         "script_level.chapter": 56,
         "script_level.position": 8,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops8_2019"
+        "courseB_iceage_loops8_2020"
       ]
     },
     {
@@ -1569,16 +1574,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops9_2019"
+          "courseB_iceage_loops9_2020"
         ],
         "script_level.chapter": 57,
         "script_level.position": 9,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops9_2019"
+        "courseB_iceage_loops9_2020"
       ]
     },
     {
@@ -1593,16 +1598,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops10_2019"
+          "courseB_iceage_loops10_2020"
         ],
         "script_level.chapter": 58,
         "script_level.position": 10,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops10_2019"
+        "courseB_iceage_loops10_2020"
       ]
     },
     {
@@ -1616,16 +1621,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops11_2019"
+          "courseB_iceage_loops11_2020"
         ],
         "script_level.chapter": 59,
         "script_level.position": 11,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops11_2019"
+        "courseB_iceage_loops11_2020"
       ]
     },
     {
@@ -1639,16 +1644,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops12_2019"
+          "courseB_iceage_loops12_2020"
         ],
         "script_level.chapter": 60,
         "script_level.position": 12,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_iceage_loops12_2019"
+        "courseB_iceage_loops12_2020"
       ]
     },
     {
@@ -1662,16 +1667,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseAB_video_collector_2019"
+          "courseAB_video_collector_2020"
         ],
         "script_level.chapter": 61,
         "script_level.position": 1,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseAB_video_collector_2019"
+        "courseAB_video_collector_2020"
       ]
     },
     {
@@ -1685,16 +1690,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops1_2019"
+          "courseA_collector_loops1_2020"
         ],
         "script_level.chapter": 62,
         "script_level.position": 2,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops1_2019"
+        "courseA_collector_loops1_2020"
       ]
     },
     {
@@ -1708,16 +1713,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops2_2019"
+          "courseA_collector_loops2_2020"
         ],
         "script_level.chapter": 63,
         "script_level.position": 3,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops2_2019"
+        "courseA_collector_loops2_2020"
       ]
     },
     {
@@ -1731,16 +1736,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_video_Loops_2019"
+          "courseA_video_Loops_2020"
         ],
         "script_level.chapter": 64,
         "script_level.position": 4,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_video_Loops_2019"
+        "courseA_video_Loops_2020"
       ]
     },
     {
@@ -1754,16 +1759,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops3_2019"
+          "courseA_collector_loops3_2020"
         ],
         "script_level.chapter": 65,
         "script_level.position": 5,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops3_2019"
+        "courseA_collector_loops3_2020"
       ]
     },
     {
@@ -1777,16 +1782,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops4_2019"
+          "courseA_collector_loops4_2020"
         ],
         "script_level.chapter": 66,
         "script_level.position": 6,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops4_2019"
+        "courseA_collector_loops4_2020"
       ]
     },
     {
@@ -1800,16 +1805,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops5_2019"
+          "courseA_collector_loops5_2020"
         ],
         "script_level.chapter": 67,
         "script_level.position": 7,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops5_2019"
+        "courseA_collector_loops5_2020"
       ]
     },
     {
@@ -1823,16 +1828,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops6_2019"
+          "courseA_collector_loops6_2020"
         ],
         "script_level.chapter": 68,
         "script_level.position": 8,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops6_2019"
+        "courseA_collector_loops6_2020"
       ]
     },
     {
@@ -1846,16 +1851,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops7_2019"
+          "courseA_collector_loops7_2020"
         ],
         "script_level.chapter": 69,
         "script_level.position": 9,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops7_2019"
+        "courseA_collector_loops7_2020"
       ]
     },
     {
@@ -1869,16 +1874,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops8_2019"
+          "courseA_collector_loops8_2020"
         ],
         "script_level.chapter": 70,
         "script_level.position": 10,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops8_2019"
+        "courseA_collector_loops8_2020"
       ]
     },
     {
@@ -1893,16 +1898,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops9_2019"
+          "courseA_collector_loops9_2020"
         ],
         "script_level.chapter": 71,
         "script_level.position": 11,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops9_2019"
+        "courseA_collector_loops9_2020"
       ]
     },
     {
@@ -1916,16 +1921,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops10_2019"
+          "courseA_collector_loops10_2020"
         ],
         "script_level.chapter": 72,
         "script_level.position": 12,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops10_2019"
+        "courseA_collector_loops10_2020"
       ]
     },
     {
@@ -1939,16 +1944,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops11_2019"
+          "courseA_collector_loops11_2020"
         ],
         "script_level.chapter": 73,
         "script_level.position": 13,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops11_2019"
+        "courseA_collector_loops11_2020"
       ]
     },
     {
@@ -1962,16 +1967,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops12_2019"
+          "courseA_collector_loops12_2020"
         ],
         "script_level.chapter": 74,
         "script_level.position": 14,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops12_2019"
+        "courseA_collector_loops12_2020"
       ]
     },
     {
@@ -1984,16 +1989,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge2kp_2019"
+          "courseA_collector_loops_challenge2kp_2020"
         ],
         "script_level.chapter": 75,
         "script_level.position": 15,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops_challenge2kp_2019"
+        "courseA_collector_loops_challenge2kp_2020"
       ]
     },
     {
@@ -2006,16 +2011,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge1_2019"
+          "courseA_collector_loops_challenge1_2020"
         ],
         "script_level.chapter": 76,
         "script_level.position": 16,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_collector_loops_challenge1_2019"
+        "courseA_collector_loops_challenge1_2020"
       ]
     },
     {
@@ -2029,16 +2034,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_video_ArtistIntro_2019"
+          "courseB_video_ArtistIntro_2020"
         ],
         "script_level.chapter": 77,
         "script_level.position": 1,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseB_video_ArtistIntro_2019"
+        "courseB_video_ArtistIntro_2020"
       ]
     },
     {
@@ -2052,16 +2057,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops1_2019"
+          "courseA_artist_loops1_2020"
         ],
         "script_level.chapter": 78,
         "script_level.position": 2,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops1_2019"
+        "courseA_artist_loops1_2020"
       ]
     },
     {
@@ -2075,16 +2080,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops2_2019"
+          "courseA_artist_loops2_2020"
         ],
         "script_level.chapter": 79,
         "script_level.position": 3,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops2_2019"
+        "courseA_artist_loops2_2020"
       ]
     },
     {
@@ -2098,16 +2103,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops3_2019"
+          "courseA_artist_loops3_2020"
         ],
         "script_level.chapter": 80,
         "script_level.position": 4,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops3_2019"
+        "courseA_artist_loops3_2020"
       ]
     },
     {
@@ -2121,16 +2126,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_video_loops1_2019"
+          "courseA_video_loops1_2020"
         ],
         "script_level.chapter": 81,
         "script_level.position": 5,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_video_loops1_2019"
+        "courseA_video_loops1_2020"
       ]
     },
     {
@@ -2144,16 +2149,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops4_2019"
+          "courseA_artist_loops4_2020"
         ],
         "script_level.chapter": 82,
         "script_level.position": 6,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops4_2019"
+        "courseA_artist_loops4_2020"
       ]
     },
     {
@@ -2167,16 +2172,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops5_2019"
+          "courseA_artist_loops5_2020"
         ],
         "script_level.chapter": 83,
         "script_level.position": 7,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops5_2019"
+        "courseA_artist_loops5_2020"
       ]
     },
     {
@@ -2190,16 +2195,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops6_2019"
+          "courseA_artist_loops6_2020"
         ],
         "script_level.chapter": 84,
         "script_level.position": 8,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops6_2019"
+        "courseA_artist_loops6_2020"
       ]
     },
     {
@@ -2213,16 +2218,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops7_2019"
+          "courseA_artist_loops7_2020"
         ],
         "script_level.chapter": 85,
         "script_level.position": 9,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops7_2019"
+        "courseA_artist_loops7_2020"
       ]
     },
     {
@@ -2236,16 +2241,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops8_2019"
+          "courseA_artist_loops8_2020"
         ],
         "script_level.chapter": 86,
         "script_level.position": 10,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops8_2019"
+        "courseA_artist_loops8_2020"
       ]
     },
     {
@@ -2260,16 +2265,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops9_2019"
+          "courseA_artist_loops9_2020"
         ],
         "script_level.chapter": 87,
         "script_level.position": 11,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops9_2019"
+        "courseA_artist_loops9_2020"
       ]
     },
     {
@@ -2283,16 +2288,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops10_2019"
+          "courseA_artist_loops10_2020"
         ],
         "script_level.chapter": 88,
         "script_level.position": 12,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops10_2019"
+        "courseA_artist_loops10_2020"
       ]
     },
     {
@@ -2306,16 +2311,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops11_2019"
+          "courseA_artist_loops11_2020"
         ],
         "script_level.chapter": 89,
         "script_level.position": 13,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops11_2019"
+        "courseA_artist_loops11_2020"
       ]
     },
     {
@@ -2329,16 +2334,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops12_2019"
+          "courseA_artist_loops12_2020"
         ],
         "script_level.chapter": 90,
         "script_level.position": 14,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops12_2019"
+        "courseA_artist_loops12_2020"
       ]
     },
     {
@@ -2351,16 +2356,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops_challenge2a_2019"
+          "courseA_artist_loops_challenge2a_2020"
         ],
         "script_level.chapter": 91,
         "script_level.position": 15,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops_challenge2a_2019"
+        "courseA_artist_loops_challenge2a_2020"
       ]
     },
     {
@@ -2373,16 +2378,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops_challenge1_2019"
+          "courseA_artist_loops_challenge1_2020"
         ],
         "script_level.chapter": 92,
         "script_level.position": 16,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_artist_loops_challenge1_2019"
+        "courseA_artist_loops_challenge1_2020"
       ]
     },
     {
@@ -2395,16 +2400,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "BigEvent-Unplugged"
+          "BigEvent-Unplugged_2020"
         ],
         "script_level.chapter": 93,
         "script_level.position": 1,
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "BigEvent-Unplugged"
+        "BigEvent-Unplugged_2020"
       ]
     },
     {
@@ -2418,16 +2423,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_video_events_2019"
+          "courseA_video_events_2020"
         ],
         "script_level.chapter": 94,
         "script_level.position": 1,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_video_events_2019"
+        "courseA_video_events_2020"
       ]
     },
     {
@@ -2441,16 +2446,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events1_2019"
+          "courseA_playLab_events1_2020"
         ],
         "script_level.chapter": 95,
         "script_level.position": 2,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events1_2019"
+        "courseA_playLab_events1_2020"
       ]
     },
     {
@@ -2464,16 +2469,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events2_2019"
+          "courseA_playLab_events2_2020"
         ],
         "script_level.chapter": 96,
         "script_level.position": 3,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events2_2019"
+        "courseA_playLab_events2_2020"
       ]
     },
     {
@@ -2487,16 +2492,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events3_2019"
+          "courseA_playLab_events3_2020"
         ],
         "script_level.chapter": 97,
         "script_level.position": 4,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events3_2019"
+        "courseA_playLab_events3_2020"
       ]
     },
     {
@@ -2510,16 +2515,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events4_2019"
+          "courseA_playLab_events4_2020"
         ],
         "script_level.chapter": 98,
         "script_level.position": 5,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events4_2019"
+        "courseA_playLab_events4_2020"
       ]
     },
     {
@@ -2533,16 +2538,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events5_2019"
+          "courseA_playLab_events5_2020"
         ],
         "script_level.chapter": 99,
         "script_level.position": 6,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events5_2019"
+        "courseA_playLab_events5_2020"
       ]
     },
     {
@@ -2556,16 +2561,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events6_2019"
+          "courseA_playLab_events6_2020"
         ],
         "script_level.chapter": 100,
         "script_level.position": 7,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events6_2019"
+        "courseA_playLab_events6_2020"
       ]
     },
     {
@@ -2579,16 +2584,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events7_2019"
+          "courseA_playLab_events7_2020"
         ],
         "script_level.chapter": 101,
         "script_level.position": 8,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playLab_events7_2019"
+        "courseA_playLab_events7_2020"
       ]
     },
     {
@@ -2601,16 +2606,16 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge2_2019"
+          "courseA_playlab_events_challenge2_2020"
         ],
         "script_level.chapter": 102,
         "script_level.position": 9,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playlab_events_challenge2_2019"
+        "courseA_playlab_events_challenge2_2020"
       ]
     },
     {
@@ -2623,31 +2628,31 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge1_2019"
+          "courseA_playlab_events_challenge1_2020"
         ],
         "script_level.chapter": 103,
         "script_level.position": 10,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       },
       "level_keys": [
-        "courseA_playlab_events_challenge1_2019"
+        "courseA_playlab_events_challenge1_2020"
       ]
     }
   ],
   "levels_script_levels": [
     {
       "seeding_key": {
-        "level.key": "GoingPlacesSafely-unplugged",
+        "level.key": "csf_safety_in_my_online_neighborhood",
         "script_level.level_keys": [
-          "GoingPlacesSafely-unplugged"
+          "csf_safety_in_my_online_neighborhood"
         ],
         "script_level.chapter": 1,
         "script_level.position": 1,
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Safety in My Online Neighborhood",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2660,7 +2665,7 @@
         "script_level.position": 1,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2673,7 +2678,7 @@
         "script_level.position": 2,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2686,7 +2691,7 @@
         "script_level.position": 3,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2699,7 +2704,7 @@
         "script_level.position": 4,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2712,7 +2717,7 @@
         "script_level.position": 5,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2725,7 +2730,7 @@
         "script_level.position": 6,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2738,7 +2743,7 @@
         "script_level.position": 7,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2751,7 +2756,7 @@
         "script_level.position": 8,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2764,7 +2769,7 @@
         "script_level.position": 9,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2777,7 +2782,7 @@
         "script_level.position": 10,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2790,7 +2795,7 @@
         "script_level.position": 11,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
@@ -2803,1177 +2808,1177 @@
         "script_level.position": 12,
         "lesson.key": "Learn to Drag and Drop",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "HappyMaps-Unplugged",
+        "level.key": "HappyMaps-Unplugged_2020",
         "script_level.level_keys": [
-          "HappyMaps-Unplugged"
+          "HappyMaps-Unplugged_2020"
         ],
         "script_level.chapter": 14,
         "script_level.position": 1,
         "lesson.key": "Programming: Happy Maps",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseAB_video_NewIntro_2019",
+        "level.key": "courseAB_video_NewIntro_2020",
         "script_level.level_keys": [
-          "courseAB_video_NewIntro_2019"
+          "courseAB_video_NewIntro_2020"
         ],
         "script_level.chapter": 15,
         "script_level.position": 1,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp1_2019",
+        "level.key": "courseB_Scrat_ramp1_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp1_2019"
+          "courseB_Scrat_ramp1_2020"
         ],
         "script_level.chapter": 16,
         "script_level.position": 2,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp2_2019",
+        "level.key": "courseB_Scrat_ramp2_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp2_2019"
+          "courseB_Scrat_ramp2_2020"
         ],
         "script_level.chapter": 17,
         "script_level.position": 3,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp3a_2019",
+        "level.key": "courseB_Scrat_ramp3a_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3a_2019"
+          "courseB_Scrat_ramp3a_2020"
         ],
         "script_level.chapter": 18,
         "script_level.position": 4,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp3b_2019",
+        "level.key": "courseB_Scrat_ramp3b_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3b_2019"
+          "courseB_Scrat_ramp3b_2020"
         ],
         "script_level.chapter": 19,
         "script_level.position": 5,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp4a_2019",
+        "level.key": "courseB_Scrat_ramp4a_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp4a_2019"
+          "courseB_Scrat_ramp4a_2020"
         ],
         "script_level.chapter": 20,
         "script_level.position": 6,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp5a_2019",
+        "level.key": "courseB_Scrat_ramp5a_2020",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp5a_2019"
+          "courseB_Scrat_ramp5a_2020"
         ],
         "script_level.chapter": 21,
         "script_level.position": 7,
         "lesson.key": "Sequencing with Scrat",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "elementary_video_pairProgramming_2019",
+        "level.key": "elementary_video_pairProgramming_2020",
         "script_level.level_keys": [
-          "elementary_video_pairProgramming_2019"
+          "elementary_video_pairProgramming_2020"
         ],
         "script_level.chapter": 22,
         "script_level.position": 1,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq1_2019",
+        "level.key": "courseB_maze_seq1_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq1_2019"
+          "courseB_maze_seq1_2020"
         ],
         "script_level.chapter": 23,
         "script_level.position": 2,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq4_2019",
+        "level.key": "courseB_maze_seq4_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq4_2019"
+          "courseB_maze_seq4_2020"
         ],
         "script_level.chapter": 24,
         "script_level.position": 3,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq5_2019",
+        "level.key": "courseB_maze_seq5_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq5_2019"
+          "courseB_maze_seq5_2020"
         ],
         "script_level.chapter": 25,
         "script_level.position": 4,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq6_2019",
+        "level.key": "courseB_maze_seq6_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq6_2019"
+          "courseB_maze_seq6_2020"
         ],
         "script_level.chapter": 26,
         "script_level.position": 5,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseAB_video_debugging_2019",
+        "level.key": "courseAB_video_debugging_2020",
         "script_level.level_keys": [
-          "courseAB_video_debugging_2019"
+          "courseAB_video_debugging_2020"
         ],
         "script_level.chapter": 27,
         "script_level.position": 6,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq7_2019",
+        "level.key": "courseB_maze_seq7_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq7_2019"
+          "courseB_maze_seq7_2020"
         ],
         "script_level.chapter": 28,
         "script_level.position": 7,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq8_2019",
+        "level.key": "courseB_maze_seq8_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq8_2019"
+          "courseB_maze_seq8_2020"
         ],
         "script_level.chapter": 29,
         "script_level.position": 8,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq9_2019",
+        "level.key": "courseB_maze_seq9_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq9_2019"
+          "courseB_maze_seq9_2020"
         ],
         "script_level.chapter": 30,
         "script_level.position": 9,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq10_2019",
+        "level.key": "courseB_maze_seq10_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq10_2019"
+          "courseB_maze_seq10_2020"
         ],
         "script_level.chapter": 31,
         "script_level.position": 10,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq11_2019",
+        "level.key": "courseB_maze_seq11_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq11_2019"
+          "courseB_maze_seq11_2020"
         ],
         "script_level.chapter": 32,
         "script_level.position": 11,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq12_2019",
+        "level.key": "courseB_maze_seq12_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq12_2019"
+          "courseB_maze_seq12_2020"
         ],
         "script_level.chapter": 33,
         "script_level.position": 12,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq_challenge1_2019",
+        "level.key": "courseB_maze_seq_challenge1_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge1_2019"
+          "courseB_maze_seq_challenge1_2020"
         ],
         "script_level.chapter": 34,
         "script_level.position": 13,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq_challenge2_2019",
+        "level.key": "courseB_maze_seq_challenge2_2020",
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge2_2019"
+          "courseB_maze_seq_challenge2_2020"
         ],
         "script_level.chapter": 35,
         "script_level.position": 14,
         "lesson.key": "Programming in Ice Age",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "bb8_skinOverview_K-1_video_2019",
+        "level.key": "bb8_skinOverview_K-1_video_2020",
         "script_level.level_keys": [
-          "bb8_skinOverview_K-1_video_2019"
+          "bb8_skinOverview_K-1_video_2020"
         ],
         "script_level.chapter": 36,
         "script_level.position": 1,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog1_2019",
+        "level.key": "courseB_starWars_prog1_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog1_2019"
+          "courseB_starWars_prog1_2020"
         ],
         "script_level.chapter": 37,
         "script_level.position": 2,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog2_2019",
+        "level.key": "courseB_starWars_prog2_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog2_2019"
+          "courseB_starWars_prog2_2020"
         ],
         "script_level.chapter": 38,
         "script_level.position": 3,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog3_2019",
+        "level.key": "courseB_starWars_prog3_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog3_2019"
+          "courseB_starWars_prog3_2020"
         ],
         "script_level.chapter": 39,
         "script_level.position": 4,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog4_2019",
+        "level.key": "courseB_starWars_prog4_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog4_2019"
+          "courseB_starWars_prog4_2020"
         ],
         "script_level.chapter": 40,
         "script_level.position": 5,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog5_2019",
+        "level.key": "courseB_starWars_prog5_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog5_2019"
+          "courseB_starWars_prog5_2020"
         ],
         "script_level.chapter": 41,
         "script_level.position": 6,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog6_2019",
+        "level.key": "courseB_starWars_prog6_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog6_2019"
+          "courseB_starWars_prog6_2020"
         ],
         "script_level.chapter": 42,
         "script_level.position": 7,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog7_2019",
+        "level.key": "courseB_starWars_prog7_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog7_2019"
+          "courseB_starWars_prog7_2020"
         ],
         "script_level.chapter": 43,
         "script_level.position": 8,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog8_2019",
+        "level.key": "courseB_starWars_prog8_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog8_2019"
+          "courseB_starWars_prog8_2020"
         ],
         "script_level.chapter": 44,
         "script_level.position": 9,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog9_2019",
+        "level.key": "courseB_starWars_prog9_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog9_2019"
+          "courseB_starWars_prog9_2020"
         ],
         "script_level.chapter": 45,
         "script_level.position": 10,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog10_2019",
+        "level.key": "courseB_starWars_prog10_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog10_2019"
+          "courseB_starWars_prog10_2020"
         ],
         "script_level.chapter": 46,
         "script_level.position": 11,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog11_2019",
+        "level.key": "courseB_starWars_prog11_2020",
         "script_level.level_keys": [
-          "courseB_starWars_prog11_2019"
+          "courseB_starWars_prog11_2020"
         ],
         "script_level.chapter": 47,
         "script_level.position": 12,
         "lesson.key": "Programming with Rey and BB-8",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "HappyLoops-Unplugged",
+        "level.key": "HappyLoops-Unplugged_2020",
         "script_level.level_keys": [
-          "HappyLoops-Unplugged"
+          "HappyLoops-Unplugged_2020"
         ],
         "script_level.chapter": 48,
         "script_level.position": 1,
         "lesson.key": "Loops: Happy Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops1_2019",
+        "level.key": "courseB_iceage_loops1_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops1_2019"
+          "courseB_iceage_loops1_2020"
         ],
         "script_level.chapter": 49,
         "script_level.position": 1,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops2_2019",
+        "level.key": "courseB_iceage_loops2_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops2_2019"
+          "courseB_iceage_loops2_2020"
         ],
         "script_level.chapter": 50,
         "script_level.position": 2,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops_video_2019",
+        "level.key": "courseB_iceage_loops_video_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops_video_2019"
+          "courseB_iceage_loops_video_2020"
         ],
         "script_level.chapter": 51,
         "script_level.position": 3,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops3_2019",
+        "level.key": "courseB_iceage_loops3_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops3_2019"
+          "courseB_iceage_loops3_2020"
         ],
         "script_level.chapter": 52,
         "script_level.position": 4,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops4_2019",
+        "level.key": "courseB_iceage_loops4_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops4_2019"
+          "courseB_iceage_loops4_2020"
         ],
         "script_level.chapter": 53,
         "script_level.position": 5,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops6_2019",
+        "level.key": "courseB_iceage_loops6_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops6_2019"
+          "courseB_iceage_loops6_2020"
         ],
         "script_level.chapter": 54,
         "script_level.position": 6,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops7_2019",
+        "level.key": "courseB_iceage_loops7_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops7_2019"
+          "courseB_iceage_loops7_2020"
         ],
         "script_level.chapter": 55,
         "script_level.position": 7,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops8_2019",
+        "level.key": "courseB_iceage_loops8_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops8_2019"
+          "courseB_iceage_loops8_2020"
         ],
         "script_level.chapter": 56,
         "script_level.position": 8,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops9_2019",
+        "level.key": "courseB_iceage_loops9_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops9_2019"
+          "courseB_iceage_loops9_2020"
         ],
         "script_level.chapter": 57,
         "script_level.position": 9,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops10_2019",
+        "level.key": "courseB_iceage_loops10_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops10_2019"
+          "courseB_iceage_loops10_2020"
         ],
         "script_level.chapter": 58,
         "script_level.position": 10,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops11_2019",
+        "level.key": "courseB_iceage_loops11_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops11_2019"
+          "courseB_iceage_loops11_2020"
         ],
         "script_level.chapter": 59,
         "script_level.position": 11,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops12_2019",
+        "level.key": "courseB_iceage_loops12_2020",
         "script_level.level_keys": [
-          "courseB_iceage_loops12_2019"
+          "courseB_iceage_loops12_2020"
         ],
         "script_level.chapter": 60,
         "script_level.position": 12,
         "lesson.key": "Loops in Ice Age",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseAB_video_collector_2019",
+        "level.key": "courseAB_video_collector_2020",
         "script_level.level_keys": [
-          "courseAB_video_collector_2019"
+          "courseAB_video_collector_2020"
         ],
         "script_level.chapter": 61,
         "script_level.position": 1,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops1_2019",
+        "level.key": "courseA_collector_loops1_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops1_2019"
+          "courseA_collector_loops1_2020"
         ],
         "script_level.chapter": 62,
         "script_level.position": 2,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops2_2019",
+        "level.key": "courseA_collector_loops2_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops2_2019"
+          "courseA_collector_loops2_2020"
         ],
         "script_level.chapter": 63,
         "script_level.position": 3,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_video_Loops_2019",
+        "level.key": "courseA_video_Loops_2020",
         "script_level.level_keys": [
-          "courseA_video_Loops_2019"
+          "courseA_video_Loops_2020"
         ],
         "script_level.chapter": 64,
         "script_level.position": 4,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops3_2019",
+        "level.key": "courseA_collector_loops3_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops3_2019"
+          "courseA_collector_loops3_2020"
         ],
         "script_level.chapter": 65,
         "script_level.position": 5,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops4_2019",
+        "level.key": "courseA_collector_loops4_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops4_2019"
+          "courseA_collector_loops4_2020"
         ],
         "script_level.chapter": 66,
         "script_level.position": 6,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops5_2019",
+        "level.key": "courseA_collector_loops5_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops5_2019"
+          "courseA_collector_loops5_2020"
         ],
         "script_level.chapter": 67,
         "script_level.position": 7,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops6_2019",
+        "level.key": "courseA_collector_loops6_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops6_2019"
+          "courseA_collector_loops6_2020"
         ],
         "script_level.chapter": 68,
         "script_level.position": 8,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops7_2019",
+        "level.key": "courseA_collector_loops7_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops7_2019"
+          "courseA_collector_loops7_2020"
         ],
         "script_level.chapter": 69,
         "script_level.position": 9,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops8_2019",
+        "level.key": "courseA_collector_loops8_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops8_2019"
+          "courseA_collector_loops8_2020"
         ],
         "script_level.chapter": 70,
         "script_level.position": 10,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops9_2019",
+        "level.key": "courseA_collector_loops9_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops9_2019"
+          "courseA_collector_loops9_2020"
         ],
         "script_level.chapter": 71,
         "script_level.position": 11,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops10_2019",
+        "level.key": "courseA_collector_loops10_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops10_2019"
+          "courseA_collector_loops10_2020"
         ],
         "script_level.chapter": 72,
         "script_level.position": 12,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops11_2019",
+        "level.key": "courseA_collector_loops11_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops11_2019"
+          "courseA_collector_loops11_2020"
         ],
         "script_level.chapter": 73,
         "script_level.position": 13,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops12_2019",
+        "level.key": "courseA_collector_loops12_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops12_2019"
+          "courseA_collector_loops12_2020"
         ],
         "script_level.chapter": 74,
         "script_level.position": 14,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops_challenge2kp_2019",
+        "level.key": "courseA_collector_loops_challenge2kp_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge2kp_2019"
+          "courseA_collector_loops_challenge2kp_2020"
         ],
         "script_level.chapter": 75,
         "script_level.position": 15,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops_challenge1_2019",
+        "level.key": "courseA_collector_loops_challenge1_2020",
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge1_2019"
+          "courseA_collector_loops_challenge1_2020"
         ],
         "script_level.chapter": 76,
         "script_level.position": 16,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_video_ArtistIntro_2019",
+        "level.key": "courseB_video_ArtistIntro_2020",
         "script_level.level_keys": [
-          "courseB_video_ArtistIntro_2019"
+          "courseB_video_ArtistIntro_2020"
         ],
         "script_level.chapter": 77,
         "script_level.position": 1,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops1_2019",
+        "level.key": "courseA_artist_loops1_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops1_2019"
+          "courseA_artist_loops1_2020"
         ],
         "script_level.chapter": 78,
         "script_level.position": 2,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops2_2019",
+        "level.key": "courseA_artist_loops2_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops2_2019"
+          "courseA_artist_loops2_2020"
         ],
         "script_level.chapter": 79,
         "script_level.position": 3,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops3_2019",
+        "level.key": "courseA_artist_loops3_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops3_2019"
+          "courseA_artist_loops3_2020"
         ],
         "script_level.chapter": 80,
         "script_level.position": 4,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_video_loops1_2019",
+        "level.key": "courseA_video_loops1_2020",
         "script_level.level_keys": [
-          "courseA_video_loops1_2019"
+          "courseA_video_loops1_2020"
         ],
         "script_level.chapter": 81,
         "script_level.position": 5,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops4_2019",
+        "level.key": "courseA_artist_loops4_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops4_2019"
+          "courseA_artist_loops4_2020"
         ],
         "script_level.chapter": 82,
         "script_level.position": 6,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops5_2019",
+        "level.key": "courseA_artist_loops5_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops5_2019"
+          "courseA_artist_loops5_2020"
         ],
         "script_level.chapter": 83,
         "script_level.position": 7,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops6_2019",
+        "level.key": "courseA_artist_loops6_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops6_2019"
+          "courseA_artist_loops6_2020"
         ],
         "script_level.chapter": 84,
         "script_level.position": 8,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops7_2019",
+        "level.key": "courseA_artist_loops7_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops7_2019"
+          "courseA_artist_loops7_2020"
         ],
         "script_level.chapter": 85,
         "script_level.position": 9,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops8_2019",
+        "level.key": "courseA_artist_loops8_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops8_2019"
+          "courseA_artist_loops8_2020"
         ],
         "script_level.chapter": 86,
         "script_level.position": 10,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops9_2019",
+        "level.key": "courseA_artist_loops9_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops9_2019"
+          "courseA_artist_loops9_2020"
         ],
         "script_level.chapter": 87,
         "script_level.position": 11,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops10_2019",
+        "level.key": "courseA_artist_loops10_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops10_2019"
+          "courseA_artist_loops10_2020"
         ],
         "script_level.chapter": 88,
         "script_level.position": 12,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops11_2019",
+        "level.key": "courseA_artist_loops11_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops11_2019"
+          "courseA_artist_loops11_2020"
         ],
         "script_level.chapter": 89,
         "script_level.position": 13,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops12_2019",
+        "level.key": "courseA_artist_loops12_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops12_2019"
+          "courseA_artist_loops12_2020"
         ],
         "script_level.chapter": 90,
         "script_level.position": 14,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops_challenge2a_2019",
+        "level.key": "courseA_artist_loops_challenge2a_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops_challenge2a_2019"
+          "courseA_artist_loops_challenge2a_2020"
         ],
         "script_level.chapter": 91,
         "script_level.position": 15,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops_challenge1_2019",
+        "level.key": "courseA_artist_loops_challenge1_2020",
         "script_level.level_keys": [
-          "courseA_artist_loops_challenge1_2019"
+          "courseA_artist_loops_challenge1_2020"
         ],
         "script_level.chapter": 92,
         "script_level.position": 16,
         "lesson.key": "Ocean Scene with Loops",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "BigEvent-Unplugged",
+        "level.key": "BigEvent-Unplugged_2020",
         "script_level.level_keys": [
-          "BigEvent-Unplugged"
+          "BigEvent-Unplugged_2020"
         ],
         "script_level.chapter": 93,
         "script_level.position": 1,
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_video_events_2019",
+        "level.key": "courseA_video_events_2020",
         "script_level.level_keys": [
-          "courseA_video_events_2019"
+          "courseA_video_events_2020"
         ],
         "script_level.chapter": 94,
         "script_level.position": 1,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events1_2019",
+        "level.key": "courseA_playLab_events1_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events1_2019"
+          "courseA_playLab_events1_2020"
         ],
         "script_level.chapter": 95,
         "script_level.position": 2,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events2_2019",
+        "level.key": "courseA_playLab_events2_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events2_2019"
+          "courseA_playLab_events2_2020"
         ],
         "script_level.chapter": 96,
         "script_level.position": 3,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events3_2019",
+        "level.key": "courseA_playLab_events3_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events3_2019"
+          "courseA_playLab_events3_2020"
         ],
         "script_level.chapter": 97,
         "script_level.position": 4,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events4_2019",
+        "level.key": "courseA_playLab_events4_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events4_2019"
+          "courseA_playLab_events4_2020"
         ],
         "script_level.chapter": 98,
         "script_level.position": 5,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events5_2019",
+        "level.key": "courseA_playLab_events5_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events5_2019"
+          "courseA_playLab_events5_2020"
         ],
         "script_level.chapter": 99,
         "script_level.position": 6,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events6_2019",
+        "level.key": "courseA_playLab_events6_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events6_2019"
+          "courseA_playLab_events6_2020"
         ],
         "script_level.chapter": 100,
         "script_level.position": 7,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events7_2019",
+        "level.key": "courseA_playLab_events7_2020",
         "script_level.level_keys": [
-          "courseA_playLab_events7_2019"
+          "courseA_playLab_events7_2020"
         ],
         "script_level.chapter": 101,
         "script_level.position": 8,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playlab_events_challenge2_2019",
+        "level.key": "courseA_playlab_events_challenge2_2020",
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge2_2019"
+          "courseA_playlab_events_challenge2_2020"
         ],
         "script_level.chapter": 102,
         "script_level.position": 9,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playlab_events_challenge1_2019",
+        "level.key": "courseA_playlab_events_challenge1_2020",
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge1_2019"
+          "courseA_playlab_events_challenge1_2020"
         ],
         "script_level.chapter": 103,
         "script_level.position": 10,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "coursea-2020"
       }
     }
   ]

--- a/dashboard/config/scripts_json/coursea-draft.script_json
+++ b/dashboard/config/scripts_json/coursea-draft.script_json
@@ -1,0 +1,4203 @@
+{
+  "script": {
+    "name": "coursea-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursea-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Marbles",
+      "name": "Persistence & Frustration: Stevie and the Marbles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Learn to Drag and Drop",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Programming: Happy Maps",
+      "name": "Programming: Happy Maps",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Going Places Safely",
+      "name": "Going Places Safely",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Loops: Happy Loops",
+      "name": "Loops: Happy Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops in Collector",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs10"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs11"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs12"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs13"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs14"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs15"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs16"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs17"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs18"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_video_Stevie"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie6"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie9"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie10"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie11"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie12"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie12a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie12a"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie13"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie14"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 17,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie15"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 18,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:13"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "UnplugHappyMaps"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq1"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_debug1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_video_debug1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq3"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq4"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq9"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq9"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq11"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq12"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq13"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 17,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "GoingPlacesSafely"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeK_unplugged_loops"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "gradeK_unplugged_loops"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops2"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops9"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops10"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops11"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops12"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_video_loops1"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops10"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops11"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops12"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_video_events"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events3"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events4"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events5"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events6"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playLab_events7"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs1",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs2",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs3",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs4",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs5",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs6",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs7",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs8",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs9",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs10",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs11",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs12",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs13",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs14",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs15",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs16",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs17",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs18",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie",
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie1",
+        "script_level.level_keys": [
+          "courseA_external_stevie1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie2",
+        "script_level.level_keys": [
+          "courseA_external_stevie2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie3",
+        "script_level.level_keys": [
+          "courseA_external_stevie3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie4",
+        "script_level.level_keys": [
+          "courseA_external_stevie4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie5",
+        "script_level.level_keys": [
+          "courseA_external_stevie5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie6",
+        "script_level.level_keys": [
+          "courseA_external_stevie6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie7",
+        "script_level.level_keys": [
+          "courseA_external_stevie7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie8",
+        "script_level.level_keys": [
+          "courseA_external_stevie8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie9",
+        "script_level.level_keys": [
+          "courseA_external_stevie9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie10",
+        "script_level.level_keys": [
+          "courseA_external_stevie10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie11",
+        "script_level.level_keys": [
+          "courseA_external_stevie11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie12",
+        "script_level.level_keys": [
+          "courseA_external_stevie12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie12a",
+        "script_level.level_keys": [
+          "courseA_external_stevie12a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie13",
+        "script_level.level_keys": [
+          "courseA_external_stevie13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie14",
+        "script_level.level_keys": [
+          "courseA_external_stevie14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie15",
+        "script_level.level_keys": [
+          "courseA_external_stevie15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 17,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie16",
+        "script_level.level_keys": [
+          "courseA_external_stevie16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 18,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:13",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "UnplugHappyMaps",
+        "script_level.level_keys": [
+          "UnplugHappyMaps"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Happy Maps",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1",
+        "script_level.level_keys": [
+          "courseA_maze_seq1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_debug1",
+        "script_level.level_keys": [
+          "courseA_video_debug1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq2",
+        "script_level.level_keys": [
+          "courseA_maze_seq2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq3",
+        "script_level.level_keys": [
+          "courseA_maze_seq3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq4",
+        "script_level.level_keys": [
+          "courseA_maze_seq4"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5",
+        "script_level.level_keys": [
+          "courseA_maze_seq5"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6",
+        "script_level.level_keys": [
+          "courseA_maze_seq6"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq7",
+        "script_level.level_keys": [
+          "courseA_maze_seq7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8",
+        "script_level.level_keys": [
+          "courseA_maze_seq8"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq9",
+        "script_level.level_keys": [
+          "courseA_maze_seq9"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10",
+        "script_level.level_keys": [
+          "courseA_maze_seq10"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11",
+        "script_level.level_keys": [
+          "courseA_maze_seq11"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12",
+        "script_level.level_keys": [
+          "courseA_maze_seq12"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13",
+        "script_level.level_keys": [
+          "courseA_maze_seq13"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 17,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoingPlacesSafely",
+        "script_level.level_keys": [
+          "GoingPlacesSafely"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Going Places Safely",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeK_unplugged_loops",
+        "script_level.level_keys": [
+          "gradeK_unplugged_loops"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Happy Loops",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops1",
+        "script_level.level_keys": [
+          "courseA_collector_loops1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops2",
+        "script_level.level_keys": [
+          "courseA_collector_loops2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops3",
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops4",
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops5",
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops6",
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops7",
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops8",
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops9",
+        "script_level.level_keys": [
+          "courseA_collector_loops9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops10",
+        "script_level.level_keys": [
+          "courseA_collector_loops10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops11",
+        "script_level.level_keys": [
+          "courseA_collector_loops11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops12",
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops1",
+        "script_level.level_keys": [
+          "courseA_artist_loops1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2",
+        "script_level.level_keys": [
+          "courseA_artist_loops2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3",
+        "script_level.level_keys": [
+          "courseA_artist_loops3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1",
+        "script_level.level_keys": [
+          "courseA_video_loops1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4",
+        "script_level.level_keys": [
+          "courseA_artist_loops4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5",
+        "script_level.level_keys": [
+          "courseA_artist_loops5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6",
+        "script_level.level_keys": [
+          "courseA_artist_loops6"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7",
+        "script_level.level_keys": [
+          "courseA_artist_loops7"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8",
+        "script_level.level_keys": [
+          "courseA_artist_loops8"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9",
+        "script_level.level_keys": [
+          "courseA_artist_loops9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10",
+        "script_level.level_keys": [
+          "courseA_artist_loops10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11",
+        "script_level.level_keys": [
+          "courseA_artist_loops11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12",
+        "script_level.level_keys": [
+          "courseA_artist_loops12"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events",
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1",
+        "script_level.level_keys": [
+          "courseA_playLab_events1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2",
+        "script_level.level_keys": [
+          "courseA_playLab_events2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3",
+        "script_level.level_keys": [
+          "courseA_playLab_events3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4",
+        "script_level.level_keys": [
+          "courseA_playLab_events4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5",
+        "script_level.level_keys": [
+          "courseA_playLab_events5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events6",
+        "script_level.level_keys": [
+          "courseA_playLab_events6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events7",
+        "script_level.level_keys": [
+          "courseA_playLab_events7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursea-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/courseb-2017.script_json
+++ b/dashboard/config/scripts_json/courseb-2017.script_json
@@ -1,0 +1,3292 @@
+{
+  "script": {
+    "name": "courseb-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/courseb/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "ar-SA",
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN",
+        "zh-TW"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "courseb-2017",
+    "family_name": "courseb",
+    "seeding_key": {
+      "script.name": "courseb-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Marbles",
+      "name": "Persistence: Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Sequencing with Drag and Drop",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Your Digital Footprint",
+      "name": "Digital Citizenship: My Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops in Collector",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseA_video_Stevie"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:13"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "DigitalFootprint"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_video_debuggingOrg"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq9"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq11"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq12"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops2"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops9"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops10"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops11"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops10"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseA_video_events"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playLab_events1"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events2"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events3"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events4"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events5"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events6"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events7"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie",
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:13",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint",
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1",
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_debuggingOrg",
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq2",
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq3",
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq4",
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq5",
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq6",
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq7",
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq8",
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq9",
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10",
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq11",
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq12",
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1",
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2",
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3",
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4",
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5",
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6",
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7",
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8",
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9",
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10",
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11",
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1",
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2",
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3",
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4",
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5",
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6",
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7",
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8",
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9",
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10",
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events",
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1",
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2",
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3",
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4",
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5",
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6",
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7",
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/courseb-2018.script_json
+++ b/dashboard/config/scripts_json/courseb-2018.script_json
@@ -1,0 +1,3442 @@
+{
+  "script": {
+    "name": "courseb-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/courseb/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/courseb/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/courseb/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/courseb/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "courseb",
+    "seeding_key": {
+      "script.name": "courseb-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Move It, Move It",
+      "name": "Move It, Move It",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Sequencing with Scrat",
+      "name": "Sequencing with Scrat",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Your Digital Footprint",
+      "name": "Your Digital Footprint",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends Jr.",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Programming in Ice Age",
+      "name": "Programming with Scrat",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Copyright and Creativity",
+      "name": "It's Great to Create and Play Fair",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends Jr.",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops with Scrat",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Gardens with Loops",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event Jr.",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "A Royal Battle with Events",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MoveItMoveIt_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "MoveItMoveIt_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3a_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3b_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp4a_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "DigitalFootprint_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq1_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq4_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq4_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq5_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq5_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq6_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq6_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq7_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq7_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq8_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq8_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq9_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq9_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq10_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq11_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq11_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq12_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq12_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_CnC_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "bb8_skinOverview_K-1_video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops_video"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops4"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops6"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops7"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops7"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops8"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops8"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops9"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops9"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops10"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops11"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops11"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops12"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops12"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "BigEvent_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseA_video_events_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playLab_events1_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events2_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events3_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events4_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events5_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MoveItMoveIt_2018",
+        "script_level.level_keys": [
+          "MoveItMoveIt_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2018",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp1_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp2_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3b_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp4a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint_2018",
+        "script_level.level_keys": [
+          "DigitalFootprint_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2018",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq1_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq4_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq4_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq5_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq5_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq6_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq6_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq7_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq7_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq8_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq8_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq9_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq9_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq10_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq11_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq11_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq12_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq12_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_CnC_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_K-1_video",
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops1",
+        "script_level.level_keys": [
+          "courseB_iceage_loops1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops2",
+        "script_level.level_keys": [
+          "courseB_iceage_loops2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops_video",
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops3",
+        "script_level.level_keys": [
+          "courseB_iceage_loops3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops4",
+        "script_level.level_keys": [
+          "courseB_iceage_loops4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops6",
+        "script_level.level_keys": [
+          "courseB_iceage_loops6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops7",
+        "script_level.level_keys": [
+          "courseB_iceage_loops7"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops8",
+        "script_level.level_keys": [
+          "courseB_iceage_loops8"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops9",
+        "script_level.level_keys": [
+          "courseB_iceage_loops9"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops10",
+        "script_level.level_keys": [
+          "courseB_iceage_loops10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops11",
+        "script_level.level_keys": [
+          "courseB_iceage_loops11"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops12",
+        "script_level.level_keys": [
+          "courseB_iceage_loops12"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2018",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2018",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2018",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2018",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2018",
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2018",
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1_2018",
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/courseb-2019.script_json
+++ b/dashboard/config/scripts_json/courseb-2019.script_json
@@ -1,6 +1,6 @@
 {
   "script": {
-    "name": "coursea-2019",
+    "name": "courseb-2019",
     "wrapup_video_id": null,
     "hidden": false,
     "login_required": false,
@@ -12,7 +12,7 @@
         "artist_k1"
       ],
       "lesson_extras_available": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursea/{LESSON}",
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/courseb/{LESSON}",
       "version_year": "2019",
       "supported_locales": [
         "cs-CZ",
@@ -26,19 +26,19 @@
       "teacher_resources": [
         [
           "lessonPlans",
-          "https://curriculum.code.org/csf-19/coursea/"
+          "https://curriculum.code.org/csf-19/courseb/"
         ],
         [
           "teacherForum",
-          "http://forum.code.org/c/csf"
+          "https://forum.code.org/c/csf"
         ],
         [
           "vocabulary",
-          "https://curriculum.code.org/csf-19/coursea/vocab/"
+          "https://curriculum.code.org/csf-19/courseb/vocab/"
         ],
         [
           "standardMappings",
-          "https://curriculum.code.org/csf-19/coursea/standards/"
+          "https://curriculum.code.org/csf-19/courseb/standards/"
         ],
         [
           "curriculumGuide",
@@ -47,9 +47,9 @@
       ]
     },
     "new_name": null,
-    "family_name": "coursea",
+    "family_name": "courseb",
     "seeding_key": {
-      "script.name": "coursea-2019"
+      "script.name": "courseb-2019"
     }
   },
   "lesson_groups": [
@@ -62,7 +62,7 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -74,7 +74,7 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -86,161 +86,173 @@
       },
       "seeding_key": {
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2019"
       }
     },
     {
       "key": "csf_events",
       "user_facing": true,
-      "position": 4,
+      "position": 5,
       "properties": {
         "display_name": "Events"
       },
       "seeding_key": {
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     }
   ],
   "lessons": [
     {
-      "key": "Going Places Safely",
-      "name": "Going Places Safely",
+      "key": "Your Digital Footprint",
+      "name": "Your Digital Footprint",
       "absolute_position": 1,
       "lockable": false,
       "relative_position": 1,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Your Digital Footprint",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Learn to Drag and Drop",
-      "name": "Learn to Drag and Drop",
+      "key": "Move It, Move It",
+      "name": "Move It, Move It",
       "absolute_position": 2,
       "lockable": false,
       "relative_position": 2,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Learn to Drag and Drop",
+        "lesson.key": "Move It, Move It",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Programming: Happy Maps",
-      "name": "Happy Maps",
+      "key": "Sequencing in Maze",
+      "name": "Sequencing with Angry Birds",
       "absolute_position": 3,
       "lockable": false,
       "relative_position": 3,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Programming: Happy Maps",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Sequencing with Scrat",
-      "name": "Sequencing with Scrat",
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
       "absolute_position": 4,
       "lockable": false,
       "relative_position": 4,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Programming in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Programming in Ice Age",
-      "name": "Programming with Scrat",
+      "key": "Programming in Harvester",
+      "name": "Programming with Harvester",
       "absolute_position": 5,
       "lockable": false,
       "relative_position": 5,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Programming with Rey and BB-8",
-      "name": "Programming with Rey and BB-8",
+      "key": "Loops: Getting Loopy",
+      "name": "Getting Loopy",
       "absolute_position": 6,
       "lockable": false,
       "relative_position": 6,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Loops: Happy Loops",
-      "name": "Happy Loops",
+      "key": "Loops in Harvester",
+      "name": "Loops with Harvester",
       "absolute_position": 7,
       "lockable": false,
       "relative_position": 7,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Loops: Happy Loops",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Loops in Ice Age",
-      "name": "Loops with Scrat",
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
       "absolute_position": 8,
       "lockable": false,
       "relative_position": 8,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Loops in Collector",
-      "name": "Loops with Laurel",
+      "key": "Loops in Artist",
+      "name": "Drawing Gardens with Loops",
       "absolute_position": 9,
       "lockable": false,
       "relative_position": 9,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Loops in Collector",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
-      "key": "Ocean Scene with Loops",
-      "name": "Ocean Scene with Loops",
+      "key": "The Right App",
+      "name": "The Right App",
       "absolute_position": 10,
       "lockable": false,
       "relative_position": 10,
       "properties": {
       },
       "seeding_key": {
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -254,12 +266,12 @@
       "seeding_key": {
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "key": "Events in Play Lab",
-      "name": "On the Move with Events",
+      "name": "A Royal Battle with Events",
       "absolute_position": 12,
       "lockable": false,
       "relative_position": 12,
@@ -268,7 +280,7 @@
       "seeding_key": {
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     }
   ],
@@ -283,16 +295,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "GoingPlacesSafely-unplugged"
+          "DigitalFootprint-Unplugged"
         ],
         "script_level.chapter": 1,
         "script_level.position": 1,
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Your Digital Footprint",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "GoingPlacesSafely-unplugged"
+        "DigitalFootprint-Unplugged"
       ]
     },
     {
@@ -300,301 +312,25 @@
       "position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:Jigsaw:1"
+          "MoveItMoveIt-Unplugged"
         ],
         "script_level.chapter": 2,
         "script_level.position": 1,
-        "lesson.key": "Learn to Drag and Drop",
+        "lesson.key": "Move It, Move It",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "blockly:Jigsaw:1"
+        "MoveItMoveIt-Unplugged"
       ]
     },
     {
       "chapter": 3,
-      "position": 2,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:2"
-        ],
-        "script_level.chapter": 3,
-        "script_level.position": 2,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:2"
-      ]
-    },
-    {
-      "chapter": 4,
-      "position": 3,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:3"
-        ],
-        "script_level.chapter": 4,
-        "script_level.position": 3,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:3"
-      ]
-    },
-    {
-      "chapter": 5,
-      "position": 4,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:4"
-        ],
-        "script_level.chapter": 5,
-        "script_level.position": 4,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:4"
-      ]
-    },
-    {
-      "chapter": 6,
-      "position": 5,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:5"
-        ],
-        "script_level.chapter": 6,
-        "script_level.position": 5,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:5"
-      ]
-    },
-    {
-      "chapter": 7,
-      "position": 6,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:6"
-        ],
-        "script_level.chapter": 7,
-        "script_level.position": 6,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:6"
-      ]
-    },
-    {
-      "chapter": 8,
-      "position": 7,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:7"
-        ],
-        "script_level.chapter": 8,
-        "script_level.position": 7,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:7"
-      ]
-    },
-    {
-      "chapter": 9,
-      "position": 8,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:8"
-        ],
-        "script_level.chapter": 9,
-        "script_level.position": 8,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:8"
-      ]
-    },
-    {
-      "chapter": 10,
-      "position": 9,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:9"
-        ],
-        "script_level.chapter": 10,
-        "script_level.position": 9,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:9"
-      ]
-    },
-    {
-      "chapter": 11,
-      "position": 10,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:10"
-        ],
-        "script_level.chapter": 11,
-        "script_level.position": 10,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:10"
-      ]
-    },
-    {
-      "chapter": 12,
-      "position": 11,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:11"
-        ],
-        "script_level.chapter": 12,
-        "script_level.position": 11,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:11"
-      ]
-    },
-    {
-      "chapter": 13,
-      "position": 12,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "blockly:Jigsaw:12"
-        ],
-        "script_level.chapter": 13,
-        "script_level.position": 12,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "blockly:Jigsaw:12"
-      ]
-    },
-    {
-      "chapter": 14,
-      "position": 1,
-      "assessment": null,
-      "properties": {
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "HappyMaps-Unplugged"
-        ],
-        "script_level.chapter": 14,
-        "script_level.position": 1,
-        "lesson.key": "Programming: Happy Maps",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "HappyMaps-Unplugged"
-      ]
-    },
-    {
-      "chapter": 15,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -606,18 +342,18 @@
         "script_level.level_keys": [
           "courseAB_video_NewIntro_2019"
         ],
-        "script_level.chapter": 15,
+        "script_level.chapter": 3,
         "script_level.position": 1,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseAB_video_NewIntro_2019"
       ]
     },
     {
-      "chapter": 16,
+      "chapter": 4,
       "position": 2,
       "assessment": null,
       "properties": {
@@ -627,20 +363,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp1_2019"
+          "coursea_maze_ramp1_2019"
         ],
-        "script_level.chapter": 16,
+        "script_level.chapter": 4,
         "script_level.position": 2,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp1_2019"
+        "coursea_maze_ramp1_2019"
       ]
     },
     {
-      "chapter": 17,
+      "chapter": 5,
       "position": 3,
       "assessment": null,
       "properties": {
@@ -650,20 +386,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp2_2019"
+          "courseA_maze_ramp2_2019"
         ],
-        "script_level.chapter": 17,
+        "script_level.chapter": 5,
         "script_level.position": 3,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp2_2019"
+        "courseA_maze_ramp2_2019"
       ]
     },
     {
-      "chapter": 18,
+      "chapter": 6,
       "position": 4,
       "assessment": null,
       "properties": {
@@ -673,20 +409,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3a_2019"
+          "courseA_maze_ramp3a_2019"
         ],
-        "script_level.chapter": 18,
+        "script_level.chapter": 6,
         "script_level.position": 4,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp3a_2019"
+        "courseA_maze_ramp3a_2019"
       ]
     },
     {
-      "chapter": 19,
+      "chapter": 7,
       "position": 5,
       "assessment": null,
       "properties": {
@@ -696,20 +432,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3b_2019"
+          "courseA_maze_ramp3b_2019"
         ],
-        "script_level.chapter": 19,
+        "script_level.chapter": 7,
         "script_level.position": 5,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp3b_2019"
+        "courseA_maze_ramp3b_2019"
       ]
     },
     {
-      "chapter": 20,
+      "chapter": 8,
       "position": 6,
       "assessment": null,
       "properties": {
@@ -719,20 +455,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp4a_2019"
+          "courseA_maze_ramp4a_2019"
         ],
-        "script_level.chapter": 20,
+        "script_level.chapter": 8,
         "script_level.position": 6,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp4a_2019"
+        "courseA_maze_ramp4a_2019"
       ]
     },
     {
-      "chapter": 21,
+      "chapter": 9,
       "position": 7,
       "assessment": null,
       "properties": {
@@ -742,20 +478,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_Scrat_ramp5a_2019"
+          "courseA_maze_ramp5a_2019"
         ],
-        "script_level.chapter": 21,
+        "script_level.chapter": 9,
         "script_level.position": 7,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_Scrat_ramp5a_2019"
+        "courseA_maze_ramp5a_2019"
       ]
     },
     {
-      "chapter": 22,
+      "chapter": 10,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -767,14 +503,289 @@
         "script_level.level_keys": [
           "elementary_video_pairProgramming_2019"
         ],
-        "script_level.chapter": 22,
+        "script_level.chapter": 10,
         "script_level.position": 1,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "elementary_video_pairProgramming_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_intro_2019"
       ]
     },
     {
@@ -788,16 +799,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq1_2019"
+          "courseA_harvester_seq1_2019"
         ],
         "script_level.chapter": 23,
         "script_level.position": 2,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq1_2019"
+        "courseA_harvester_seq1_2019"
       ]
     },
     {
@@ -811,16 +822,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq4_2019"
+          "courseA_harvester_seq2_2019"
         ],
         "script_level.chapter": 24,
         "script_level.position": 3,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq4_2019"
+        "courseA_harvester_seq2_2019"
       ]
     },
     {
@@ -834,44 +845,21 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq5_2019"
+          "courseA_harvester_seq3_2019"
         ],
         "script_level.chapter": 25,
         "script_level.position": 4,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq5_2019"
+        "courseA_harvester_seq3_2019"
       ]
     },
     {
       "chapter": 26,
       "position": 5,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_maze_seq6_2019"
-        ],
-        "script_level.chapter": 26,
-        "script_level.position": 5,
-        "lesson.key": "Programming in Ice Age",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_maze_seq6_2019"
-      ]
-    },
-    {
-      "chapter": 27,
-      "position": 6,
       "assessment": null,
       "properties": {
         "progression": "Debugging with the Step Button"
@@ -882,14 +870,37 @@
         "script_level.level_keys": [
           "courseAB_video_debugging_2019"
         ],
-        "script_level.chapter": 27,
-        "script_level.position": 6,
-        "lesson.key": "Programming in Ice Age",
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseAB_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq4_2019"
       ]
     },
     {
@@ -903,16 +914,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq7_2019"
+          "courseA_harvester_seq5_2019"
         ],
         "script_level.chapter": 28,
         "script_level.position": 7,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq7_2019"
+        "courseA_harvester_seq5_2019"
       ]
     },
     {
@@ -926,16 +937,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq8_2019"
+          "courseA_harvester_seq6_2019"
         ],
         "script_level.chapter": 29,
         "script_level.position": 8,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq8_2019"
+        "courseA_harvester_seq6_2019"
       ]
     },
     {
@@ -943,23 +954,22 @@
       "position": 9,
       "assessment": null,
       "properties": {
-        "progression": "Challenge",
-        "challenge": true
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq9_2019"
+          "courseA_harvester_seq7_2019"
         ],
         "script_level.chapter": 30,
         "script_level.position": 9,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq9_2019"
+        "courseA_harvester_seq7_2019"
       ]
     },
     {
@@ -973,16 +983,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq10_2019"
+          "courseA_harvester_seq8_2019"
         ],
         "script_level.chapter": 31,
         "script_level.position": 10,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq10_2019"
+        "courseA_harvester_seq8_2019"
       ]
     },
     {
@@ -996,16 +1006,16 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq11_2019"
+          "courseA_harvester_seq9_2019"
         ],
         "script_level.chapter": 32,
         "script_level.position": 11,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq11_2019"
+        "courseA_harvester_seq9_2019"
       ]
     },
     {
@@ -1013,22 +1023,23 @@
       "position": 12,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
+        "progression": "Challenge",
+        "challenge": true
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq12_2019"
+          "courseA_harvester_seq10_2019"
         ],
         "script_level.chapter": 33,
         "script_level.position": 12,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq12_2019"
+        "courseA_harvester_seq10_2019"
       ]
     },
     {
@@ -1036,21 +1047,22 @@
       "position": 13,
       "assessment": null,
       "properties": {
+        "progression": "Practice"
       },
       "named_level": null,
-      "bonus": true,
+      "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge1_2019"
+          "courseA_harvester_seq12_2019"
         ],
         "script_level.chapter": 34,
         "script_level.position": 13,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq_challenge1_2019"
+        "courseA_harvester_seq12_2019"
       ]
     },
     {
@@ -1058,72 +1070,72 @@
       "position": 14,
       "assessment": null,
       "properties": {
+        "progression": "Practice"
       },
       "named_level": null,
-      "bonus": true,
+      "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge2_2019"
+          "courseA_harvester_seq11_2019"
         ],
         "script_level.chapter": 35,
         "script_level.position": 14,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_maze_seq_challenge2_2019"
+        "courseA_harvester_seq11_2019"
       ]
     },
     {
       "chapter": 36,
-      "position": 1,
+      "position": 15,
       "assessment": null,
       "properties": {
-        "progression": "Programming with Rey and BB-8"
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "bb8_skinOverview_K-1_video_2019"
+          "courseA_harvester_seq13_2019"
         ],
         "script_level.chapter": 36,
-        "script_level.position": 1,
-        "lesson.key": "Programming with Rey and BB-8",
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "bb8_skinOverview_K-1_video_2019"
+        "courseA_harvester_seq13_2019"
       ]
     },
     {
       "chapter": 37,
-      "position": 2,
+      "position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog1_2019"
+          "GettingLoopy-Unplugged"
         ],
         "script_level.chapter": 37,
-        "script_level.position": 2,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_starWars_prog1_2019"
+        "GettingLoopy-Unplugged"
       ]
     },
     {
       "chapter": 38,
-      "position": 3,
+      "position": 1,
       "assessment": null,
       "properties": {
         "progression": "Practice"
@@ -1132,273 +1144,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_starWars_prog2_2019"
+          "courseA_harvester_loops1_2019"
         ],
         "script_level.chapter": 38,
-        "script_level.position": 3,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_starWars_prog2_2019"
+        "courseA_harvester_loops1_2019"
       ]
     },
     {
       "chapter": 39,
-      "position": 4,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog3_2019"
-        ],
-        "script_level.chapter": 39,
-        "script_level.position": 4,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog3_2019"
-      ]
-    },
-    {
-      "chapter": 40,
-      "position": 5,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog4_2019"
-        ],
-        "script_level.chapter": 40,
-        "script_level.position": 5,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog4_2019"
-      ]
-    },
-    {
-      "chapter": 41,
-      "position": 6,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog5_2019"
-        ],
-        "script_level.chapter": 41,
-        "script_level.position": 6,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog5_2019"
-      ]
-    },
-    {
-      "chapter": 42,
-      "position": 7,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog6_2019"
-        ],
-        "script_level.chapter": 42,
-        "script_level.position": 7,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog6_2019"
-      ]
-    },
-    {
-      "chapter": 43,
-      "position": 8,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog7_2019"
-        ],
-        "script_level.chapter": 43,
-        "script_level.position": 8,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog7_2019"
-      ]
-    },
-    {
-      "chapter": 44,
-      "position": 9,
-      "assessment": null,
-      "properties": {
-        "progression": "Challenge",
-        "challenge": true
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog8_2019"
-        ],
-        "script_level.chapter": 44,
-        "script_level.position": 9,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog8_2019"
-      ]
-    },
-    {
-      "chapter": 45,
-      "position": 10,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog9_2019"
-        ],
-        "script_level.chapter": 45,
-        "script_level.position": 10,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog9_2019"
-      ]
-    },
-    {
-      "chapter": 46,
-      "position": 11,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog10_2019"
-        ],
-        "script_level.chapter": 46,
-        "script_level.position": 11,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog10_2019"
-      ]
-    },
-    {
-      "chapter": 47,
-      "position": 12,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_starWars_prog11_2019"
-        ],
-        "script_level.chapter": 47,
-        "script_level.position": 12,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_starWars_prog11_2019"
-      ]
-    },
-    {
-      "chapter": 48,
-      "position": 1,
-      "assessment": null,
-      "properties": {
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "HappyLoops-Unplugged"
-        ],
-        "script_level.chapter": 48,
-        "script_level.position": 1,
-        "lesson.key": "Loops: Happy Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "HappyLoops-Unplugged"
-      ]
-    },
-    {
-      "chapter": 49,
-      "position": 1,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_iceage_loops1_2019"
-        ],
-        "script_level.chapter": 49,
-        "script_level.position": 1,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_iceage_loops1_2019"
-      ]
-    },
-    {
-      "chapter": 50,
       "position": 2,
       "assessment": null,
       "properties": {
@@ -1408,43 +1167,43 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops2_2019"
+          "courseA_harvester_loops2_2019"
         ],
-        "script_level.chapter": 50,
+        "script_level.chapter": 39,
         "script_level.position": 2,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops2_2019"
+        "courseA_harvester_loops2_2019"
       ]
     },
     {
-      "chapter": 51,
+      "chapter": 40,
       "position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Ice Age Loops"
+        "progression": "Repeat Blocks"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops_video_2019"
+          "courseA_harvester_loops_video_2019"
         ],
-        "script_level.chapter": 51,
+        "script_level.chapter": 40,
         "script_level.position": 3,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops_video_2019"
+        "courseA_harvester_loops_video_2019"
       ]
     },
     {
-      "chapter": 52,
+      "chapter": 41,
       "position": 4,
       "assessment": null,
       "properties": {
@@ -1454,20 +1213,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops3_2019"
+          "courseA_harvester_loops3_2019"
         ],
-        "script_level.chapter": 52,
+        "script_level.chapter": 41,
         "script_level.position": 4,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops3_2019"
+        "courseA_harvester_loops3_2019"
       ]
     },
     {
-      "chapter": 53,
+      "chapter": 42,
       "position": 5,
       "assessment": null,
       "properties": {
@@ -1477,20 +1236,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops4_2019"
+          "courseA_harvester_loops4_2019"
         ],
-        "script_level.chapter": 53,
+        "script_level.chapter": 42,
         "script_level.position": 5,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops4_2019"
+        "courseA_harvester_loops4_2019"
       ]
     },
     {
-      "chapter": 54,
+      "chapter": 43,
       "position": 6,
       "assessment": null,
       "properties": {
@@ -1500,20 +1259,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops6_2019"
+          "courseA_harvester_loops5_2019"
         ],
-        "script_level.chapter": 54,
+        "script_level.chapter": 43,
         "script_level.position": 6,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops6_2019"
+        "courseA_harvester_loops5_2019"
       ]
     },
     {
-      "chapter": 55,
+      "chapter": 44,
       "position": 7,
       "assessment": null,
       "properties": {
@@ -1523,20 +1282,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops7_2019"
+          "courseA_harvester_loops5a_2019"
         ],
-        "script_level.chapter": 55,
+        "script_level.chapter": 44,
         "script_level.position": 7,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops7_2019"
+        "courseA_harvester_loops5a_2019"
       ]
     },
     {
-      "chapter": 56,
+      "chapter": 45,
       "position": 8,
       "assessment": null,
       "properties": {
@@ -1546,20 +1305,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops8_2019"
+          "courseA_harvester_loops5b_2019"
         ],
-        "script_level.chapter": 56,
+        "script_level.chapter": 45,
         "script_level.position": 8,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops8_2019"
+        "courseA_harvester_loops5b_2019"
       ]
     },
     {
-      "chapter": 57,
+      "chapter": 46,
       "position": 9,
       "assessment": null,
       "properties": {
@@ -1569,21 +1328,44 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops9_2019"
+          "courseA_harvester_loops6_2019"
         ],
-        "script_level.chapter": 57,
+        "script_level.chapter": 46,
         "script_level.position": 9,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops9_2019"
+        "courseA_harvester_loops6_2019"
       ]
     },
     {
-      "chapter": 58,
+      "chapter": 47,
       "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops7_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
       "assessment": null,
       "properties": {
         "progression": "Challenge",
@@ -1593,43 +1375,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops10_2019"
+          "courseA_harvester_loops9_2019"
         ],
-        "script_level.chapter": 58,
-        "script_level.position": 10,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseB_iceage_loops10_2019"
-      ]
-    },
-    {
-      "chapter": 59,
-      "position": 11,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseB_iceage_loops11_2019"
-        ],
-        "script_level.chapter": 59,
+        "script_level.chapter": 48,
         "script_level.position": 11,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops11_2019"
+        "courseA_harvester_loops9_2019"
       ]
     },
     {
-      "chapter": 60,
+      "chapter": 49,
       "position": 12,
       "assessment": null,
       "properties": {
@@ -1639,20 +1398,43 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseB_iceage_loops12_2019"
+          "courseA_harvester_loops10_2019"
         ],
-        "script_level.chapter": 60,
+        "script_level.chapter": 49,
         "script_level.position": 12,
-        "lesson.key": "Loops in Ice Age",
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseB_iceage_loops12_2019"
+        "courseA_harvester_loops10_2019"
       ]
     },
     {
-      "chapter": 61,
+      "chapter": 50,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops11_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 51,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -1664,18 +1446,18 @@
         "script_level.level_keys": [
           "courseAB_video_collector_2019"
         ],
-        "script_level.chapter": 61,
+        "script_level.chapter": 51,
         "script_level.position": 1,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseAB_video_collector_2019"
       ]
     },
     {
-      "chapter": 62,
+      "chapter": 52,
       "position": 2,
       "assessment": null,
       "properties": {
@@ -1685,20 +1467,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops1_2019"
+          "courseB_collector_loops1_2019"
         ],
-        "script_level.chapter": 62,
+        "script_level.chapter": 52,
         "script_level.position": 2,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops1_2019"
+        "courseB_collector_loops1_2019"
       ]
     },
     {
-      "chapter": 63,
+      "chapter": 53,
       "position": 3,
       "assessment": null,
       "properties": {
@@ -1708,20 +1490,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops2_2019"
+          "courseB_collector_loops2_2019"
         ],
-        "script_level.chapter": 63,
+        "script_level.chapter": 53,
         "script_level.position": 3,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops2_2019"
+        "courseB_collector_loops2_2019"
       ]
     },
     {
-      "chapter": 64,
+      "chapter": 54,
       "position": 4,
       "assessment": null,
       "properties": {
@@ -1733,18 +1515,18 @@
         "script_level.level_keys": [
           "courseA_video_Loops_2019"
         ],
-        "script_level.chapter": 64,
+        "script_level.chapter": 54,
         "script_level.position": 4,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseA_video_Loops_2019"
       ]
     },
     {
-      "chapter": 65,
+      "chapter": 55,
       "position": 5,
       "assessment": null,
       "properties": {
@@ -1754,20 +1536,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops3_2019"
+          "courseB_collector_loops3_2019"
         ],
-        "script_level.chapter": 65,
+        "script_level.chapter": 55,
         "script_level.position": 5,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops3_2019"
+        "courseB_collector_loops3_2019"
       ]
     },
     {
-      "chapter": 66,
+      "chapter": 56,
       "position": 6,
       "assessment": null,
       "properties": {
@@ -1777,20 +1559,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops4_2019"
+          "courseB_collector_loops4_2019"
         ],
-        "script_level.chapter": 66,
+        "script_level.chapter": 56,
         "script_level.position": 6,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops4_2019"
+        "courseB_collector_loops4_2019"
       ]
     },
     {
-      "chapter": 67,
+      "chapter": 57,
       "position": 7,
       "assessment": null,
       "properties": {
@@ -1800,20 +1582,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops5_2019"
+          "courseB_collector_loops5_2019"
         ],
-        "script_level.chapter": 67,
+        "script_level.chapter": 57,
         "script_level.position": 7,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops5_2019"
+        "courseB_collector_loops5_2019"
       ]
     },
     {
-      "chapter": 68,
+      "chapter": 58,
       "position": 8,
       "assessment": null,
       "properties": {
@@ -1823,20 +1605,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops6_2019"
+          "courseB_collector_loops6_2019"
         ],
-        "script_level.chapter": 68,
+        "script_level.chapter": 58,
         "script_level.position": 8,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops6_2019"
+        "courseB_collector_loops6_2019"
       ]
     },
     {
-      "chapter": 69,
+      "chapter": 59,
       "position": 9,
       "assessment": null,
       "properties": {
@@ -1846,44 +1628,21 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops7_2019"
+          "courseB_collector_loops7_2019"
         ],
-        "script_level.chapter": 69,
+        "script_level.chapter": 59,
         "script_level.position": 9,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops7_2019"
+        "courseB_collector_loops7_2019"
       ]
     },
     {
-      "chapter": 70,
+      "chapter": 60,
       "position": 10,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_collector_loops8_2019"
-        ],
-        "script_level.chapter": 70,
-        "script_level.position": 10,
-        "lesson.key": "Loops in Collector",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_collector_loops8_2019"
-      ]
-    },
-    {
-      "chapter": 71,
-      "position": 11,
       "assessment": null,
       "properties": {
         "progression": "Challenge",
@@ -1893,20 +1652,43 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops9_2019"
+          "courseB_collector_loops8_2019"
         ],
-        "script_level.chapter": 71,
-        "script_level.position": 11,
+        "script_level.chapter": 60,
+        "script_level.position": 10,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops9_2019"
+        "courseB_collector_loops8_2019"
       ]
     },
     {
-      "chapter": 72,
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 62,
       "position": 12,
       "assessment": null,
       "properties": {
@@ -1916,20 +1698,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops10_2019"
+          "courseB_collector_loops10_2019"
         ],
-        "script_level.chapter": 72,
+        "script_level.chapter": 62,
         "script_level.position": 12,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops10_2019"
+        "courseB_collector_loops10_2019"
       ]
     },
     {
-      "chapter": 73,
+      "chapter": 63,
       "position": 13,
       "assessment": null,
       "properties": {
@@ -1939,43 +1721,42 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops11_2019"
+          "courseB_collector_loops11_2019"
         ],
-        "script_level.chapter": 73,
+        "script_level.chapter": 63,
         "script_level.position": 13,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops11_2019"
+        "courseB_collector_loops11_2019"
       ]
     },
     {
-      "chapter": 74,
+      "chapter": 64,
       "position": 14,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
       },
       "named_level": null,
-      "bonus": null,
+      "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops12_2019"
+          "courseB_collector_loops_challenge1_2019"
         ],
-        "script_level.chapter": 74,
+        "script_level.chapter": 64,
         "script_level.position": 14,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops12_2019"
+        "courseB_collector_loops_challenge1_2019"
       ]
     },
     {
-      "chapter": 75,
+      "chapter": 65,
       "position": 15,
       "assessment": null,
       "properties": {
@@ -1984,42 +1765,20 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge2kp_2019"
+          "courseB_collector_loops_challenge2a_2019"
         ],
-        "script_level.chapter": 75,
+        "script_level.chapter": 65,
         "script_level.position": 15,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_collector_loops_challenge2kp_2019"
+        "courseB_collector_loops_challenge2a_2019"
       ]
     },
     {
-      "chapter": 76,
-      "position": 16,
-      "assessment": null,
-      "properties": {
-      },
-      "named_level": null,
-      "bonus": true,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_collector_loops_challenge1_2019"
-        ],
-        "script_level.chapter": 76,
-        "script_level.position": 16,
-        "lesson.key": "Loops in Collector",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_collector_loops_challenge1_2019"
-      ]
-    },
-    {
-      "chapter": 77,
+      "chapter": 66,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -2031,18 +1790,18 @@
         "script_level.level_keys": [
           "courseB_video_ArtistIntro_2019"
         ],
-        "script_level.chapter": 77,
+        "script_level.chapter": 66,
         "script_level.position": 1,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseB_video_ArtistIntro_2019"
       ]
     },
     {
-      "chapter": 78,
+      "chapter": 67,
       "position": 2,
       "assessment": null,
       "properties": {
@@ -2052,43 +1811,43 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops1_2019"
+          "courseB_artist_loops1_2019"
         ],
-        "script_level.chapter": 78,
+        "script_level.chapter": 67,
         "script_level.position": 2,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops1_2019"
+        "courseB_artist_loops1_2019"
       ]
     },
     {
-      "chapter": 79,
+      "chapter": 68,
       "position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
+        "progression": "Repeat Blocks with the Artist"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops2_2019"
+          "courseB_video_artistLoops_2019"
         ],
-        "script_level.chapter": 79,
+        "script_level.chapter": 68,
         "script_level.position": 3,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops2_2019"
+        "courseB_video_artistLoops_2019"
       ]
     },
     {
-      "chapter": 80,
+      "chapter": 69,
       "position": 4,
       "assessment": null,
       "properties": {
@@ -2098,20 +1857,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops3_2019"
+          "courseB_artist_loops2_2019"
         ],
-        "script_level.chapter": 80,
+        "script_level.chapter": 69,
         "script_level.position": 4,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops3_2019"
+        "courseB_artist_loops2_2019"
       ]
     },
     {
-      "chapter": 81,
+      "chapter": 70,
       "position": 5,
       "assessment": null,
       "properties": {
@@ -2121,20 +1880,20 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_video_loops1_2019"
+          "courseB_artist_loops3_2019"
         ],
-        "script_level.chapter": 81,
+        "script_level.chapter": 70,
         "script_level.position": 5,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_video_loops1_2019"
+        "courseB_artist_loops3_2019"
       ]
     },
     {
-      "chapter": 82,
+      "chapter": 71,
       "position": 6,
       "assessment": null,
       "properties": {
@@ -2144,43 +1903,43 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops4_2019"
+          "courseB_artist_loops4_2019"
         ],
-        "script_level.chapter": 82,
+        "script_level.chapter": 71,
         "script_level.position": 6,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops4_2019"
+        "courseB_artist_loops4_2019"
       ]
     },
     {
-      "chapter": 83,
+      "chapter": 72,
       "position": 7,
       "assessment": null,
       "properties": {
-        "progression": "Repeat Blocks with the Artist"
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops5_2019"
+          "courseB_artist_loops5_2019"
         ],
-        "script_level.chapter": 83,
+        "script_level.chapter": 72,
         "script_level.position": 7,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops5_2019"
+        "courseB_artist_loops5_2019"
       ]
     },
     {
-      "chapter": 84,
+      "chapter": 73,
       "position": 8,
       "assessment": null,
       "properties": {
@@ -2190,67 +1949,21 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops6_2019"
+          "courseB_artist_loops6_2019"
         ],
-        "script_level.chapter": 84,
+        "script_level.chapter": 73,
         "script_level.position": 8,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops6_2019"
+        "courseB_artist_loops6_2019"
       ]
     },
     {
-      "chapter": 85,
+      "chapter": 74,
       "position": 9,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_artist_loops7_2019"
-        ],
-        "script_level.chapter": 85,
-        "script_level.position": 9,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_artist_loops7_2019"
-      ]
-    },
-    {
-      "chapter": 86,
-      "position": 10,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_artist_loops8_2019"
-        ],
-        "script_level.chapter": 86,
-        "script_level.position": 10,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_artist_loops8_2019"
-      ]
-    },
-    {
-      "chapter": 87,
-      "position": 11,
       "assessment": null,
       "properties": {
         "progression": "Challenge",
@@ -2260,67 +1973,67 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops9_2019"
+          "courseB_artist_loops7_2019"
         ],
-        "script_level.chapter": 87,
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2019"
+        ],
+        "script_level.chapter": 76,
         "script_level.position": 11,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops9_2019"
+        "courseB_artist_loops9_2019"
       ]
     },
     {
-      "chapter": 88,
+      "chapter": 77,
       "position": 12,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_artist_loops10_2019"
-        ],
-        "script_level.chapter": 88,
-        "script_level.position": 12,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_artist_loops10_2019"
-      ]
-    },
-    {
-      "chapter": 89,
-      "position": 13,
-      "assessment": null,
-      "properties": {
-        "progression": "Practice"
-      },
-      "named_level": null,
-      "bonus": null,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_artist_loops11_2019"
-        ],
-        "script_level.chapter": 89,
-        "script_level.position": 13,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_artist_loops11_2019"
-      ]
-    },
-    {
-      "chapter": 90,
-      "position": 14,
       "assessment": null,
       "properties": {
         "progression": "Free Play"
@@ -2329,64 +2042,86 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops12_2019"
+          "courseB_artist_loops10_2019"
         ],
-        "script_level.chapter": 90,
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 79,
         "script_level.position": 14,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops12_2019"
+        "courseB_artist_loops_challenge2_2019"
       ]
     },
     {
-      "chapter": 91,
-      "position": 15,
+      "chapter": 80,
+      "position": 1,
       "assessment": null,
       "properties": {
       },
       "named_level": null,
-      "bonus": true,
+      "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_artist_loops_challenge2a_2019"
+          "TheRightAppMarkdownLevel_2019"
         ],
-        "script_level.chapter": 91,
-        "script_level.position": 15,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_artist_loops_challenge2a_2019"
+        "TheRightAppMarkdownLevel_2019"
       ]
     },
     {
-      "chapter": 92,
-      "position": 16,
-      "assessment": null,
-      "properties": {
-      },
-      "named_level": null,
-      "bonus": true,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "courseA_artist_loops_challenge1_2019"
-        ],
-        "script_level.chapter": 92,
-        "script_level.position": 16,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      },
-      "level_keys": [
-        "courseA_artist_loops_challenge1_2019"
-      ]
-    },
-    {
-      "chapter": 93,
+      "chapter": 81,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -2397,18 +2132,18 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged"
         ],
-        "script_level.chapter": 93,
+        "script_level.chapter": 81,
         "script_level.position": 1,
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "BigEvent-Unplugged"
       ]
     },
     {
-      "chapter": 94,
+      "chapter": 82,
       "position": 1,
       "assessment": null,
       "properties": {
@@ -2420,18 +2155,18 @@
         "script_level.level_keys": [
           "courseA_video_events_2019"
         ],
-        "script_level.chapter": 94,
+        "script_level.chapter": 82,
         "script_level.position": 1,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
         "courseA_video_events_2019"
       ]
     },
     {
-      "chapter": 95,
+      "chapter": 83,
       "position": 2,
       "assessment": null,
       "properties": {
@@ -2441,180 +2176,181 @@
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events1_2019"
+          "courseB_playLab_events1_2019"
         ],
-        "script_level.chapter": 95,
+        "script_level.chapter": 83,
         "script_level.position": 2,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events1_2019"
+        "courseB_playLab_events1_2019"
       ]
     },
     {
-      "chapter": 96,
+      "chapter": 84,
       "position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Practice"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events2_2019"
+          "courseB_playlab_events2_2019"
         ],
-        "script_level.chapter": 96,
+        "script_level.chapter": 84,
         "script_level.position": 3,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events2_2019"
+        "courseB_playlab_events2_2019"
       ]
     },
     {
-      "chapter": 97,
+      "chapter": 85,
       "position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Mini-project: Jorge the Dog"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events3_2019"
+          "courseB_playlab_events3_2019"
         ],
-        "script_level.chapter": 97,
+        "script_level.chapter": 85,
         "script_level.position": 4,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events3_2019"
+        "courseB_playlab_events3_2019"
       ]
     },
     {
-      "chapter": 98,
+      "chapter": 86,
       "position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Mini-project: Jorge the Dog"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events4_2019"
+          "courseB_playlab_events4_2019"
         ],
-        "script_level.chapter": 98,
+        "script_level.chapter": 86,
         "script_level.position": 5,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events4_2019"
+        "courseB_playlab_events4_2019"
       ]
     },
     {
-      "chapter": 99,
+      "chapter": 87,
       "position": 6,
       "assessment": null,
       "properties": {
-        "progression": "Mini-project: Jorge the Dog"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events5_2019"
+          "courseB_playlab_events5_2019"
         ],
-        "script_level.chapter": 99,
+        "script_level.chapter": 87,
         "script_level.position": 6,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events5_2019"
+        "courseB_playlab_events5_2019"
       ]
     },
     {
-      "chapter": 100,
+      "chapter": 88,
       "position": 7,
       "assessment": null,
       "properties": {
-        "progression": "Mini-project: Jorge the Dog"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events6_2019"
+          "courseB_playlab_events6_2019"
         ],
-        "script_level.chapter": 100,
+        "script_level.chapter": 88,
         "script_level.position": 7,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events6_2019"
+        "courseB_playlab_events6_2019"
       ]
     },
     {
-      "chapter": 101,
+      "chapter": 89,
       "position": 8,
       "assessment": null,
       "properties": {
-        "progression": "Mini-project: Jorge the Dog"
+        "progression": "Mini-Project: Royal Battle"
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playLab_events7_2019"
+          "courseB_playlab_events7_2019"
         ],
-        "script_level.chapter": 101,
+        "script_level.chapter": 89,
         "script_level.position": 8,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playLab_events7_2019"
+        "courseB_playlab_events7_2019"
       ]
     },
     {
-      "chapter": 102,
+      "chapter": 90,
       "position": 9,
       "assessment": null,
       "properties": {
+        "progression": "Free Play"
       },
       "named_level": null,
-      "bonus": true,
+      "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge2_2019"
+          "courseB_playlab_eventsFP_2019"
         ],
-        "script_level.chapter": 102,
+        "script_level.chapter": 90,
         "script_level.position": 9,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playlab_events_challenge2_2019"
+        "courseB_playlab_eventsFP_2019"
       ]
     },
     {
-      "chapter": 103,
+      "chapter": 91,
       "position": 10,
       "assessment": null,
       "properties": {
@@ -2623,200 +2359,66 @@
       "bonus": true,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge1_2019"
+          "courseB_playlab_events_challenge1_2019"
         ],
-        "script_level.chapter": 103,
+        "script_level.chapter": 91,
         "script_level.position": 10,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       },
       "level_keys": [
-        "courseA_playlab_events_challenge1_2019"
+        "courseB_playlab_events_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2019"
       ]
     }
   ],
   "levels_script_levels": [
     {
       "seeding_key": {
-        "level.key": "GoingPlacesSafely-unplugged",
+        "level.key": "DigitalFootprint-Unplugged",
         "script_level.level_keys": [
-          "GoingPlacesSafely-unplugged"
+          "DigitalFootprint-Unplugged"
         ],
         "script_level.chapter": 1,
         "script_level.position": 1,
-        "lesson.key": "Going Places Safely",
+        "lesson.key": "Your Digital Footprint",
         "lesson_group.key": "csf_digcit",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "blockly:Jigsaw:1",
+        "level.key": "MoveItMoveIt-Unplugged",
         "script_level.level_keys": [
-          "blockly:Jigsaw:1"
+          "MoveItMoveIt-Unplugged"
         ],
         "script_level.chapter": 2,
         "script_level.position": 1,
-        "lesson.key": "Learn to Drag and Drop",
+        "lesson.key": "Move It, Move It",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:2",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:2"
-        ],
-        "script_level.chapter": 3,
-        "script_level.position": 2,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:3",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:3"
-        ],
-        "script_level.chapter": 4,
-        "script_level.position": 3,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:4",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:4"
-        ],
-        "script_level.chapter": 5,
-        "script_level.position": 4,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:5",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:5"
-        ],
-        "script_level.chapter": 6,
-        "script_level.position": 5,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:6",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:6"
-        ],
-        "script_level.chapter": 7,
-        "script_level.position": 6,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:7",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:7"
-        ],
-        "script_level.chapter": 8,
-        "script_level.position": 7,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:8",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:8"
-        ],
-        "script_level.chapter": 9,
-        "script_level.position": 8,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:9",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:9"
-        ],
-        "script_level.chapter": 10,
-        "script_level.position": 9,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:10",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:10"
-        ],
-        "script_level.chapter": 11,
-        "script_level.position": 10,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:11",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:11"
-        ],
-        "script_level.chapter": 12,
-        "script_level.position": 11,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "blockly:Jigsaw:12",
-        "script_level.level_keys": [
-          "blockly:Jigsaw:12"
-        ],
-        "script_level.chapter": 13,
-        "script_level.position": 12,
-        "lesson.key": "Learn to Drag and Drop",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "HappyMaps-Unplugged",
-        "script_level.level_keys": [
-          "HappyMaps-Unplugged"
-        ],
-        "script_level.chapter": 14,
-        "script_level.position": 1,
-        "lesson.key": "Programming: Happy Maps",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -2825,89 +2427,89 @@
         "script_level.level_keys": [
           "courseAB_video_NewIntro_2019"
         ],
-        "script_level.chapter": 15,
+        "script_level.chapter": 3,
         "script_level.position": 1,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp1_2019",
+        "level.key": "coursea_maze_ramp1_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp1_2019"
+          "coursea_maze_ramp1_2019"
         ],
-        "script_level.chapter": 16,
+        "script_level.chapter": 4,
         "script_level.position": 2,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp2_2019",
+        "level.key": "courseA_maze_ramp2_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp2_2019"
+          "courseA_maze_ramp2_2019"
         ],
-        "script_level.chapter": 17,
+        "script_level.chapter": 5,
         "script_level.position": 3,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp3a_2019",
+        "level.key": "courseA_maze_ramp3a_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3a_2019"
+          "courseA_maze_ramp3a_2019"
         ],
-        "script_level.chapter": 18,
+        "script_level.chapter": 6,
         "script_level.position": 4,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp3b_2019",
+        "level.key": "courseA_maze_ramp3b_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp3b_2019"
+          "courseA_maze_ramp3b_2019"
         ],
-        "script_level.chapter": 19,
+        "script_level.chapter": 7,
         "script_level.position": 5,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp4a_2019",
+        "level.key": "courseA_maze_ramp4a_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp4a_2019"
+          "courseA_maze_ramp4a_2019"
         ],
-        "script_level.chapter": 20,
+        "script_level.chapter": 8,
         "script_level.position": 6,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_Scrat_ramp5a_2019",
+        "level.key": "courseA_maze_ramp5a_2019",
         "script_level.level_keys": [
-          "courseB_Scrat_ramp5a_2019"
+          "courseA_maze_ramp5a_2019"
         ],
-        "script_level.chapter": 21,
+        "script_level.chapter": 9,
         "script_level.position": 7,
-        "lesson.key": "Sequencing with Scrat",
+        "lesson.key": "Sequencing in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -2916,63 +2518,206 @@
         "script_level.level_keys": [
           "elementary_video_pairProgramming_2019"
         ],
-        "script_level.chapter": 22,
+        "script_level.chapter": 10,
         "script_level.position": 1,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Maze",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq1_2019",
+        "level.key": "courseA_maze_seq1_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq1_2019"
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_intro_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq1_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2019"
         ],
         "script_level.chapter": 23,
         "script_level.position": 2,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq4_2019",
+        "level.key": "courseA_harvester_seq2_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq4_2019"
+          "courseA_harvester_seq2_2019"
         ],
         "script_level.chapter": 24,
         "script_level.position": 3,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq5_2019",
+        "level.key": "courseA_harvester_seq3_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq5_2019"
+          "courseA_harvester_seq3_2019"
         ],
         "script_level.chapter": 25,
         "script_level.position": 4,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_maze_seq6_2019",
-        "script_level.level_keys": [
-          "courseB_maze_seq6_2019"
-        ],
-        "script_level.chapter": 26,
-        "script_level.position": 5,
-        "lesson.key": "Programming in Ice Age",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -2981,440 +2726,323 @@
         "script_level.level_keys": [
           "courseAB_video_debugging_2019"
         ],
-        "script_level.chapter": 27,
-        "script_level.position": 6,
-        "lesson.key": "Programming in Ice Age",
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq7_2019",
+        "level.key": "courseA_harvester_seq4_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq7_2019"
+          "courseA_harvester_seq4_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq5_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2019"
         ],
         "script_level.chapter": 28,
         "script_level.position": 7,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq8_2019",
+        "level.key": "courseA_harvester_seq6_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq8_2019"
+          "courseA_harvester_seq6_2019"
         ],
         "script_level.chapter": 29,
         "script_level.position": 8,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq9_2019",
+        "level.key": "courseA_harvester_seq7_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq9_2019"
+          "courseA_harvester_seq7_2019"
         ],
         "script_level.chapter": 30,
         "script_level.position": 9,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq10_2019",
+        "level.key": "courseA_harvester_seq8_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq10_2019"
+          "courseA_harvester_seq8_2019"
         ],
         "script_level.chapter": 31,
         "script_level.position": 10,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq11_2019",
+        "level.key": "courseA_harvester_seq9_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq11_2019"
+          "courseA_harvester_seq9_2019"
         ],
         "script_level.chapter": 32,
         "script_level.position": 11,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq12_2019",
+        "level.key": "courseA_harvester_seq10_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq12_2019"
+          "courseA_harvester_seq10_2019"
         ],
         "script_level.chapter": 33,
         "script_level.position": 12,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq_challenge1_2019",
+        "level.key": "courseA_harvester_seq12_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge1_2019"
+          "courseA_harvester_seq12_2019"
         ],
         "script_level.chapter": 34,
         "script_level.position": 13,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_maze_seq_challenge2_2019",
+        "level.key": "courseA_harvester_seq11_2019",
         "script_level.level_keys": [
-          "courseB_maze_seq_challenge2_2019"
+          "courseA_harvester_seq11_2019"
         ],
         "script_level.chapter": 35,
         "script_level.position": 14,
-        "lesson.key": "Programming in Ice Age",
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "bb8_skinOverview_K-1_video_2019",
+        "level.key": "courseA_harvester_seq13_2019",
         "script_level.level_keys": [
-          "bb8_skinOverview_K-1_video_2019"
+          "courseA_harvester_seq13_2019"
         ],
         "script_level.chapter": 36,
-        "script_level.position": 1,
-        "lesson.key": "Programming with Rey and BB-8",
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
         "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog1_2019",
+        "level.key": "GettingLoopy-Unplugged",
         "script_level.level_keys": [
-          "courseB_starWars_prog1_2019"
+          "GettingLoopy-Unplugged"
         ],
         "script_level.chapter": 37,
-        "script_level.position": 2,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog2_2019",
+        "level.key": "courseA_harvester_loops1_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog2_2019"
+          "courseA_harvester_loops1_2019"
         ],
         "script_level.chapter": 38,
-        "script_level.position": 3,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog3_2019",
+        "level.key": "courseA_harvester_loops2_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog3_2019"
+          "courseA_harvester_loops2_2019"
         ],
         "script_level.chapter": 39,
-        "script_level.position": 4,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog4_2019",
+        "level.key": "courseA_harvester_loops_video_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog4_2019"
+          "courseA_harvester_loops_video_2019"
         ],
         "script_level.chapter": 40,
-        "script_level.position": 5,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog5_2019",
+        "level.key": "courseA_harvester_loops3_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog5_2019"
+          "courseA_harvester_loops3_2019"
         ],
         "script_level.chapter": 41,
-        "script_level.position": 6,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog6_2019",
+        "level.key": "courseA_harvester_loops4_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog6_2019"
+          "courseA_harvester_loops4_2019"
         ],
         "script_level.chapter": 42,
-        "script_level.position": 7,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog7_2019",
+        "level.key": "courseA_harvester_loops5_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog7_2019"
+          "courseA_harvester_loops5_2019"
         ],
         "script_level.chapter": 43,
-        "script_level.position": 8,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog8_2019",
+        "level.key": "courseA_harvester_loops5a_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog8_2019"
+          "courseA_harvester_loops5a_2019"
         ],
         "script_level.chapter": 44,
-        "script_level.position": 9,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog9_2019",
+        "level.key": "courseA_harvester_loops5b_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog9_2019"
+          "courseA_harvester_loops5b_2019"
         ],
         "script_level.chapter": 45,
-        "script_level.position": 10,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog10_2019",
+        "level.key": "courseA_harvester_loops6_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog10_2019"
+          "courseA_harvester_loops6_2019"
         ],
         "script_level.chapter": 46,
-        "script_level.position": 11,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_starWars_prog11_2019",
+        "level.key": "courseA_harvester_loops7_2019",
         "script_level.level_keys": [
-          "courseB_starWars_prog11_2019"
+          "courseA_harvester_loops7_2019"
         ],
         "script_level.chapter": 47,
-        "script_level.position": 12,
-        "lesson.key": "Programming with Rey and BB-8",
-        "lesson_group.key": "csf_sequencing",
-        "script.name": "coursea-2019"
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "HappyLoops-Unplugged",
+        "level.key": "courseA_harvester_loops9_2019",
         "script_level.level_keys": [
-          "HappyLoops-Unplugged"
+          "courseA_harvester_loops9_2019"
         ],
         "script_level.chapter": 48,
-        "script_level.position": 1,
-        "lesson.key": "Loops: Happy Loops",
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops1_2019",
+        "level.key": "courseA_harvester_loops10_2019",
         "script_level.level_keys": [
-          "courseB_iceage_loops1_2019"
+          "courseA_harvester_loops10_2019"
         ],
         "script_level.chapter": 49,
-        "script_level.position": 1,
-        "lesson.key": "Loops in Ice Age",
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseB_iceage_loops2_2019",
+        "level.key": "courseA_harvester_loops11_2019",
         "script_level.level_keys": [
-          "courseB_iceage_loops2_2019"
+          "courseA_harvester_loops11_2019"
         ],
         "script_level.chapter": 50,
-        "script_level.position": 2,
-        "lesson.key": "Loops in Ice Age",
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops_video_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops_video_2019"
-        ],
-        "script_level.chapter": 51,
-        "script_level.position": 3,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops3_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops3_2019"
-        ],
-        "script_level.chapter": 52,
-        "script_level.position": 4,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops4_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops4_2019"
-        ],
-        "script_level.chapter": 53,
-        "script_level.position": 5,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops6_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops6_2019"
-        ],
-        "script_level.chapter": 54,
-        "script_level.position": 6,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops7_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops7_2019"
-        ],
-        "script_level.chapter": 55,
-        "script_level.position": 7,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops8_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops8_2019"
-        ],
-        "script_level.chapter": 56,
-        "script_level.position": 8,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops9_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops9_2019"
-        ],
-        "script_level.chapter": 57,
-        "script_level.position": 9,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops10_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops10_2019"
-        ],
-        "script_level.chapter": 58,
-        "script_level.position": 10,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops11_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops11_2019"
-        ],
-        "script_level.chapter": 59,
-        "script_level.position": 11,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseB_iceage_loops12_2019",
-        "script_level.level_keys": [
-          "courseB_iceage_loops12_2019"
-        ],
-        "script_level.chapter": 60,
-        "script_level.position": 12,
-        "lesson.key": "Loops in Ice Age",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -3423,37 +3051,37 @@
         "script_level.level_keys": [
           "courseAB_video_collector_2019"
         ],
-        "script_level.chapter": 61,
+        "script_level.chapter": 51,
         "script_level.position": 1,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops1_2019",
+        "level.key": "courseB_collector_loops1_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops1_2019"
+          "courseB_collector_loops1_2019"
         ],
-        "script_level.chapter": 62,
+        "script_level.chapter": 52,
         "script_level.position": 2,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops2_2019",
+        "level.key": "courseB_collector_loops2_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops2_2019"
+          "courseB_collector_loops2_2019"
         ],
-        "script_level.chapter": 63,
+        "script_level.chapter": 53,
         "script_level.position": 3,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -3462,167 +3090,154 @@
         "script_level.level_keys": [
           "courseA_video_Loops_2019"
         ],
-        "script_level.chapter": 64,
+        "script_level.chapter": 54,
         "script_level.position": 4,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops3_2019",
+        "level.key": "courseB_collector_loops3_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops3_2019"
+          "courseB_collector_loops3_2019"
         ],
-        "script_level.chapter": 65,
+        "script_level.chapter": 55,
         "script_level.position": 5,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops4_2019",
+        "level.key": "courseB_collector_loops4_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops4_2019"
+          "courseB_collector_loops4_2019"
         ],
-        "script_level.chapter": 66,
+        "script_level.chapter": 56,
         "script_level.position": 6,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops5_2019",
+        "level.key": "courseB_collector_loops5_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops5_2019"
+          "courseB_collector_loops5_2019"
         ],
-        "script_level.chapter": 67,
+        "script_level.chapter": 57,
         "script_level.position": 7,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops6_2019",
+        "level.key": "courseB_collector_loops6_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops6_2019"
+          "courseB_collector_loops6_2019"
         ],
-        "script_level.chapter": 68,
+        "script_level.chapter": 58,
         "script_level.position": 8,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops7_2019",
+        "level.key": "courseB_collector_loops7_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops7_2019"
+          "courseB_collector_loops7_2019"
         ],
-        "script_level.chapter": 69,
+        "script_level.chapter": 59,
         "script_level.position": 9,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops8_2019",
+        "level.key": "courseB_collector_loops8_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops8_2019"
+          "courseB_collector_loops8_2019"
         ],
-        "script_level.chapter": 70,
+        "script_level.chapter": 60,
         "script_level.position": 10,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops9_2019",
+        "level.key": "courseB_collector_loops9_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops9_2019"
+          "courseB_collector_loops9_2019"
         ],
-        "script_level.chapter": 71,
+        "script_level.chapter": 61,
         "script_level.position": 11,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops10_2019",
+        "level.key": "courseB_collector_loops10_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops10_2019"
+          "courseB_collector_loops10_2019"
         ],
-        "script_level.chapter": 72,
+        "script_level.chapter": 62,
         "script_level.position": 12,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops11_2019",
+        "level.key": "courseB_collector_loops11_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops11_2019"
+          "courseB_collector_loops11_2019"
         ],
-        "script_level.chapter": 73,
+        "script_level.chapter": 63,
         "script_level.position": 13,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops12_2019",
+        "level.key": "courseB_collector_loops_challenge1_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops12_2019"
+          "courseB_collector_loops_challenge1_2019"
         ],
-        "script_level.chapter": 74,
+        "script_level.chapter": 64,
         "script_level.position": 14,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_collector_loops_challenge2kp_2019",
+        "level.key": "courseB_collector_loops_challenge2a_2019",
         "script_level.level_keys": [
-          "courseA_collector_loops_challenge2kp_2019"
+          "courseB_collector_loops_challenge2a_2019"
         ],
-        "script_level.chapter": 75,
+        "script_level.chapter": 65,
         "script_level.position": 15,
         "lesson.key": "Loops in Collector",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_collector_loops_challenge1_2019",
-        "script_level.level_keys": [
-          "courseA_collector_loops_challenge1_2019"
-        ],
-        "script_level.chapter": 76,
-        "script_level.position": 16,
-        "lesson.key": "Loops in Collector",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -3631,206 +3246,193 @@
         "script_level.level_keys": [
           "courseB_video_ArtistIntro_2019"
         ],
-        "script_level.chapter": 77,
+        "script_level.chapter": 66,
         "script_level.position": 1,
-        "lesson.key": "Ocean Scene with Loops",
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops1_2019",
+        "level.key": "courseB_artist_loops1_2019",
         "script_level.level_keys": [
-          "courseA_artist_loops1_2019"
+          "courseB_artist_loops1_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2019",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2019"
         ],
         "script_level.chapter": 78,
-        "script_level.position": 2,
-        "lesson.key": "Ocean Scene with Loops",
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops2_2019",
+        "level.key": "courseB_artist_loops_challenge2_2019",
         "script_level.level_keys": [
-          "courseA_artist_loops2_2019"
+          "courseB_artist_loops_challenge2_2019"
         ],
         "script_level.chapter": 79,
-        "script_level.position": 3,
-        "lesson.key": "Ocean Scene with Loops",
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
         "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_artist_loops3_2019",
+        "level.key": "TheRightAppMarkdownLevel_2019",
         "script_level.level_keys": [
-          "courseA_artist_loops3_2019"
+          "TheRightAppMarkdownLevel_2019"
         ],
         "script_level.chapter": 80,
-        "script_level.position": 4,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_video_loops1_2019",
-        "script_level.level_keys": [
-          "courseA_video_loops1_2019"
-        ],
-        "script_level.chapter": 81,
-        "script_level.position": 5,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops4_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops4_2019"
-        ],
-        "script_level.chapter": 82,
-        "script_level.position": 6,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops5_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops5_2019"
-        ],
-        "script_level.chapter": 83,
-        "script_level.position": 7,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops6_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops6_2019"
-        ],
-        "script_level.chapter": 84,
-        "script_level.position": 8,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops7_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops7_2019"
-        ],
-        "script_level.chapter": 85,
-        "script_level.position": 9,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops8_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops8_2019"
-        ],
-        "script_level.chapter": 86,
-        "script_level.position": 10,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops9_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops9_2019"
-        ],
-        "script_level.chapter": 87,
-        "script_level.position": 11,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops10_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops10_2019"
-        ],
-        "script_level.chapter": 88,
-        "script_level.position": 12,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops11_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops11_2019"
-        ],
-        "script_level.chapter": 89,
-        "script_level.position": 13,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops12_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops12_2019"
-        ],
-        "script_level.chapter": 90,
-        "script_level.position": 14,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops_challenge2a_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops_challenge2a_2019"
-        ],
-        "script_level.chapter": 91,
-        "script_level.position": 15,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "courseA_artist_loops_challenge1_2019",
-        "script_level.level_keys": [
-          "courseA_artist_loops_challenge1_2019"
-        ],
-        "script_level.chapter": 92,
-        "script_level.position": 16,
-        "lesson.key": "Ocean Scene with Loops",
-        "lesson_group.key": "csf_loops",
-        "script.name": "coursea-2019"
+        "script_level.position": 1,
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -3839,11 +3441,11 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged"
         ],
-        "script_level.chapter": 93,
+        "script_level.chapter": 81,
         "script_level.position": 1,
         "lesson.key": "Events: The Big Event",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
@@ -3852,128 +3454,141 @@
         "script_level.level_keys": [
           "courseA_video_events_2019"
         ],
-        "script_level.chapter": 94,
+        "script_level.chapter": 82,
         "script_level.position": 1,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events1_2019",
+        "level.key": "courseB_playLab_events1_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events1_2019"
+          "courseB_playLab_events1_2019"
         ],
-        "script_level.chapter": 95,
+        "script_level.chapter": 83,
         "script_level.position": 2,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events2_2019",
+        "level.key": "courseB_playlab_events2_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events2_2019"
+          "courseB_playlab_events2_2019"
         ],
-        "script_level.chapter": 96,
+        "script_level.chapter": 84,
         "script_level.position": 3,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events3_2019",
+        "level.key": "courseB_playlab_events3_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events3_2019"
+          "courseB_playlab_events3_2019"
         ],
-        "script_level.chapter": 97,
+        "script_level.chapter": 85,
         "script_level.position": 4,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events4_2019",
+        "level.key": "courseB_playlab_events4_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events4_2019"
+          "courseB_playlab_events4_2019"
         ],
-        "script_level.chapter": 98,
+        "script_level.chapter": 86,
         "script_level.position": 5,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events5_2019",
+        "level.key": "courseB_playlab_events5_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events5_2019"
+          "courseB_playlab_events5_2019"
         ],
-        "script_level.chapter": 99,
+        "script_level.chapter": 87,
         "script_level.position": 6,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events6_2019",
+        "level.key": "courseB_playlab_events6_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events6_2019"
+          "courseB_playlab_events6_2019"
         ],
-        "script_level.chapter": 100,
+        "script_level.chapter": 88,
         "script_level.position": 7,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playLab_events7_2019",
+        "level.key": "courseB_playlab_events7_2019",
         "script_level.level_keys": [
-          "courseA_playLab_events7_2019"
+          "courseB_playlab_events7_2019"
         ],
-        "script_level.chapter": 101,
+        "script_level.chapter": 89,
         "script_level.position": 8,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playlab_events_challenge2_2019",
+        "level.key": "courseB_playlab_eventsFP_2019",
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge2_2019"
+          "courseB_playlab_eventsFP_2019"
         ],
-        "script_level.chapter": 102,
+        "script_level.chapter": 90,
         "script_level.position": 9,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
       }
     },
     {
       "seeding_key": {
-        "level.key": "courseA_playlab_events_challenge1_2019",
+        "level.key": "courseB_playlab_events_challenge1_2019",
         "script_level.level_keys": [
-          "courseA_playlab_events_challenge1_2019"
+          "courseB_playlab_events_challenge1_2019"
         ],
-        "script_level.chapter": 103,
+        "script_level.chapter": 91,
         "script_level.position": 10,
         "lesson.key": "Events in Play Lab",
         "lesson_group.key": "csf_events",
-        "script.name": "coursea-2019"
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2019"
       }
     }
   ]

--- a/dashboard/config/scripts_json/courseb-2020.script_json
+++ b/dashboard/config/scripts_json/courseb-2020.script_json
@@ -1,0 +1,3600 @@
+{
+  "script": {
+    "name": "courseb-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/courseb/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course B!",
+          "link": "https://curriculum.code.org/csf-20/courseb",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/courseb/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/courseb/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/courseb/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "courseb",
+    "seeding_key": {
+      "script.name": "courseb-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Digital Trails",
+      "name": "Digital Trails",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Trails",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Move It, Move It",
+      "name": "Move It, Move It",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Sequencing in Maze",
+      "name": "Sequencing with Angry Birds",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Programming in Harvester",
+      "name": "Programming with Harvester",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Loops: Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Loops with Harvester",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Gardens with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "The Right App",
+      "name": "The Right App",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event Jr.",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "A Royal Battle with Events",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csf_digital_trails"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Trails",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "csf_digital_trails"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MoveItMoveIt-Unplugged_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "MoveItMoveIt-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursea_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "coursea_maze_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_ramp2_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp3a_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_ramp3a_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp3b_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_ramp3b_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp4a_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_ramp4a_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_ramp5a_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_ramp5a_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Pair Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_intro_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq1_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq2_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq3_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq4_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq5_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq6_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq7_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq8_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq9_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq10_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq12_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq11_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq13_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy-Unplugged_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "GettingLoopy-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops1_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops2_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops_video_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops_video_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops3_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops4_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5a_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5a_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops5b_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops5b_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops6_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops7_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops9_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops10_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_loops11_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Collector"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Repeat Block"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Artist in Code Studio"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Blocks with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TheRightAppMarkdownLevel_2019_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "TheRightAppMarkdownLevel_2019_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "BigEvent-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create a Story"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseA_video_events_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playLab_events1_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events2_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events3_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events4_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events5_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Royal Battle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csf_digital_trails",
+        "script_level.level_keys": [
+          "csf_digital_trails"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Trails",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MoveItMoveIt-Unplugged_2020",
+        "script_level.level_keys": [
+          "MoveItMoveIt-Unplugged_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2020",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursea_maze_ramp1_2020",
+        "script_level.level_keys": [
+          "coursea_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp2_2020",
+        "script_level.level_keys": [
+          "courseA_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp3a_2020",
+        "script_level.level_keys": [
+          "courseA_maze_ramp3a_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp3b_2020",
+        "script_level.level_keys": [
+          "courseA_maze_ramp3b_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp4a_2020",
+        "script_level.level_keys": [
+          "courseA_maze_ramp4a_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_ramp5a_2020",
+        "script_level.level_keys": [
+          "courseA_maze_ramp5a_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2020",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_intro_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq1_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq2_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq3_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq4_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq5_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq6_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq7_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq8_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq9_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq10_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq12_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq11_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq13_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy-Unplugged_2020",
+        "script_level.level_keys": [
+          "GettingLoopy-Unplugged_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops1_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops1_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops2_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops2_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops_video_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops_video_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops3_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops3_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops4_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops4_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5a_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5a_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops5b_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops5b_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops6_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops6_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops7_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops7_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops9_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops9_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops10_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops10_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_loops11_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_loops11_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2020",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2020",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2020",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2020",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TheRightAppMarkdownLevel_2019_2020",
+        "script_level.level_keys": [
+          "TheRightAppMarkdownLevel_2019_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "The Right App",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent-Unplugged_2020",
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2020",
+        "script_level.level_keys": [
+          "courseA_video_events_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1_2020",
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "courseb-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/courseb-draft.script_json
+++ b/dashboard/config/scripts_json/courseb-draft.script_json
@@ -1,0 +1,4130 @@
+{
+  "script": {
+    "name": "courseb-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "courseb-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Marbles",
+      "name": "Persistence & Frustration: Stevie and the Marbles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Learn to Drag and Drop",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Your Digital Footprint",
+      "name": "Your Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops in Collector",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs10"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs11"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs12"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs13"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs14"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs15"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs16"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs17"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_story_unspottedBugs18"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_video_Stevie"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie6"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie9"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie10"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie11"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie12"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie12a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie12a"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie13"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie14"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 17,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie15"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_external_stevie16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 18,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_external_stevie16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradek1_activity_beNice"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "gradek1_activity_beNice"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:13"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "DigitalFootprint"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_external_MRF"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_external_MRF"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_video_debuggingOrg"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq4"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq9"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq11"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq12"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_external_loopMRF"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_external_loopMRF"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops2"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops9"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops10"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops11"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops10"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseA_video_events"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playLab_events1"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events3"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events5"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events6"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events7"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs1",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs2",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs3",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs4",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs5",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs6",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs7",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs8",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs9",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs10",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs11",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs12",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs13",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs14",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs15",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs16",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs16"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs17",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs17"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_story_unspottedBugs18",
+        "script_level.level_keys": [
+          "courseB_story_unspottedBugs18"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie",
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie1",
+        "script_level.level_keys": [
+          "courseA_external_stevie1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie2",
+        "script_level.level_keys": [
+          "courseA_external_stevie2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie3",
+        "script_level.level_keys": [
+          "courseA_external_stevie3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie4",
+        "script_level.level_keys": [
+          "courseA_external_stevie4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie5",
+        "script_level.level_keys": [
+          "courseA_external_stevie5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie6",
+        "script_level.level_keys": [
+          "courseA_external_stevie6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie7",
+        "script_level.level_keys": [
+          "courseA_external_stevie7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie8",
+        "script_level.level_keys": [
+          "courseA_external_stevie8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie9",
+        "script_level.level_keys": [
+          "courseA_external_stevie9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie10",
+        "script_level.level_keys": [
+          "courseA_external_stevie10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie11",
+        "script_level.level_keys": [
+          "courseA_external_stevie11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie12",
+        "script_level.level_keys": [
+          "courseA_external_stevie12"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie12a",
+        "script_level.level_keys": [
+          "courseA_external_stevie12a"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie13",
+        "script_level.level_keys": [
+          "courseA_external_stevie13"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie14",
+        "script_level.level_keys": [
+          "courseA_external_stevie14"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie15",
+        "script_level.level_keys": [
+          "courseA_external_stevie15"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 17,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_external_stevie16",
+        "script_level.level_keys": [
+          "courseA_external_stevie16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 18,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradek1_activity_beNice",
+        "script_level.level_keys": [
+          "gradek1_activity_beNice"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:13",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint",
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_external_MRF",
+        "script_level.level_keys": [
+          "courseB_external_MRF"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1",
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_debuggingOrg",
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq2",
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq3",
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq4",
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq5",
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq6",
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq7",
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq8",
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq9",
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10",
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq11",
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq12",
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_external_loopMRF",
+        "script_level.level_keys": [
+          "courseB_external_loopMRF"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1",
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2",
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3",
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4",
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5",
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6",
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7",
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8",
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9",
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10",
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11",
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1",
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2",
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3",
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4",
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5",
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6",
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7",
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8",
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9",
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10",
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events",
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1",
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2",
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3",
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4",
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5",
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6",
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7",
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "courseb-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursec-2017.script_json
+++ b/dashboard/config/scripts_json/coursec-2017.script_json
@@ -1,0 +1,4512 @@
+{
+  "script": {
+    "name": "coursec-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/coursec/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "ar-SA",
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN",
+        "zh-TW"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "coursec-2017",
+    "family_name": "coursec",
+    "seeding_key": {
+      "script.name": "coursec-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Building a Foundation",
+      "name": "Persistence: Building a Foundation",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging in Maze",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Paper Planes",
+      "name": "Real-life Algorithms: Paper Planes",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Programming in Collector",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Loops: Getting Loopy",
+      "name": "Loops: Getting Loopy",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Loops in Harvester",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Screen Out the Mean",
+      "name": "Digital Citizenship: Screen Out the Mean",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Beyond Programming: Binary Bracelets",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_video_maze"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "PaperPlanes"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_video_collector"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog5"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog6"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog7"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog8"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog9"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "grade2_collector_A"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "grade2_collector_10"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loop1"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops6"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops7"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops7"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops5"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops5"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops8"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops9"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops9"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops10"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops10"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_predict1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge1a"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events1"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events3"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events4"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events5"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events6"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events7"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events8"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events9"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_flappy_events10"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events1"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events2"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events3"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events4"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events5"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events6"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events7"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events8"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events9"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsFP"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "courseC_Unplugged_ScreenOutTheMean"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      },
+      "level_keys": [
+        "BinaryBracelets"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze",
+        "script_level.level_keys": [
+          "courseC_video_maze"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1",
+        "script_level.level_keys": [
+          "courseC_maze_programming1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2",
+        "script_level.level_keys": [
+          "courseC_maze_programming2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3",
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4",
+        "script_level.level_keys": [
+          "courseC_maze_programming4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5",
+        "script_level.level_keys": [
+          "courseC_maze_programming5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6",
+        "script_level.level_keys": [
+          "courseC_maze_programming6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7",
+        "script_level.level_keys": [
+          "courseC_maze_programming7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8",
+        "script_level.level_keys": [
+          "courseC_maze_programming8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9",
+        "script_level.level_keys": [
+          "courseC_maze_programming9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PaperPlanes",
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector",
+        "script_level.level_keys": [
+          "courseC_video_collector"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1",
+        "script_level.level_keys": [
+          "courseC_collector_prog1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2",
+        "script_level.level_keys": [
+          "courseC_collector_prog2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3",
+        "script_level.level_keys": [
+          "courseC_collector_prog3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4",
+        "script_level.level_keys": [
+          "courseC_collector_prog4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5",
+        "script_level.level_keys": [
+          "courseC_collector_prog5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6",
+        "script_level.level_keys": [
+          "courseC_collector_prog6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7",
+        "script_level.level_keys": [
+          "courseC_collector_prog7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8",
+        "script_level.level_keys": [
+          "courseC_collector_prog8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9",
+        "script_level.level_keys": [
+          "courseC_collector_prog9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A",
+        "script_level.level_keys": [
+          "grade2_collector_A"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10",
+        "script_level.level_keys": [
+          "grade2_collector_10"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1",
+        "script_level.level_keys": [
+          "courseC_artist_loop1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops1",
+        "script_level.level_keys": [
+          "courseC_harvester_loops1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops2",
+        "script_level.level_keys": [
+          "courseC_harvester_loops2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops3",
+        "script_level.level_keys": [
+          "courseC_harvester_loops3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops4",
+        "script_level.level_keys": [
+          "courseC_harvester_loops4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops6",
+        "script_level.level_keys": [
+          "courseC_harvester_loops6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops7",
+        "script_level.level_keys": [
+          "courseC_harvester_loops7"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops5",
+        "script_level.level_keys": [
+          "courseC_harvester_loops5"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops8",
+        "script_level.level_keys": [
+          "courseC_harvester_loops8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops9",
+        "script_level.level_keys": [
+          "courseC_harvester_loops9"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops10",
+        "script_level.level_keys": [
+          "courseC_harvester_loops10"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_predict1",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge1a",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge2",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1",
+        "script_level.level_keys": [
+          "courseC_flappy_events1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2",
+        "script_level.level_keys": [
+          "courseC_flappy_events2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3",
+        "script_level.level_keys": [
+          "courseC_flappy_events3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4",
+        "script_level.level_keys": [
+          "courseC_flappy_events4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5",
+        "script_level.level_keys": [
+          "courseC_flappy_events5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6",
+        "script_level.level_keys": [
+          "courseC_flappy_events6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7",
+        "script_level.level_keys": [
+          "courseC_flappy_events7"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8",
+        "script_level.level_keys": [
+          "courseC_flappy_events8"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9",
+        "script_level.level_keys": [
+          "courseC_flappy_events9"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10",
+        "script_level.level_keys": [
+          "courseC_flappy_events10"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events1",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events2",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events3",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events4",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events5",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events6",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events7",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events8",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events9",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsFP",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events_challenge1",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_Unplugged_ScreenOutTheMean",
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets",
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursec-2018.script_json
+++ b/dashboard/config/scripts_json/coursec-2018.script_json
@@ -1,0 +1,5130 @@
+{
+  "script": {
+    "name": "coursec-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/coursec/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/coursec/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/coursec/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/coursec/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursec",
+    "seeding_key": {
+      "script.name": "coursec-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging in Maze",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Paper Planes",
+      "name": "Paper Planes",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Loops: Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Harvesting Crops with Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Screen Out the Mean",
+      "name": "Screen Out the Mean",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Chase Game with Events",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Looking Ahead",
+      "name": "Looking Ahead with Minecraft",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_video_maze_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PaperPlanes_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "PaperPlanes_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_video_collector_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "grade2_collector_A_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "grade2_collector_10_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "GettingLoopy_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loop1_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge1a_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "BigEvent_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events1_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events2_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events3_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events4_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events5_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events6_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events7_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events8_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events9_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events10_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_Unplugged_ScreenOutTheMean_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events1_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events2_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events3_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events4_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events5_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events6_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events7_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events8_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events9_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsFP_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      },
+      "level_keys": [
+        "BinaryBracelets_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2018",
+        "script_level.level_keys": [
+          "courseC_video_maze_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PaperPlanes_2018",
+        "script_level.level_keys": [
+          "PaperPlanes_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2018",
+        "script_level.level_keys": [
+          "courseC_video_collector_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2018",
+        "script_level.level_keys": [
+          "grade2_collector_A_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2018",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2018",
+        "script_level.level_keys": [
+          "grade2_collector_10_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy_2018",
+        "script_level.level_keys": [
+          "GettingLoopy_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2018",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops1_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops2_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops3_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops4_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops6_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops7_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops5_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops8_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops9_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops10_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge1a_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2018",
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro_2018",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_Unplugged_ScreenOutTheMean_2018",
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events1_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events2_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events3_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events4_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events5_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events6_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events7_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events8_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events9_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsFP_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets_2018",
+        "script_level.level_keys": [
+          "BinaryBracelets_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursec-2019.script_json
+++ b/dashboard/config/scripts_json/coursec-2019.script_json
@@ -1,0 +1,5608 @@
+{
+  "script": {
+    "name": "coursec-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursec/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-19/coursec/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-19/coursec/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-19/coursec/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursec",
+    "seeding_key": {
+      "script.name": "coursec-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "csf_binary",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Binary"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "csf_data",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Screen Out the Mean",
+      "name": "Screen Out the Mean",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Powerful Passwords",
+      "name": "Powerful Passwords",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Powerful Passwords",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends Jr.",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging in Maze",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends Jr.",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Harvesting Crops with Loops",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Looking Ahead",
+      "name": "Looking Ahead with Minecraft",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Sticker Art with Loops",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Chase Game with Events",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "Picturing Data",
+      "name": "Picturing Data",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "key": "End of Course Project: Create a Play Lab Game",
+      "name": "End of Course Project",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ScreenOutTheMean-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "ScreenOutTheMean-Unplugged"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PowerfulPasswords-Unplugged"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Powerful Passwords",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "PowerfulPasswords-Unplugged"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MyRoboticFriends-Unplugged"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "MyRoboticFriends-Unplugged"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_video_maze_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Collector"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_video_collector_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "grade2_collector_A_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "grade2_collector_10_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Extras"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Extras"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrand"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_video_artist_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets-Unplugged"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "BinaryBracelets-Unplugged"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MyLoopyRoboticFriends-Unplugged"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "MyLoopyRoboticFriends-Unplugged"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Programming with Rey and BB-8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Blocks with BB-8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge1a_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Chop Tree_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Chop Trees_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Place Wall_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Plant Crops_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Underground Mining Coal_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Underground Iron_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Underground If Statements_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1b_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops1b_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent-Unplugged"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "BigEvent-Unplugged"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Your Own Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events1_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events2_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events3_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events4_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events5_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events6_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events7_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events8_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events9_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_flappy_events10_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events1_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events2_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events3_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events4_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events5_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_embed_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA_embed_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events6_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events7_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events8_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events9_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsFP_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PicturingData-Unplugged"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "PicturingData-Unplugged"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_data wizard"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC_data wizard"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "Begin planning your project_2018_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC1"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC2"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC2"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC3"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC3"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC4"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC4"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC5"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC5"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC6"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC6"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ScreenOutTheMean-Unplugged",
+        "script_level.level_keys": [
+          "ScreenOutTheMean-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PowerfulPasswords-Unplugged",
+        "script_level.level_keys": [
+          "PowerfulPasswords-Unplugged"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Powerful Passwords",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MyRoboticFriends-Unplugged",
+        "script_level.level_keys": [
+          "MyRoboticFriends-Unplugged"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2019",
+        "script_level.level_keys": [
+          "courseC_video_maze_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2019",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2019",
+        "script_level.level_keys": [
+          "courseC_video_collector_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2019",
+        "script_level.level_keys": [
+          "grade2_collector_A_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2019",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2019",
+        "script_level.level_keys": [
+          "grade2_collector_10_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2019",
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets-Unplugged",
+        "script_level.level_keys": [
+          "BinaryBracelets-Unplugged"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MyLoopyRoboticFriends-Unplugged",
+        "script_level.level_keys": [
+          "MyLoopyRoboticFriends-Unplugged"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video_2019",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video_2019",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2019",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops1_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops2_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops3_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops4_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops6_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops7_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops5_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops8_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops9_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops10_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge1a_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep_2019",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree_2019",
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep_2019",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees_2019",
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall_2019",
+        "script_level.level_keys": [
+          "Overworld Place Wall_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen_2019",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops_2019",
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters_2019",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal_2019",
+        "script_level.level_keys": [
+          "Underground Mining Coal_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron_2019",
+        "script_level.level_keys": [
+          "Underground Iron_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava_2019",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements_2019",
+        "script_level.level_keys": [
+          "Underground If Statements_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart_2019",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20_2019",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1b_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops1b_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent-Unplugged",
+        "script_level.level_keys": [
+          "BigEvent-Unplugged"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro_2019",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events1_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events2_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events3_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events4_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events5_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA_embed_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_embed_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events6_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events7_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events8_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events9_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsFP_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PicturingData-Unplugged",
+        "script_level.level_keys": [
+          "PicturingData-Unplugged"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_data wizard",
+        "script_level.level_keys": [
+          "courseC_data wizard"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018_2019",
+        "script_level.level_keys": [
+          "Begin planning your project_2018_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC1",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC2",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC2"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC3",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC3"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC4",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC4"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC5",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC5"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC6",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC6"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursec-2020.script_json
+++ b/dashboard/config/scripts_json/coursec-2020.script_json
@@ -1,0 +1,5613 @@
+{
+  "script": {
+    "name": "coursec-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/coursec/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course C!",
+          "link": "https://curriculum.code.org/csf-20/coursec",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/coursec/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/coursec/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/coursec/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursec",
+    "seeding_key": {
+      "script.name": "coursec-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "csf_binary",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Binary"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "csf_data",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Putting a STOP to Online Meanness",
+      "name": "Putting a STOP to Online Meanness",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Putting a STOP to Online Meanness",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Password Power-Up",
+      "name": "Password Power-Up",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Password Power-Up",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends Jr.",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging in Maze",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends Jr.",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Harvesting Crops with Loops",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Looking Ahead",
+      "name": "Looking Ahead with Minecraft",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Sticker Art with Loops",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Chase Game with Events",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "Picturing Data",
+      "name": "Picturing Data",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "key": "End of Course Project: Create a Play Lab Game",
+      "name": "End of Course Project",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csf_putting_a_stop_to_online_meanness"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Putting a STOP to Online Meanness",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "csf_putting_a_stop_to_online_meanness"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csf_password_power-up"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Password Power-Up",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "csf_password_power-up"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MyRoboticFriends-Unplugged_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "MyRoboticFriends-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_video_maze_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Collector"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_video_collector_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "grade2_collector_A_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "grade2_collector_10_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Extras"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Extras"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrand"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_video_artist_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets-Unplugged_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "BinaryBracelets-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MyLoopyRoboticFriends-Unplugged_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "MyLoopyRoboticFriends-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Programming with Rey and BB-8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Blocks with BB-8"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge1a_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Chop Tree_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Chop Trees_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Place Wall_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Plant Crops_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Underground Mining Coal_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Underground Iron_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Underground If Statements_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1b_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops1b_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Sticker Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "BigEvent-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Your Own Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events1_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events2_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events3_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events4_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events5_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events6_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events7_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events8_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events9_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_flappy_events10_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events1_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events2_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events3_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events4_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events5_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_embed_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA_embed_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events6_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events7_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events8_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events9_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Chase Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsFP_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PicturingData-Unplugged_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "PicturingData-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_data wizard_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC_data wizard_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018_2019_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "Begin planning your project_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC1_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC1_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC2_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC2_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC3_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC3_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC4_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC4_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC5_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC5_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC6_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      },
+      "level_keys": [
+        "courseC19_playLab_EOC6_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csf_putting_a_stop_to_online_meanness",
+        "script_level.level_keys": [
+          "csf_putting_a_stop_to_online_meanness"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Putting a STOP to Online Meanness",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csf_password_power-up",
+        "script_level.level_keys": [
+          "csf_password_power-up"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Password Power-Up",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MyRoboticFriends-Unplugged_2020",
+        "script_level.level_keys": [
+          "MyRoboticFriends-Unplugged_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2020",
+        "script_level.level_keys": [
+          "courseC_video_maze_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2020",
+        "script_level.level_keys": [
+          "courseC_video_collector_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2020",
+        "script_level.level_keys": [
+          "grade2_collector_A_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2020",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2020",
+        "script_level.level_keys": [
+          "grade2_collector_10_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2020",
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets-Unplugged_2020",
+        "script_level.level_keys": [
+          "BinaryBracelets-Unplugged_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MyLoopyRoboticFriends-Unplugged_2020",
+        "script_level.level_keys": [
+          "MyLoopyRoboticFriends-Unplugged_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video_2020",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video_2020",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2020",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2020",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops1_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops1_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops2_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops2_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops3_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops3_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops4_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops4_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops6_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops6_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops7_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops7_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops5_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops5_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops8_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops8_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops9_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops9_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops10_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops10_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge1a_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep_2020",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree_2020",
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep_2020",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees_2020",
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall_2020",
+        "script_level.level_keys": [
+          "Overworld Place Wall_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen_2020",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops_2020",
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters_2020",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal_2020",
+        "script_level.level_keys": [
+          "Underground Mining Coal_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron_2020",
+        "script_level.level_keys": [
+          "Underground Iron_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava_2020",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements_2020",
+        "script_level.level_keys": [
+          "Underground If Statements_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart_2020",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20_2020",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1b_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops1b_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent-Unplugged_2020",
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro_2020",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10_2020",
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events1_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events2_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events3_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events4_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events5_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA_embed_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_embed_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events6_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events7_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events8_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events9_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsFP_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PicturingData-Unplugged_2020",
+        "script_level.level_keys": [
+          "PicturingData-Unplugged_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_data wizard_2020",
+        "script_level.level_keys": [
+          "courseC_data wizard_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Picturing Data",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018_2019_2020",
+        "script_level.level_keys": [
+          "Begin planning your project_2018_2019_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC1_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC1_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC2_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC2_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC3_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC3_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC4_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC4_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC5_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC5_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC19_playLab_EOC6_2020",
+        "script_level.level_keys": [
+          "courseC19_playLab_EOC6_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "End of Course Project: Create a Play Lab Game",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursec-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursec-draft.script_json
+++ b/dashboard/config/scripts_json/coursec-draft.script_json
@@ -1,0 +1,3989 @@
+{
+  "script": {
+    "name": "coursec-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursec-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging in Maze",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Paper Planes",
+      "name": "Real-life Algorithms: Paper Planes",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Programming in Collector",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Loops: Getting Loopy",
+      "name": "Loops: Getting Loopy",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Loops in Maze",
+      "name": "Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Loops in Harvester",
+      "name": "Loops in Harvester",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Screen Out the Mean",
+      "name": "Screen Out the Mean",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_video_maze"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "PaperPlanes"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_video_collector"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog5"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog6"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog7"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog8"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog9"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "grade2_collector_A"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "grade2_collector_10"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_loops"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_video_loops"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops2_predict1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops2_predict1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops9"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops10"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops10_predict2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops10_predict2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops11"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops4"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops6"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops7"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops5"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops8"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops8"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops9"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops9"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops10"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops10"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops11_predict1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_harvester_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events3"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events4"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events5"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events6"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events7"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events8"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_events9"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsA"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_PlayLab_eventsFP"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_screenoutthemean"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "courseC_screenoutthemean"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      },
+      "level_keys": [
+        "BinaryBracelets"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze",
+        "script_level.level_keys": [
+          "courseC_video_maze"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1",
+        "script_level.level_keys": [
+          "courseC_maze_programming1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2",
+        "script_level.level_keys": [
+          "courseC_maze_programming2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3",
+        "script_level.level_keys": [
+          "courseC_maze_programming3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4",
+        "script_level.level_keys": [
+          "courseC_maze_programming4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5",
+        "script_level.level_keys": [
+          "courseC_maze_programming5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6",
+        "script_level.level_keys": [
+          "courseC_maze_programming6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7",
+        "script_level.level_keys": [
+          "courseC_maze_programming7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8",
+        "script_level.level_keys": [
+          "courseC_maze_programming8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9",
+        "script_level.level_keys": [
+          "courseC_maze_programming9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PaperPlanes",
+        "script_level.level_keys": [
+          "PaperPlanes"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Paper Planes",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector",
+        "script_level.level_keys": [
+          "courseC_video_collector"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1",
+        "script_level.level_keys": [
+          "courseC_collector_prog1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2",
+        "script_level.level_keys": [
+          "courseC_collector_prog2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3",
+        "script_level.level_keys": [
+          "courseC_collector_prog3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4",
+        "script_level.level_keys": [
+          "courseC_collector_prog4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5",
+        "script_level.level_keys": [
+          "courseC_collector_prog5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6",
+        "script_level.level_keys": [
+          "courseC_collector_prog6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7",
+        "script_level.level_keys": [
+          "courseC_collector_prog7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8",
+        "script_level.level_keys": [
+          "courseC_collector_prog8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9",
+        "script_level.level_keys": [
+          "courseC_collector_prog9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A",
+        "script_level.level_keys": [
+          "grade2_collector_A"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10",
+        "script_level.level_keys": [
+          "grade2_collector_10"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops1",
+        "script_level.level_keys": [
+          "courseC_maze_loops1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_loops",
+        "script_level.level_keys": [
+          "courseC_video_loops"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops2_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_loops2_predict1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops2",
+        "script_level.level_keys": [
+          "courseC_maze_loops2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops4",
+        "script_level.level_keys": [
+          "courseC_maze_loops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops5",
+        "script_level.level_keys": [
+          "courseC_maze_loops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops6",
+        "script_level.level_keys": [
+          "courseC_maze_loops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops7",
+        "script_level.level_keys": [
+          "courseC_maze_loops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops8",
+        "script_level.level_keys": [
+          "courseC_maze_loops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops9",
+        "script_level.level_keys": [
+          "courseC_maze_loops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops10",
+        "script_level.level_keys": [
+          "courseC_maze_loops10"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops10_predict2",
+        "script_level.level_keys": [
+          "courseC_maze_loops10_predict2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops11",
+        "script_level.level_keys": [
+          "courseC_maze_loops11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops1",
+        "script_level.level_keys": [
+          "courseC_harvester_loops1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops2",
+        "script_level.level_keys": [
+          "courseC_harvester_loops2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops3",
+        "script_level.level_keys": [
+          "courseC_harvester_loops3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops4",
+        "script_level.level_keys": [
+          "courseC_harvester_loops4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops6",
+        "script_level.level_keys": [
+          "courseC_harvester_loops6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops7",
+        "script_level.level_keys": [
+          "courseC_harvester_loops7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops5",
+        "script_level.level_keys": [
+          "courseC_harvester_loops5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops8",
+        "script_level.level_keys": [
+          "courseC_harvester_loops8"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops9",
+        "script_level.level_keys": [
+          "courseC_harvester_loops9"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops10",
+        "script_level.level_keys": [
+          "courseC_harvester_loops10"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops11_predict1",
+        "script_level.level_keys": [
+          "courseC_harvester_loops11_predict1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge1",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_harvester_loops_challenge2",
+        "script_level.level_keys": [
+          "courseC_harvester_loops_challenge2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events1",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events2",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events3",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events4",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events5",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events5"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events6",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events6"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events7",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events7"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events8",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_events9",
+        "script_level.level_keys": [
+          "courseC_PlayLab_events9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsA",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsA"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_PlayLab_eventsFP",
+        "script_level.level_keys": [
+          "courseC_PlayLab_eventsFP"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_screenoutthemean",
+        "script_level.level_keys": [
+          "courseC_screenoutthemean"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets",
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "coursec-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-2017.script_json
+++ b/dashboard/config/scripts_json/coursed-2017.script_json
@@ -1,0 +1,5871 @@
+{
+  "script": {
+    "name": "coursed-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/coursed/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "ar-SA",
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN",
+        "zh-TW"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "coursed-2017",
+    "family_name": "coursed",
+    "seeding_key": {
+      "script.name": "coursed-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Programming: Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Nested Loops in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Nested Loops Project in Artist",
+      "name": "Nested Loops in Frozen",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Algorithms: Relay Programming",
+      "name": "Debugging: Relay Programming",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Debugging in Collector",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "If/Else: Conditionals with Cards",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "Conditionals in Bee",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Maze",
+      "name": "Conditionals & Loops in Maze",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Farmer",
+      "name": "Conditionals & Loops in Harvester",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship: Practicing Digital Citizenship",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Beyond Programming: Binary Images",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Binary in Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_ramp8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_ramp9"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_ramp10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_ramp11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_ramp12"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2a"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2a"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "RelayProgramming"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_debugging"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging10_predict1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1a"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_debugging_challenge1a"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while1"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while2"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while3"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while4"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while5"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while6"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while7"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while8"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while9"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while10"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge2"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until1"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until3"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until4"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until5"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until6"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until7"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until8"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until9"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until10"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until_challenge1"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_until_challenge2"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond2"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3a"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond4"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond5"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6a"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_playLab_condFP"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "BinaryImages"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_external_binary1"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary1"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary2"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary3"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary4"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary5"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary6"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary7"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary8"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP8"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP8"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp8",
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp9",
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp10",
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp11",
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp12",
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2a",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2a"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming",
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging",
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging10_predict1",
+        "script_level.level_keys": [
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging_challenge1a",
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1a"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1",
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2",
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3",
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4",
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5",
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6",
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7",
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8",
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9",
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10",
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1",
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3",
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4",
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5",
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6",
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7",
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ifElse",
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until8",
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9",
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10",
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until_challenge1",
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_until_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond1",
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond2",
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3a",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond4",
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond5",
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6a",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_condFP",
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages",
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1",
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1",
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2",
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3",
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4",
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5",
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6",
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7",
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8",
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP8",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP8"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-2018.script_json
+++ b/dashboard/config/scripts_json/coursed-2018.script_json
@@ -1,0 +1,6151 @@
+{
+  "script": {
+    "name": "coursed-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/coursed/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/coursed/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/coursed/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/coursed/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursed",
+    "seeding_key": {
+      "script.name": "coursed-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Introduction to Online Puzzles",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Relay Programming",
+      "name": "Relay Programming",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Debugging with Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops in Ice Age",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Shapes with Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Fancy Shapes using Nested Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Snowflakes with Anna and Elsa",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Ninjas vs. Pirates Game",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Binary Images",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Binary Images with Artist",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "GraphPaperProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "RelayProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1a_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2a_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3a_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4a_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5a_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6a_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8a_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9a_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events1s_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events2s_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events5s_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events6s_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events7s_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events10s_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events11s_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bounce_events12s_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "scrat_loops_C-F_video"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops4"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops6"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops7"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops8"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops9"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops10"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops11"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops11"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops12"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_iceage_loops12"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_1_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_1_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_2_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_2_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_3_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_3_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_4_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_4_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_5_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_5_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_6_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_6_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "Conditionals_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond1_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond1_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond2_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond2_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3a_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond4_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond4_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond5_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond5_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6a_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_condFP_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_playLab_condFP_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "BinaryImages_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_external_binary1_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary1_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary2_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary3_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary4_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary5_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary6_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary7_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge2_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming_2018",
+        "script_level.level_keys": [
+          "GraphPaperProgramming_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming_2018",
+        "script_level.level_keys": [
+          "RelayProgramming_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseD_video_debugging_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9a_2018",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s_2018",
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops1",
+        "script_level.level_keys": [
+          "courseD_iceage_loops1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops2",
+        "script_level.level_keys": [
+          "courseD_iceage_loops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat_loops_C-F_video",
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops3",
+        "script_level.level_keys": [
+          "courseD_iceage_loops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops4",
+        "script_level.level_keys": [
+          "courseD_iceage_loops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops6",
+        "script_level.level_keys": [
+          "courseD_iceage_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops7",
+        "script_level.level_keys": [
+          "courseD_iceage_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops8",
+        "script_level.level_keys": [
+          "courseD_iceage_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops9",
+        "script_level.level_keys": [
+          "courseD_iceage_loops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops10",
+        "script_level.level_keys": [
+          "courseD_iceage_loops10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops11",
+        "script_level.level_keys": [
+          "courseD_iceage_loops11"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops12",
+        "script_level.level_keys": [
+          "courseD_iceage_loops12"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_1_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_2_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_3_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_4_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_5_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_6_2018",
+        "script_level.level_keys": [
+          "courseD_artist_6_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2018",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2018",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals_2018",
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship_2018",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond1_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond1_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond2_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond2_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3a_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond4_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond4_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond5_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond5_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6a_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_condFP_2018",
+        "script_level.level_keys": [
+          "courseD_playLab_condFP_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages_2018",
+        "script_level.level_keys": [
+          "BinaryImages_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1_2018",
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-2019.script_json
+++ b/dashboard/config/scripts_json/coursed-2019.script_json
@@ -1,0 +1,6113 @@
+{
+  "script": {
+    "name": "coursed-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursed/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-19/coursed/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-19/coursed/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-19/coursed/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursed",
+    "seeding_key": {
+      "script.name": "coursed-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "csf_binary",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Binary"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Introduction to Online Puzzles",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Relay Programming",
+      "name": "Relay Programming",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Debugging with Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops in Ice Age",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Shapes with Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Binary Images",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Binary Images with Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "GraphPaperProgramming-Unplugged"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro4_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_intro4_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro5a_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_intro5a_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro5c_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_intro5c_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming-Unplugged"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "RelayProgramming-Unplugged"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "De-bugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1a_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2a_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3a_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4a_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5a_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6a_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8a_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9a_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events1s_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events2s_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events5s_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events6s_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events7s_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events10s_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events11s_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bounce_events12s_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseE_video_StarWarsProject_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Repeat Block"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "scrat_loops_C-F_video_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_iceage_loops12_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrand"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "ConditionalsWithCards-Unplugged"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Conditionals: If Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Conditionals: If and If/Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Until Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages-Unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "BinaryImages-Unplugged"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_external_binary1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary1_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary2_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary3_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary4_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary5_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary6_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary7_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalCitizenship-Unplugged"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "DigitalCitizenship-Unplugged"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_12"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_12"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming-Unplugged",
+        "script_level.level_keys": [
+          "GraphPaperProgramming-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2019",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_intro4_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro5a_2019",
+        "script_level.level_keys": [
+          "courseD_maze_intro5a_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro5c_2019",
+        "script_level.level_keys": [
+          "courseD_maze_intro5c_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming-Unplugged",
+        "script_level.level_keys": [
+          "RelayProgramming-Unplugged"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging_2019",
+        "script_level.level_keys": [
+          "courseD_video_debugging_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9a_2019",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s_2019",
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_StarWarsProject_2019",
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops1_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops2_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat_loops_C-F_video_2019",
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops3_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops4_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops6_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops7_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops8_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops9_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops10_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops11_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops12_2019",
+        "script_level.level_keys": [
+          "courseD_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2019",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2019",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ConditionalsWithCards-Unplugged",
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2019",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2019",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages-Unplugged",
+        "script_level.level_keys": [
+          "BinaryImages-Unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1_2018_2019",
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalCitizenship-Unplugged",
+        "script_level.level_keys": [
+          "DigitalCitizenship-Unplugged"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_12",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_12"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-2020.script_json
+++ b/dashboard/config/scripts_json/coursed-2020.script_json
@@ -1,0 +1,6346 @@
+{
+  "script": {
+    "name": "coursed-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/coursed/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course D!",
+          "link": "https://curriculum.code.org/csf-20/coursed",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/coursed/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/coursed/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/coursed/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursed",
+    "seeding_key": {
+      "script.name": "coursed-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "csf_binary",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Binary"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Introduction to Online Puzzles",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Relay Programming",
+      "name": "Relay Programming",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Debugging with Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops in Ice Age",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Shapes with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Binary Images",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Binary Images with Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "Be A Super Digital Citizen",
+      "name": "Be A Super Digital Citizen",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Be A Super Digital Citizen",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming-Unplugged_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "GraphPaperProgramming-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro4_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_intro4_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro5a_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_intro5a_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_intro5c_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_intro5c_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming-Unplugged_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "RelayProgramming-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "De-bugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1a_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2a_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3a_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4a_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5a_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6a_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8a_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9a_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events1s_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events2s_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events5s_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events6s_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events7s_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events10s_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events11s_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bounce_events12s_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseE_video_StarWarsProject_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Warm Up"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_01"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_01"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_02"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_02"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_03"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_03"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Measures"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Measures"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_04"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_04"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Measures"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_05"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_05"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Measures"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_06"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_06"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid4"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_07"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_07"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_08"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_08"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_09"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_09"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Wrap-up"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid5"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_10"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_10"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_bonus1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus3"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 17,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_bonus3"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops1_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops2_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Repeat Block"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "scrat_loops_C-F_video_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops3_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops4_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops6_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops7_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops8_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops9_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops10_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops11_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops12_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_iceage_loops12_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrand"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "ConditionalsWithCards-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Conditionals: If Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Conditionals: If and If/Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Until Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages-Unplugged_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "BinaryImages-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018_2019_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_external_binary1_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary1_2020"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary2_2020"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary3_2020"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary4_2020"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary5_2020"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary6_2020"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary7_2020"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_2020"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP_2020"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csf_be_a_super_digital_citizen"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 1,
+        "lesson.key": "Be A Super Digital Citizen",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "csf_be_a_super_digital_citizen"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_project_exemplars_2020_2021"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_project_exemplars_2020_2021"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create your project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_EOC_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      },
+      "level_keys": [
+        "courseD_EOC_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming-Unplugged_2020",
+        "script_level.level_keys": [
+          "GraphPaperProgramming-Unplugged_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2020",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_intro4_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro5a_2020",
+        "script_level.level_keys": [
+          "courseD_maze_intro5a_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_intro5c_2020",
+        "script_level.level_keys": [
+          "courseD_maze_intro5c_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Online Puzzles",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming-Unplugged_2020",
+        "script_level.level_keys": [
+          "RelayProgramming-Unplugged_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseD_video_debugging_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9a_2020",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events1s_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events2s_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events5s_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events6s_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events7s_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events10s_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events11s_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s_2020",
+        "script_level.level_keys": [
+          "courseD_bounce_events12s_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_StarWarsProject_2020",
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid1",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_01"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid2",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_02"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_03"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid3",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_04"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_05"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_06"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid4",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_07",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_07"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_08"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_09"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid5",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_10"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_bonus1",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_bonus3",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus3"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 17,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_events",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops1_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops1_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops2_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops2_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat_loops_C-F_video_2020",
+        "script_level.level_keys": [
+          "scrat_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops3_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops3_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops4_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops4_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops6_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops6_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops7_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops7_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops8_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops8_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops9_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops9_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops10_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops10_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops11_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops11_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops12_2020",
+        "script_level.level_keys": [
+          "courseD_iceage_loops12_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2020",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2020",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2020",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ConditionalsWithCards-Unplugged_2020",
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2020",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2020",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2020",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages-Unplugged_2020",
+        "script_level.level_keys": [
+          "BinaryImages-Unplugged_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1_2018_2019_2020",
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018_2019_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "csf_binary",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csf_be_a_super_digital_citizen",
+        "script_level.level_keys": [
+          "csf_be_a_super_digital_citizen"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 1,
+        "lesson.key": "Be A Super Digital Citizen",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_project_exemplars_2020_2021",
+        "script_level.level_keys": [
+          "courseD_project_exemplars_2020_2021"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_EOC_2020",
+        "script_level.level_keys": [
+          "courseD_EOC_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursed-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-draft.script_json
+++ b/dashboard/config/scripts_json/coursed-draft.script_json
@@ -1,0 +1,4992 @@
+{
+  "script": {
+    "name": "coursed-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursed-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Algorithms: Graph Paper Programming",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Nested Loops in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Algorithms: Relay Programming",
+      "name": "Algorithms: Relay Programming",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Debugging in Bee",
+      "name": "Debugging in Bee",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "Conditionals in Bee",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Maze",
+      "name": "Conditionals & Loops in Maze",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Farmer",
+      "name": "Conditionals & Loops in Harvester",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Unplugged: Binary",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Artist Binary",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_collector_ramp8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_collector_ramp9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_collector_ramp10"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_ramp11"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_ramp12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "RelayProgramming"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging9"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging9_predict1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_debugging9_predict1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while3"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while5"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while6"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while7"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while8"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while9"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while10"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until3"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until4"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until5"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until6"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until7"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until8"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until9"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until10"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond1"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond2"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond4"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond5"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_playLab_condFP"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "BinaryImages"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_external_binary1"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary2"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary3"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary4"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary5"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary6"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary7"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary8"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp8",
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp9",
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp10",
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp11",
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp12",
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming",
+        "script_level.level_keys": [
+          "RelayProgramming"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging1",
+        "script_level.level_keys": [
+          "courseD_bee_debugging1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging2",
+        "script_level.level_keys": [
+          "courseD_bee_debugging2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging3",
+        "script_level.level_keys": [
+          "courseD_bee_debugging3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging4",
+        "script_level.level_keys": [
+          "courseD_bee_debugging4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging5",
+        "script_level.level_keys": [
+          "courseD_bee_debugging5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging6",
+        "script_level.level_keys": [
+          "courseD_bee_debugging6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging7",
+        "script_level.level_keys": [
+          "courseD_bee_debugging7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging8",
+        "script_level.level_keys": [
+          "courseD_bee_debugging8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging9",
+        "script_level.level_keys": [
+          "courseD_bee_debugging9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging9_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_debugging9_predict1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1",
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2",
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3",
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4",
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5",
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6",
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7",
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8",
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9",
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10",
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1",
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3",
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4",
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5",
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6",
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7",
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ifElse",
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until8",
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9",
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10",
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond1",
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond2",
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond4",
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond5",
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_condFP",
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages",
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1",
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1",
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2",
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3",
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4",
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5",
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6",
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7",
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8",
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "coursed-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursed-ramp.script_json
+++ b/dashboard/config/scripts_json/coursed-ramp.script_json
@@ -1,0 +1,609 @@
+{
+  "script": {
+    "name": "coursed-ramp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursed-ramp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_video_Loops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_video_Loops"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_collector_ramp8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_collector_ramp9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_collector_ramp10"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_ramp11"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_ramp12"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_ramp14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      },
+      "level_keys": [
+        "courseD_farmer_ramp14"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_video_Loops",
+        "script_level.level_keys": [
+          "courseD_maze_video_Loops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_maze_ramp7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp8",
+        "script_level.level_keys": [
+          "courseD_collector_ramp8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp9",
+        "script_level.level_keys": [
+          "courseD_collector_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_ramp10",
+        "script_level.level_keys": [
+          "courseD_collector_ramp10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp11",
+        "script_level.level_keys": [
+          "courseD_artist_ramp11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_ramp12",
+        "script_level.level_keys": [
+          "courseD_artist_ramp12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseD_farmer_ramp13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_ramp14",
+        "script_level.level_keys": [
+          "courseD_farmer_ramp14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursed-ramp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-2017.script_json
+++ b/dashboard/config/scripts_json/coursee-2017.script_json
@@ -1,0 +1,7178 @@
+{
+  "script": {
+    "name": "coursee-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/coursee/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "coursee-2017",
+    "family_name": "coursee",
+    "seeding_key": {
+      "script.name": "coursee-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_e_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course E (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "csf_e_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course E Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Algorithms: Dice Race",
+      "name": "Algorithms: Dice Race",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals in Farmer",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Digital Citizenship: Private and Personal Information",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions in Harvester",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Beyond Programming: The Internet",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Beyond Programming: Crowdsourcing",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1",
+        "courseE_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2",
+        "courseE_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3",
+        "courseE_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4",
+        "courseE_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5",
+        "courseE_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1",
+        "courseE_maze_predict1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseCDEF_video_AngryBirdLoops": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops",
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6",
+        "courseE_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp7": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7",
+        "courseE_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_ramp12": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b",
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b",
+        "courseE_farmer_ramp12"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict1",
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_predict1",
+        "courseE_farmer_ramp12b"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_video_ifElse": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap",
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap",
+        "courseE_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_ramp12a": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil",
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil",
+        "courseE_farmer_ramp12a"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_ramp13": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c",
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c",
+        "courseE_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_bee_ramp14": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_ramp14",
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_ramp14",
+        "courseE_farmer_ramp12d"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_predict2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict2",
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_predict2",
+        "courseE_farmer_ramp12e"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_farmer_ramp15": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f",
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f",
+        "courseE_farmer_ramp15"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_unplugged_privateInformation"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions1"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions3"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions4"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions5"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions6"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions7"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions8"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions9"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions10"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions1"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions5"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions8"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions9"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions10"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions11_predict1"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions4b"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions5c"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions6c"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7b"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8b"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9b"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10b"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_concept1"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_concept2"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_concept3"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_concept1"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_concept4"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_bee_concept5"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_concept4"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold1"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold2"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold3"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold4"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold5"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold6"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseE_playLab_challenge1"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Geometric Sun"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Robot Doodle"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Alien Defender"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Find the Wizard"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Course E: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Course E: Artist Project"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      },
+      "level_keys": [
+        "Crowdsourcing"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b",
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b",
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict1",
+        "script_level.level_keys": [
+          "courseE_farmer_predict1",
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b",
+        "script_level.level_keys": [
+          "courseE_farmer_predict1",
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap",
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ifElse",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap",
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil",
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12a",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil",
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c",
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c",
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_ramp14",
+        "script_level.level_keys": [
+          "courseE_bee_ramp14",
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d",
+        "script_level.level_keys": [
+          "courseE_bee_ramp14",
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict2",
+        "script_level.level_keys": [
+          "courseE_farmer_predict2",
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e",
+        "script_level.level_keys": [
+          "courseE_farmer_predict2",
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f",
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp15",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f",
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_privateInformation",
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1",
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2",
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3",
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4",
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5",
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions6",
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7",
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8",
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9",
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10",
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions1",
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions2",
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions3",
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions4",
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions5",
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions6",
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions7",
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions8",
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions9",
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions10",
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions11_predict1",
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions4b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions5c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions6c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1",
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2",
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3",
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1",
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4",
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5",
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4",
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold1",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold2",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold3",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold4",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold5",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold6",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_challenge1",
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun",
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle",
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Alien Defender",
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Find the Wizard",
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Play Lab Project",
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project",
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing",
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-2018.script_json
+++ b/dashboard/config/scripts_json/coursee-2018.script_json
@@ -1,0 +1,7332 @@
+{
+  "script": {
+    "name": "coursee-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/coursee/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/coursee/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/coursee/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/coursee/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursee",
+    "seeding_key": {
+      "script.name": "coursee-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_e_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course E (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "csf_e_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course E Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Coding with Comments",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Shapes with Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals with the Farmer",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Copyright and Creativity",
+      "name": "Digital Sharing",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprite Lab",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Pet Giraffe with Sprite Lab",
+      "name": "Pet Giraffe",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "The Internet",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_intro"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "comment_intro_maze_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_end"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_end"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_intro"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_end"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_intro"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_end"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Conditionals_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_intro"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_conditionals_intro"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_end"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_conditionals_end"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_unplugged_privateInformation_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_video_StarWarsProject"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "SongwritingParameters_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_unplugged_CnC_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept5_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseF_video_csMatters_2018"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Geometric Sun_2018"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Robot Doodle_2018"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_hoops"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "CourseE_hoops"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_Dogger_2"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "courseE_Dogger_2"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Begin planning your project_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Course E: Artist Project_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "CourseE_Project_SpriteLab"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Prepare for your presentation_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Internet_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      },
+      "level_keys": [
+        "Crowdsourcing_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comment_intro_maze_2018",
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_end",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_end",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals_2018",
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_conditionals_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_intro"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2018",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2018",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_2018",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_conditionals_end",
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_end"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_privateInformation_2018",
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_StarWarsProject",
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters_2018",
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2018",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_CnC_2018",
+        "script_level.level_keys": [
+          "courseE_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters_2018",
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun_2018",
+        "script_level.level_keys": [
+          "Geometric Sun_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle_2018",
+        "script_level.level_keys": [
+          "Robot Doodle_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_hoops",
+        "script_level.level_keys": [
+          "CourseE_hoops"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_Dogger_2",
+        "script_level.level_keys": [
+          "courseE_Dogger_2"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018",
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project_2018",
+        "script_level.level_keys": [
+          "Course E: Artist Project_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_Project_SpriteLab",
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation_2018",
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet_2018",
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing_2018",
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-2019.script_json
+++ b/dashboard/config/scripts_json/coursee-2019.script_json
@@ -1,0 +1,6155 @@
+{
+  "script": {
+    "name": "coursee-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursee/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-19/coursee/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-19/coursee/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-19/coursee/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursee",
+    "seeding_key": {
+      "script.name": "coursee-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "csf_nested_loops",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Nested Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "csf_functions",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sequencing in the Maze",
+      "name": "Sequencing in the Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Programming and Loops with the Artist",
+      "name": "Drawing with Loops",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals with the Farmer",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Simon Says",
+      "name": "Simon Says",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Swimming Fish with Sprite Lab",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "About Me",
+      "name": "About Me with Sprite Lab",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Access Ability",
+      "name": "Designing for Accessibility",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Fancy Shapes using Nested Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_video_artist_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SimonSays-Unplugged"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "SimonSays-Unplugged"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 2_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 3_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 4_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 5_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 6_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party 7_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "PrivatePersonalInformation-Unplugged"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_4"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_5"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_6"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_aboutme_6"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "DesigningForAccessibilityMarkdownLevel_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Songwriting-Unplugged"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Songwriting-Unplugged"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Create a Simple Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "courseE_project_exemplars_2019"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Lab Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "CourseE_Project_SpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      },
+      "level_keys": [
+        "Course E: Artist Project_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2019",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2019",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2019",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2019",
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2019",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2019",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2019",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_2019",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SimonSays-Unplugged",
+        "script_level.level_keys": [
+          "SimonSays-Unplugged"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2019",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2019",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2019",
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2019",
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2019",
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2019",
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2019",
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2019",
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2019",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PrivatePersonalInformation-Unplugged",
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_1",
+        "script_level.level_keys": [
+          "courseE_aboutme_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_2",
+        "script_level.level_keys": [
+          "courseE_aboutme_2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_3",
+        "script_level.level_keys": [
+          "courseE_aboutme_3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_4",
+        "script_level.level_keys": [
+          "courseE_aboutme_4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_5",
+        "script_level.level_keys": [
+          "courseE_aboutme_5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_6",
+        "script_level.level_keys": [
+          "courseE_aboutme_6"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesigningForAccessibilityMarkdownLevel_2019",
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Songwriting-Unplugged",
+        "script_level.level_keys": [
+          "Songwriting-Unplugged"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2019",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_project_exemplars_2019",
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_Project_SpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project_2019",
+        "script_level.level_keys": [
+          "Course E: Artist Project_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-2020.script_json
+++ b/dashboard/config/scripts_json/coursee-2020.script_json
@@ -1,0 +1,6244 @@
+{
+  "script": {
+    "name": "coursee-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/coursee/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course E!",
+          "link": "https://curriculum.code.org/csf-20/coursee",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/coursee/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/coursee/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/coursee/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursee",
+    "seeding_key": {
+      "script.name": "coursee-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "csf_nested_loops",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Nested Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "csf_functions",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sequencing in the Maze",
+      "name": "Sequencing in the Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Programming and Loops with the Artist",
+      "name": "Drawing with Loops",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals with the Farmer",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Simon Says",
+      "name": "Simon Says",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Swimming Fish with Sprite Lab",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "About Me",
+      "name": "About Me with Sprite Lab",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Digital Sharing",
+      "name": "Digital Sharing",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Fancy Shapes using Nested Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "Designing for Accessibility",
+      "name": "Designing for Accessibility",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing for Accessibility",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_copy_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_copy_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_video_artist_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "SimonSays-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "spritelab_extras_repeat"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 2_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 3_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 4_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 5_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 6_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party 7_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "PrivatePersonalInformation-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_1_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_2_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_3_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_3_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_4_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_4_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_5_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_5_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_6_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_aboutme_6_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalSharing-Unplugged_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "DigitalSharing-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Songwriting-Unplugged_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Songwriting-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "Function intro Ryan_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Create a Simple Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2020"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2020"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2020"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2020"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2020"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2020"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Designing for Accessibility",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "DesigningForAccessibilityMarkdownLevel_2019_2020"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_project_exemplars_2019_2020"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create your project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_EOC_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      },
+      "level_keys": [
+        "courseE_EOC_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2020",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_copy_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_copy_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2020",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Sequencing in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2020",
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2020",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2020",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2020",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_2020",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SimonSays-Unplugged_2020",
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "spritelab_extras_repeat",
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2020",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2020",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2020",
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2020",
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2020",
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2020",
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2020",
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2020",
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2020",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PrivatePersonalInformation-Unplugged_2020",
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_1_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_2_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_3_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_3_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_4_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_4_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_5_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_5_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_6_2020",
+        "script_level.level_keys": [
+          "courseE_aboutme_6_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalSharing-Unplugged_2020",
+        "script_level.level_keys": [
+          "DigitalSharing-Unplugged_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2020",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist_2020",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2020",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Songwriting-Unplugged_2020",
+        "script_level.level_keys": [
+          "Songwriting-Unplugged_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2020",
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2020",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2020",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesigningForAccessibilityMarkdownLevel_2019_2020",
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Designing for Accessibility",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_project_exemplars_2019_2020",
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_EOC_2020",
+        "script_level.level_keys": [
+          "courseE_EOC_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-draft.script_json
+++ b/dashboard/config/scripts_json/coursee-draft.script_json
@@ -1,0 +1,4151 @@
+{
+  "script": {
+    "name": "coursee-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursee-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Dice Race",
+      "name": "Algorithms: Dice Race",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Functions in Farmer",
+      "name": "Functions in Farmer",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Internet",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_predict1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp10"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_ramp10"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp13"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_maze_ramp13"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_external_ramp14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_external_ramp14"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_predict1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12a"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_ramp14"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_ramp14"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_predict2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp15"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp16"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp16"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_ramp17"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_ramp17"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursee-privateandpersonalinformation"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "coursee-privateandpersonalinformation"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions3"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions4"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions6"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions7"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions8"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions9"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions10"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions1"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions5"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions8"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions9"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions10"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_functions11_predict1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions4b"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions5c"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions6c"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7b"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8b"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9b"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10b"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_concept1"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_concept2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_concept3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_concept1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_concept4"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_bee_concept5"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_artist_concept4"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold1"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold2"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold3"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold4"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold5"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold6"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Geometric Sun"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Robot Doodle"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Alien Defender"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Find the Wizard"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Course E: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Course E: Artist Project"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      },
+      "level_keys": [
+        "Crowdsourcing"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp1",
+        "script_level.level_keys": [
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp2",
+        "script_level.level_keys": [
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp3",
+        "script_level.level_keys": [
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp4",
+        "script_level.level_keys": [
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp5",
+        "script_level.level_keys": [
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_predict1",
+        "script_level.level_keys": [
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp6",
+        "script_level.level_keys": [
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp7",
+        "script_level.level_keys": [
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp10",
+        "script_level.level_keys": [
+          "courseE_artist_ramp10"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp13",
+        "script_level.level_keys": [
+          "courseE_maze_ramp13"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_external_ramp14",
+        "script_level.level_keys": [
+          "courseE_external_ramp14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict1",
+        "script_level.level_keys": [
+          "courseE_farmer_predict1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ifElse",
+        "script_level.level_keys": [
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_ramp14",
+        "script_level.level_keys": [
+          "courseE_bee_ramp14"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict2",
+        "script_level.level_keys": [
+          "courseE_farmer_predict2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp15",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp16",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp16"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_ramp17",
+        "script_level.level_keys": [
+          "courseE_bee_ramp17"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursee-privateandpersonalinformation",
+        "script_level.level_keys": [
+          "coursee-privateandpersonalinformation"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1",
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2",
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3",
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4",
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5",
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions6",
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7",
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8",
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9",
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10",
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions1",
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions2",
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions3",
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions4",
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions5",
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions6",
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions7",
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions8",
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions9",
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions10",
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions11_predict1",
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions4b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions5c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions6c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1",
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2",
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3",
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1",
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4",
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5",
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4",
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold1",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold2",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold3",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold4",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold5",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold6",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun",
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle",
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Alien Defender",
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Find the Wizard",
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Play Lab Project",
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project",
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing",
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "coursee-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursee-ramp.script_json
+++ b/dashboard/config/scripts_json/coursee-ramp.script_json
@@ -1,0 +1,1231 @@
+{
+  "script": {
+    "name": "coursee-ramp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursee-ramp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Real Life Algorithms: Dice Race",
+      "name": "Real Life Algorithms: Dice Race",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real Life Algorithms: Dice Race",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Real Life Algorithms: Dice Race",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_predict1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_video_Loops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_video_Loops"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp10"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_ramp10"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_maze_ramp13"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_maze_ramp13"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_external_ramp14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_external_ramp14"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_predict1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12a"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp13"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_ramp14"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_ramp14"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_predict2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_predict2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp15"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp16"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp16"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_ramp17"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_ramp17"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Real Life Algorithms: Dice Race",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp1",
+        "script_level.level_keys": [
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp2",
+        "script_level.level_keys": [
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp3",
+        "script_level.level_keys": [
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp4",
+        "script_level.level_keys": [
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp5",
+        "script_level.level_keys": [
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_predict1",
+        "script_level.level_keys": [
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_video_Loops",
+        "script_level.level_keys": [
+          "courseD_maze_video_Loops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp6",
+        "script_level.level_keys": [
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp7",
+        "script_level.level_keys": [
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp10",
+        "script_level.level_keys": [
+          "courseE_artist_ramp10"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp13",
+        "script_level.level_keys": [
+          "courseE_maze_ramp13"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_external_ramp14",
+        "script_level.level_keys": [
+          "courseE_external_ramp14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict1",
+        "script_level.level_keys": [
+          "courseE_farmer_predict1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ifElse",
+        "script_level.level_keys": [
+          "courseE_video_ifElse"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12a"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp13",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp13"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_ramp14",
+        "script_level.level_keys": [
+          "courseE_bee_ramp14"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_predict2",
+        "script_level.level_keys": [
+          "courseE_farmer_predict2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp15",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp15"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp16",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp16"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_ramp17",
+        "script_level.level_keys": [
+          "courseE_bee_ramp17"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "coursee-ramp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-2017.script_json
+++ b/dashboard/config/scripts_json/coursef-2017.script_json
@@ -1,0 +1,8822 @@
+{
+  "script": {
+    "name": "coursef-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/coursef/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "coursef-2017",
+    "family_name": "coursef",
+    "seeding_key": {
+      "script.name": "coursef-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_f_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course F (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "csf_f_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course F Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Algorithms: Tangrams",
+      "name": "Algorithms: Tangrams",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction to Online Puzzles",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "Digital Citizenship: The Power of Words",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Events in Ice Age",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft",
+      "name": "Conditionals in Minecraft",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Variables: Envelope Variables",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loops: For Loop Fun",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Songwriting with Parameters",
+      "name": "Functions: Songwriting with Parameters",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_maze_ramp1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1",
+        "courseF_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_maze_ramp2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2",
+        "courseF_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "coursef_maze_ramp3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3",
+        "coursef_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_maze_ramp4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4",
+        "courseF_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_maze_ramp5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5",
+        "courseF_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_maze_ramp6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1",
+        "courseF_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_artist_video1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops",
+          "courseF_artist_video1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops",
+        "courseF_artist_video1"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_artist_ramp8": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6",
+        "courseF_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseC_video_angles": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles",
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_artist_ramp9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8",
+        "courseF_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_artist_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_predict1",
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_predict1",
+        "ramp_video_artistIntro2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_video_nestedLoopsArtist": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist",
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_artist_ramp10": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles2",
+        "courseF_artist_ramp10"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseF_farmer_ramp11": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9",
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9",
+        "courseF_farmer_ramp11"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_unplugged_powerOfWords"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_hello1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_hello2"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_repeat"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_click_hello"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_throw_hearts"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "iceage_free_play"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables2"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables3"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables4"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables5"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables6"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables7"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables8"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables9"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables10"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for1"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for2"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_forBee"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for4"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for6"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for7"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for8"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for5"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for9"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for10"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for11"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_forArtist"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for2"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for3"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for4"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for5"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for6"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for7"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for8"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for9"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for10"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functionsPre7"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "InspirationalArtwork"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "FoodFight"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Guess The Number"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Course F: Artist Project"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursef_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops",
+          "courseF_artist_video1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_video1",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops",
+          "courseF_artist_video1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp9",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_predict1",
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro2",
+        "script_level.level_keys": [
+          "courseF_artist_predict1",
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles2",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp10",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9",
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_farmer_ramp11",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9",
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_unplugged_powerOfWords",
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1",
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2",
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag",
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor",
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat",
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello",
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts",
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play",
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2",
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3",
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4",
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5",
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6",
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7",
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8",
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9",
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10",
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1",
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2",
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee",
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4",
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6",
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7",
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8",
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5",
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9",
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10",
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11",
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist",
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1",
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2",
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3",
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4",
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5",
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6",
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7",
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8",
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9",
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10",
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functionsPre7",
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork",
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight",
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number",
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project",
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-2018.script_json
+++ b/dashboard/config/scripts_json/coursef-2018.script_json
@@ -1,0 +1,7424 @@
+{
+  "script": {
+    "name": "coursef-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/coursef/{LESSON}",
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/coursef/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/coursef/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/coursef/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursef",
+    "seeding_key": {
+      "script.name": "coursef-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_f_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course F (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "csf_f_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course F Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Coding with Comments",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Shapes with Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Conditionals in Farmer",
+      "name": "Conditionals with the Farmer",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions with Minecraft",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Variables as Constant in Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Variables that Change in Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Variables that Change in Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprite Lab",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Pet Giraffe with Sprite Lab",
+      "name": "Pet Giraffe",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_intro"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "comment_intro_maze_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_end"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_end"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_intro"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_end"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_intro"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_end"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Conditionals_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_intro"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_conditionals_intro"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_end"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_conditionals_end"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_unplugged_powerOfWords_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "EnvelopeVariables_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_intro"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_end"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "ForLoopFun_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_intro"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_end"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_video_csMatters_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "InspirationalArtwork_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_project_1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "courseF_project_1"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Begin planning your project_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "CourseF_Project_SpriteLab"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_Revise_SpriteLab"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "CourseF_Project_Revise_SpriteLab"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      },
+      "level_keys": [
+        "Prepare for your presentation_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comment_intro_maze_2018",
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_end",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_end",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals_2018",
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_conditionals_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_intro"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2018",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2018",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_2018",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_conditionals_end",
+        "script_level.level_keys": [
+          "courseF_markdown_conditionals_end"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Farmer",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_unplugged_powerOfWords_2018",
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables_2018",
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2018",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2018",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant_2018",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_end",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun_2018",
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2018",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2018",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters_2018",
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork_2018",
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_project_1",
+        "script_level.level_keys": [
+          "courseF_project_1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018",
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_SpriteLab",
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_Revise_SpriteLab",
+        "script_level.level_keys": [
+          "CourseF_Project_Revise_SpriteLab"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation_2018",
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-2019.script_json
+++ b/dashboard/config/scripts_json/coursef-2019.script_json
@@ -1,0 +1,5289 @@
+{
+  "script": {
+    "name": "coursef-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/coursef/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-19/coursef/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-19/coursef/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-19/coursef/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursef",
+    "seeding_key": {
+      "script.name": "coursef-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_variables",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_data",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_for_loops",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "For Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_internet",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Internet"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_internet",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 8,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Swimming Fish with Sprite Lab",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Events with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Loops with the Artist",
+      "name": "Drawing with Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in the Maze",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Variables as Constant in Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Variables that Change in Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Variables that Change in Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Simulating Experiments",
+      "name": "Simulating Experiments",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "The Internet",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_internet",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Editing Behaviors",
+      "name": "Behaviors in Sprite Lab",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Virtual Pet",
+      "name": "Virtual Pet with Sprite Lab",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "Digital Sharing",
+      "name": "Digital Sharing",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 2_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 3_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 4_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 5_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 6_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party 7_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_video_artist_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables-Unplugged"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "EnvelopeVariables-Unplugged"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist: Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Run a simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "simstarter"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "simstarter"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Modify simulation variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "simconfig"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "simconfig"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun-Unplugged"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "ForLoopFun-Unplugged"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Repeat Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet-Unplugged"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_internet",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Internet-Unplugged"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 1"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 2"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 3"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3a"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 3a"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 4"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 5"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors free play"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors free play"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 6"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 7"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "behaviors 7"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 1_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 2_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 3_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 4_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 5_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 6_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 7_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 7_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 8_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 8_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PowerOfWords-Unplugged"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "PowerOfWords-Unplugged"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing-Unplugged"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Crowdsourcing-Unplugged"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalSharing-Unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "DigitalSharing-Unplugged"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "courseF_project_exemplars_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Lab Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "CourseF_Project_SpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      },
+      "level_keys": [
+        "Course F: Artist Project_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2019",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2019",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2019",
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2019",
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2019",
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2019",
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2019",
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2019",
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2019",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2019",
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2019",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2019",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables-Unplugged",
+        "script_level.level_keys": [
+          "EnvelopeVariables-Unplugged"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2019",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2019",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "simstarter",
+        "script_level.level_keys": [
+          "simstarter"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "simconfig",
+        "script_level.level_keys": [
+          "simconfig"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun-Unplugged",
+        "script_level.level_keys": [
+          "ForLoopFun-Unplugged"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2019",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2019",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet-Unplugged",
+        "script_level.level_keys": [
+          "Internet-Unplugged"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_internet",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 1",
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 2",
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3",
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3a",
+        "script_level.level_keys": [
+          "behaviors 3a"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 4",
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 5",
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors free play",
+        "script_level.level_keys": [
+          "behaviors free play"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 6",
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 7",
+        "script_level.level_keys": [
+          "behaviors 7"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 1_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 2_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 3_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 4_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 5_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 6_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 7_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 7_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 8_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 8_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PowerOfWords-Unplugged",
+        "script_level.level_keys": [
+          "PowerOfWords-Unplugged"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing-Unplugged",
+        "script_level.level_keys": [
+          "Crowdsourcing-Unplugged"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalSharing-Unplugged",
+        "script_level.level_keys": [
+          "DigitalSharing-Unplugged"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Digital Sharing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_project_exemplars_2019",
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_SpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project_2019",
+        "script_level.level_keys": [
+          "Course F: Artist Project_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-2020.script_json
+++ b/dashboard/config/scripts_json/coursef-2020.script_json
@@ -1,0 +1,5512 @@
+{
+  "script": {
+    "name": "coursef-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/coursef/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Our 2020 CS Fundamentals Lessons are Live!",
+          "details": "Click \"Learn More\" to view all of the lesson plans for the 2020 version of Course F!",
+          "link": "https://curriculum.code.org/csf-20/coursef",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/coursef/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/coursef/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/coursef/standards/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "coursef",
+    "seeding_key": {
+      "script.name": "coursef-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "csf_variables",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "csf_data",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "csf_for_loops",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "For Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Swimming Fish with Sprite Lab",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Events with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Loops with the Artist",
+      "name": "Drawing with Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in the Maze",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Variables as Constant in Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Variables that Change in Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Variables that Change in Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Simulating Experiments",
+      "name": "Simulating Experiments",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "AI for Oceans",
+      "name": "AI for Oceans",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "The Internet",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Editing Behaviors",
+      "name": "Behaviors in Sprite Lab",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "Virtual Pet",
+      "name": "Virtual Pet with Sprite Lab",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Function intro Ryan_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "spritelab_extras_repeat"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 2_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 3_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 4_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 5_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 6_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party 7_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_video_artist_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 13,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PowerOfWords-Unplugged_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "PowerOfWords-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables-Unplugged_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "EnvelopeVariables-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist: Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Run a simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "simstarter_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "simstarter_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Modify simulation variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "simconfig_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "simconfig_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_extras_sim"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_extras_sim"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Video_Societal_Implications"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "CourseF_Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet-Unplugged_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Internet-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun-Unplugged_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "ForLoopFun-Unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Repeat Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 1_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 2_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 2_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 3_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3a_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 3a_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 4_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 4_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 5_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 5_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors free play_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors free play_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 6_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "behaviors 7_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 1_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 2_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 3_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 4_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 5_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 6_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 7_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 7_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Virtual Pet"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 8_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 8_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_project_exemplars_2019_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create your project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_EOC_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      },
+      "level_keys": [
+        "courseF_EOC_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2020",
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "spritelab_extras_repeat",
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2020",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2020",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2020",
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2020",
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2020",
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2020",
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2020",
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2020",
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2020",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Events with Sprite Lab",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2020",
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2020",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2020",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 13,
+        "lesson.key": "Loops with the Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2020",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in the Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PowerOfWords-Unplugged_2020",
+        "script_level.level_keys": [
+          "PowerOfWords-Unplugged_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables-Unplugged_2020",
+        "script_level.level_keys": [
+          "EnvelopeVariables-Unplugged_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2020",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2020",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "simstarter_2020",
+        "script_level.level_keys": [
+          "simstarter_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "simconfig_2020",
+        "script_level.level_keys": [
+          "simconfig_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_extras_sim",
+        "script_level.level_keys": [
+          "courseF_extras_sim"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Simulating Experiments",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "CourseF_Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Short",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Short"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Video_Societal_Implications",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Oceans_Long",
+        "script_level.level_keys": [
+          "CourseF_Oceans_Long"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "AI for Oceans",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet-Unplugged_2020",
+        "script_level.level_keys": [
+          "Internet-Unplugged_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "csf_data",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun-Unplugged_2020",
+        "script_level.level_keys": [
+          "ForLoopFun-Unplugged_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2020",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2020",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 1_2020",
+        "script_level.level_keys": [
+          "behaviors 1_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 2_2020",
+        "script_level.level_keys": [
+          "behaviors 2_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3_2020",
+        "script_level.level_keys": [
+          "behaviors 3_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3a_2020",
+        "script_level.level_keys": [
+          "behaviors 3a_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 4_2020",
+        "script_level.level_keys": [
+          "behaviors 4_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 5_2020",
+        "script_level.level_keys": [
+          "behaviors 5_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors free play_2020",
+        "script_level.level_keys": [
+          "behaviors free play_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 6_2020",
+        "script_level.level_keys": [
+          "behaviors 6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 7_2020",
+        "script_level.level_keys": [
+          "behaviors 7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 1_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 2_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 3_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 4_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 5_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 6_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 7_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 7_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 8_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 8_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_project_exemplars_2019_2020",
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_EOC_2020",
+        "script_level.level_keys": [
+          "courseF_EOC_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-draft.script_json
+++ b/dashboard/config/scripts_json/coursef-draft.script_json
@@ -1,0 +1,4972 @@
+{
+  "script": {
+    "name": "coursef-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursef-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Tangrams",
+      "name": "Algorithms: Tangrams",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Songwriting with Parameters",
+      "name": "Songwriting with Parameters",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Conditionals and Functions in Bee",
+      "name": "Conditionals and Functions in Bee",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "key": "Presentation Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Presentation Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "coursef_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_predict1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_ramp10"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_farmer_ramp11"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp13"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp7"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_ramp14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_external_ramp14"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursef_powerofwords"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "coursef_powerofwords"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_hello1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_hello2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_repeat"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_click_hello"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_throw_hearts"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "iceage_free_play"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables3"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables4"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables5"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables7"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables8"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables9"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variables10"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5b"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5b"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6b"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6b"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_forBee"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for4"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for9"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for10"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_for11"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_forArtist"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for1"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for3"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for4"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for5"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for6"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for7"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for8"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for9"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_for10"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_artistFunctions"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "InspirationalArtwork"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "FoodFight"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Guess The Number"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Course F: Artist Project"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Presentation Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp1",
+        "script_level.level_keys": [
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp2",
+        "script_level.level_keys": [
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursef_maze_ramp3",
+        "script_level.level_keys": [
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp4",
+        "script_level.level_keys": [
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp5",
+        "script_level.level_keys": [
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp6",
+        "script_level.level_keys": [
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp8",
+        "script_level.level_keys": [
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp9",
+        "script_level.level_keys": [
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_predict1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp10",
+        "script_level.level_keys": [
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_farmer_ramp11",
+        "script_level.level_keys": [
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp13",
+        "script_level.level_keys": [
+          "courseF_maze_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp7",
+        "script_level.level_keys": [
+          "courseF_maze_ramp7"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_ramp14",
+        "script_level.level_keys": [
+          "courseF_external_ramp14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursef_powerofwords",
+        "script_level.level_keys": [
+          "coursef_powerofwords"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1",
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2",
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag",
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor",
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat",
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello",
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts",
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play",
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2",
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3",
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4",
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5",
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6",
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7",
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8",
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9",
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10",
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5b"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6b"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1",
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2",
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee",
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4",
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6",
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7",
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8",
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5",
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9",
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10",
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11",
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist",
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1",
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2",
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3",
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4",
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5",
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6",
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7",
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8",
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9",
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10",
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistFunctions",
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork",
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight",
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number",
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project",
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Presentation Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "coursef-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/coursef-ramp.script_json
+++ b/dashboard/config/scripts_json/coursef-ramp.script_json
@@ -1,0 +1,1807 @@
+{
+  "script": {
+    "name": "coursef-ramp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "coursef-ramp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Tangrams",
+      "name": "Algorithms: Tangrams",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "key": "Conditionals and Functions in Bee",
+      "name": "Conditionals and Functions in Bee",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "coursef_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_predict1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_artist_ramp10"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_farmer_ramp11"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp13"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_maze_ramp7"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_ramp14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_external_ramp14"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_hello1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_hello2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_repeat"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_click_hello"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_throw_hearts"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "iceage_free_play"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp1",
+        "script_level.level_keys": [
+          "courseF_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp2",
+        "script_level.level_keys": [
+          "courseF_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursef_maze_ramp3",
+        "script_level.level_keys": [
+          "coursef_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp4",
+        "script_level.level_keys": [
+          "courseF_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp5",
+        "script_level.level_keys": [
+          "courseF_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp6",
+        "script_level.level_keys": [
+          "courseF_maze_ramp6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp8",
+        "script_level.level_keys": [
+          "courseF_artist_ramp8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp9",
+        "script_level.level_keys": [
+          "courseF_artist_ramp9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_predict1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_ramp10",
+        "script_level.level_keys": [
+          "courseF_artist_ramp10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_farmer_ramp11",
+        "script_level.level_keys": [
+          "courseF_farmer_ramp11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp13",
+        "script_level.level_keys": [
+          "courseF_maze_ramp13"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_maze_ramp7",
+        "script_level.level_keys": [
+          "courseF_maze_ramp7"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_ramp14",
+        "script_level.level_keys": [
+          "courseF_external_ramp14"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1",
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2",
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag",
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor",
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat",
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello",
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts",
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play",
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 17,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 18,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 19,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 20,
+        "lesson.key": "Conditionals and Functions in Bee",
+        "lesson_group.key": "",
+        "script.name": "coursef-ramp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/craft17-kiki.script_json
+++ b/dashboard/config/scripts_json/craft17-kiki.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "craft17-kiki",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "craft17-kiki"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "craft17 stage",
+      "name": "craft17 stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_Kiki"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_Kiki"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Kiki"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Kiki"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Kiki"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Kiki"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Kiki"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Kiki"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Kiki"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Kiki"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Kiki"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Kiki"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07a_Kiki"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07a_Kiki"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Kiki"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Kiki"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_08_Kiki"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_08_Kiki"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_09_Kiki"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_09_Kiki"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_Kiki"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_Kiki"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_11_Kiki"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      },
+      "level_keys": [
+        "MC_HOC_2017_11_Kiki"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_Kiki"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Kiki"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Kiki"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Kiki"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Kiki"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Kiki"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07a_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07a_Kiki"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Kiki"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_08_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_08_Kiki"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_09_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_09_Kiki"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_Kiki"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_11_Kiki",
+        "script_level.level_keys": [
+          "MC_HOC_2017_11_Kiki"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17-kiki"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/craft17.script_json
+++ b/dashboard/config/scripts_json/craft17.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "craft17",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "craft17"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "craft17 stage",
+      "name": "craft17 stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "craft17 stage",
+        "lesson_group.key": "",
+        "script.name": "craft17"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/craft18.script_json
+++ b/dashboard/config/scripts_json/craft18.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "craft18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "craft18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "craft18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "craft18 levels",
+      "name": "craft18 levels",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "craft18 levels",
+        "lesson_group.key": "",
+        "script.name": "craft18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Ryan_2018_mc_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft18 levels",
+        "lesson_group.key": "",
+        "script.name": "craft18"
+      },
+      "level_keys": [
+        "Ryan_2018_mc_1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Ryan_2018_mc_1",
+        "script_level.level_keys": [
+          "Ryan_2018_mc_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "craft18 levels",
+        "lesson_group.key": "",
+        "script.name": "craft18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-apprentice-18.script_json
+++ b/dashboard/config/scripts_json/csd-apprentice-18.script_json
@@ -1,0 +1,728 @@
+{
+  "script": {
+    "name": "csd-apprentice-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-apprentice-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Apprentice Reflection Overview",
+      "name": "Apprentice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "welcome-apprentice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-monday"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "feel-monday"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-tuesday"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "feel-tuesday"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "instructional-strategy-tuesday"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-wednesday"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "feel-wednesday"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "getting-buy-in-wednesday"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-thursday"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "feel-thursday"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "recruiting-thursday"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      },
+      "level_keys": [
+        "apprentice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-apprentice-18",
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-monday",
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-monday",
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit1",
+        "script_level.level_keys": [
+          "csd-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-tuesday",
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-tuesday",
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "instructional-strategy-tuesday",
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit2",
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-wednesday",
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-wednesday",
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "getting-buy-in-wednesday",
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit2",
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-thursday",
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-thursday",
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "recruiting-thursday",
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit3",
+        "script_level.level_keys": [
+          "csd-pushDL-unit3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "apprentice-congrats",
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-apprentice-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-bugs.script_json
+++ b/dashboard/config/scripts_json/csd-bugs.script_json
@@ -1,0 +1,552 @@
+{
+  "script": {
+    "name": "csd-bugs",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-bugs"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Game Lab Bugs",
+      "name": "Game Lab Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "key": "Immovable Crab",
+      "name": "Immovable Crab",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug text behind sprites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug text behind sprites"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug infinity mouse 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug infinity mouse 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug infinity mouse 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug infinity mouse 2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug not a function"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug not a function"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 5"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 6"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 6"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 7"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 7"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 8"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      },
+      "level_keys": [
+        "gamelab bug declare sprite in loop 8"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug text behind sprites",
+        "script_level.level_keys": [
+          "gamelab bug text behind sprites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug infinity mouse 1",
+        "script_level.level_keys": [
+          "gamelab bug infinity mouse 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug infinity mouse 2",
+        "script_level.level_keys": [
+          "gamelab bug infinity mouse 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug not a function",
+        "script_level.level_keys": [
+          "gamelab bug not a function"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Game Lab Bugs",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 1",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 2",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 3",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 4",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 5",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 6",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 6"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 7",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 7"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gamelab bug declare sprite in loop 8",
+        "script_level.level_keys": [
+          "gamelab bug declare sprite in loop 8"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Immovable Crab",
+        "lesson_group.key": "",
+        "script.name": "csd-bugs"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-novice-18.script_json
+++ b/dashboard/config/scripts_json/csd-novice-18.script_json
@@ -1,0 +1,623 @@
+{
+  "script": {
+    "name": "csd-novice-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-novice-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Novice Reflection Overview",
+      "name": "Novice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "welcome-novice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-monday-1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-monday-2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-tuesday-1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-tuesday-2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-wednesday-1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-wednesday-2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-thursday-1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-thursday-2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pushDL-unit3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "csd-pushDL-unit3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      },
+      "level_keys": [
+        "novice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-novice-18",
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-1",
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-2",
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit1",
+        "script_level.level_keys": [
+          "csd-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-1",
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-2",
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit2",
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-1",
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-2",
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit2",
+        "script_level.level_keys": [
+          "csd-pushDL-unit2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-1",
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-2",
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pushDL-unit3",
+        "script_level.level_keys": [
+          "csd-pushDL-unit3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-congrats",
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csd-novice-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-pilot.script_json
+++ b/dashboard/config/scripts_json/csd-pilot.script_json
@@ -1,0 +1,1455 @@
+{
+  "script": {
+    "name": "csd-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Pilot Information 1",
+      "name": "Pilot Information 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 1",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 2",
+      "name": "Pilot Information 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 2",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 3",
+      "name": "Pilot Information 3",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 3",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 4",
+      "name": "Pilot Information 4",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 4",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 5",
+      "name": "Pilot Information 5",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 5",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 6",
+      "name": "Pilot Information 6",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 6",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 7",
+      "name": "Pilot Information 7",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 7",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 8",
+      "name": "Pilot Information 8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 8",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 9",
+      "name": "Pilot Information 9",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 9",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 10",
+      "name": "Pilot Information 10",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 10",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 11",
+      "name": "Pilot Information 11",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 11",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 12",
+      "name": "Pilot Information 12",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 12",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 13",
+      "name": "Pilot Information 13",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 13",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 14",
+      "name": "Pilot Information 14",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 14",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 15",
+      "name": "Pilot Information 15",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 15",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 16",
+      "name": "Pilot Information 16",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 16",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 17",
+      "name": "Pilot Information 17",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 17",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 18",
+      "name": "Pilot Information 18",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 18",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 19",
+      "name": "Pilot Information 19",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 19",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 20",
+      "name": "Pilot Information 20",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 20",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 21",
+      "name": "Pilot Information 21",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 21",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 22",
+      "name": "Pilot Information 22",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 22",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 23",
+      "name": "Pilot Information 23",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 23",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 24",
+      "name": "Pilot Information 24",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 24",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 25",
+      "name": "Pilot Information 25",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 25",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 26",
+      "name": "Pilot Information 26",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 26",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 27",
+      "name": "Pilot Information 27",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 27",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 28",
+      "name": "Pilot Information 28",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 28",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "key": "Pilot Information 29",
+      "name": "Pilot Information 29",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pilot Information 29",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 1",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 2",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 3",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 4",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 5",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 6",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 7",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 8",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 9",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 10",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 11",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 12",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 13",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 14",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 15",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 16",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 17",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 18",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 19",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 20",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 21",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 22",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 23",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 24",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 25",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 26",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 27",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 28",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 29",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      },
+      "level_keys": [
+        "CSD Pilot Warning Page"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 1",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 2",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 3",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 4",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 5",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 6",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 7",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 8",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 9",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 10",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 11",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 12",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 13",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 14",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 15",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 16",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 17",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 18",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 19",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 20",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 21",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 22",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 23",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 24",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 25",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 26",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 27",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 28",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Pilot Warning Page",
+        "script_level.level_keys": [
+          "CSD Pilot Warning Page"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Pilot Information 29",
+        "lesson_group.key": "",
+        "script.name": "csd-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-post-survey-2018.script_json
+++ b/dashboard/config/scripts_json/csd-post-survey-2018.script_json
@@ -1,0 +1,88 @@
+{
+  "script": {
+    "name": "csd-post-survey-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-post-survey-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd-post-survey-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSD post-course survey",
+      "name": "CSD post-course survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd-post-survey-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "CS Discoveries Post-Course Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup-2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd-post-survey-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup-2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup-2018",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup-2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd-post-survey-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-post-survey.script_json
+++ b/dashboard/config/scripts_json/csd-post-survey.script_json
@@ -1,0 +1,86 @@
+{
+  "script": {
+    "name": "csd-post-survey",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-post-survey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd-post-survey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSD post-course survey",
+      "name": "CSD post-course survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd-post-survey"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "CS Discoveries Post-course Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd-post-survey"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup-2018-2nd-semester",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup-2018-2nd-semester"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD post-course survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd-post-survey"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-sample-online.script_json
+++ b/dashboard/config/scripts_json/csd-sample-online.script_json
@@ -1,0 +1,342 @@
+{
+  "script": {
+    "name": "csd-sample-online",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-sample-online"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is a Computer? - sample progression",
+      "name": "What is a Computer? - sample progression",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "key": "Problem Solving Process - sample activities",
+      "name": "Problem Solving Process - sample activities",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving Process - sample activities",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD digital Unplugged WIAC video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "CSD digital Unplugged WIAC video"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD digital unplugged WIAC Qs"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "CSD digital unplugged WIAC Qs"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving Process - sample activities",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP word search"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving Process - sample activities",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP seating"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L1",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L2",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD digital Unplugged WIAC video",
+        "script_level.level_keys": [
+          "CSD digital Unplugged WIAC video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L3",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD digital unplugged WIAC Qs",
+        "script_level.level_keys": [
+          "CSD digital unplugged WIAC Qs"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "What is a Computer? - sample progression",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP word search",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving Process - sample activities",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP seating",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving Process - sample activities",
+        "lesson_group.key": "",
+        "script.name": "csd-sample-online"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-test-saving-state.script_json
+++ b/dashboard/config/scripts_json/csd-test-saving-state.script_json
@@ -1,0 +1,342 @@
+{
+  "script": {
+    "name": "csd-test-saving-state",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-test-saving-state"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "key": "Problem Solving Process",
+      "name": "Problem Solving Process",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD digital Unplugged WIAC video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "CSD digital Unplugged WIAC video"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged WIAC L3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD digital unplugged WIAC Qs"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "CSD digital unplugged WIAC Qs"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP word search"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP seating"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L1",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L2",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD digital Unplugged WIAC video",
+        "script_level.level_keys": [
+          "CSD digital Unplugged WIAC video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged WIAC L3",
+        "script_level.level_keys": [
+          "csd digital unplugged WIAC L3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD digital unplugged WIAC Qs",
+        "script_level.level_keys": [
+          "CSD digital unplugged WIAC Qs"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP word search",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP seating",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd-test-saving-state"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-tests.script_json
+++ b/dashboard/config/scripts_json/csd-tests.script_json
@@ -1,0 +1,1128 @@
+{
+  "script": {
+    "name": "csd-tests",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-tests"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Computers and Problem Solving",
+      "name": "Computers and Problem Solving",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "key": "Web Development",
+      "name": "Web Development",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "key": "Interactive Animations and Games",
+      "name": "Interactive Animations and Games",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test define a computer"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test define a computer"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test PSP match"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test PSP match"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IOSP match"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 IOSP match"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test define problem"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test define problem"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test storage FR"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test storage FR"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test Feedback FR"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test Feedback FR"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test Collaborate FR"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test Collaborate FR"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test Iteration FR"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test Iteration FR"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U1 Test"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test HTML Usage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test HTML Usage"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test ContentStructureStyle"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test ContentStructureStyle"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test Classes"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test Classes"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test Debug"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test Debug"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test code stylesheet"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test code stylesheet"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test code styles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test code styles"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test Copyright"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test Copyright"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test Bug FR"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test Bug FR"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test Copyright FR"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test Copyright FR"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Test DigCit FR"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U2 Test DigCit FR"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD Web Development Post-Project Test"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test clean code"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test clean code"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test functions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test functions"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test variables"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test variables"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test planning"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test planning"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test debugging"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test debugging"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test comment"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test comment"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test debug FR"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test debug FR"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test parameter FR"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test parameter FR"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Test collaboration FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD U3 Test collaboration FR"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      },
+      "level_keys": [
+        "CSD Interactive Animations and Games Post-Project Test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test define a computer",
+        "script_level.level_keys": [
+          "CSD U1 Test define a computer"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test PSP match",
+        "script_level.level_keys": [
+          "CSD U1 Test PSP match"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IOSP match",
+        "script_level.level_keys": [
+          "CSD U1 IOSP match"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test define problem",
+        "script_level.level_keys": [
+          "CSD U1 Test define problem"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test storage FR",
+        "script_level.level_keys": [
+          "CSD U1 Test storage FR"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test Feedback FR",
+        "script_level.level_keys": [
+          "CSD U1 Test Feedback FR"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test Collaborate FR",
+        "script_level.level_keys": [
+          "CSD U1 Test Collaborate FR"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test Iteration FR",
+        "script_level.level_keys": [
+          "CSD U1 Test Iteration FR"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test",
+        "script_level.level_keys": [
+          "CSD U1 Test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Computers and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test HTML Usage",
+        "script_level.level_keys": [
+          "CSD U2 Test HTML Usage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test ContentStructureStyle",
+        "script_level.level_keys": [
+          "CSD U2 Test ContentStructureStyle"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test Classes",
+        "script_level.level_keys": [
+          "CSD U2 Test Classes"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test Debug",
+        "script_level.level_keys": [
+          "CSD U2 Test Debug"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test code stylesheet",
+        "script_level.level_keys": [
+          "CSD U2 Test code stylesheet"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test code styles",
+        "script_level.level_keys": [
+          "CSD U2 Test code styles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test Copyright",
+        "script_level.level_keys": [
+          "CSD U2 Test Copyright"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test Bug FR",
+        "script_level.level_keys": [
+          "CSD U2 Test Bug FR"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test Copyright FR",
+        "script_level.level_keys": [
+          "CSD U2 Test Copyright FR"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Test DigCit FR",
+        "script_level.level_keys": [
+          "CSD U2 Test DigCit FR"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Development Post-Project Test",
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test clean code",
+        "script_level.level_keys": [
+          "CSD U3 Test clean code"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test functions",
+        "script_level.level_keys": [
+          "CSD U3 Test functions"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test variables",
+        "script_level.level_keys": [
+          "CSD U3 Test variables"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test planning",
+        "script_level.level_keys": [
+          "CSD U3 Test planning"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test debugging",
+        "script_level.level_keys": [
+          "CSD U3 Test debugging"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test comment",
+        "script_level.level_keys": [
+          "CSD U3 Test comment"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test debug FR",
+        "script_level.level_keys": [
+          "CSD U3 Test debug FR"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test parameter FR",
+        "script_level.level_keys": [
+          "CSD U3 Test parameter FR"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Test collaboration FR",
+        "script_level.level_keys": [
+          "CSD U3 Test collaboration FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Interactive Animations and Games Post-Project Test",
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Interactive Animations and Games",
+        "lesson_group.key": "",
+        "script.name": "csd-tests"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd-videos.script_json
+++ b/dashboard/config/scripts_json/csd-videos.script_json
@@ -1,0 +1,1063 @@
+{
+  "script": {
+    "name": "csd-videos",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd-videos"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Problem Solving and Computers",
+      "name": "Problem Solving and Computers",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Computers",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "key": "Web Development",
+      "name": "Web Development",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "key": "Games and Animations",
+      "name": "Games and Animations",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "key": "User Centered Design",
+      "name": "User Centered Design",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Centered Design",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "key": "Data and Society",
+      "name": "Data and Society",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "key": "Physical Computing",
+      "name": "Physical Computing",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Computers",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "User Centered Design",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary video_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U5 binary video_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U5 Netflix Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U6 arrays video"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD: For Loop_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_2019",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Computers",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_2019",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_2019",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video_2019",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_2019",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_2019",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Web Development",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_2019",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_2019",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2019",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_2019",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_2019",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_2019",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_2019",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_2019",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video_2019",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_2019",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_2019",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Games and Animations",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video_2019",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "User Centered Design",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary video_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary video_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Netflix Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Data and Society",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video_2019",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays video",
+        "script_level.level_keys": [
+          "CSD U6 arrays video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop_2019",
+        "script_level.level_keys": [
+          "CSD: For Loop_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video_2019",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Physical Computing",
+        "lesson_group.key": "",
+        "script.name": "csd-videos"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-2017.script_json
+++ b/dashboard/config/scripts_json/csd1-2017.script_json
@@ -1,0 +1,654 @@
+{
+  "script": {
+    "name": "csd1-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "Are you signed up for the AP exam?",
+          "details": "Now's the time to register to take the AP CS Principles exam! Be sure to ask your teacher about your school's registration deadline and sign up today. Not sure you want to take the test? We've got SIX reasons why you should. Check them out!",
+          "link": "",
+          "type": "information"
+        }
+      ],
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit1"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd1"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": "csd1-2017",
+    "family_name": "csd1",
+    "seeding_key": {
+      "script.name": "csd1-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "csd1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: The Problem Solving Process"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Discoveries Pre-survey",
+      "name": "CS Discoveries Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Storage",
+      "name": "Storage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Apps and Problem Solving",
+      "name": "Apps and Problem Solving",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apps and Problem Solving",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "key": "Project - Propose an App",
+      "name": "Project - Propose an App",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "csd-pre-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 1 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 2 Overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 3 Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 4 Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD U1 Lesson 5 Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD U1 Lesson 6 Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD U1 Lesson 7 Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Problem Solving",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD U1 Lesson 8 Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "CSD U1 Lesson 9 Overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U1Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 1 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 2 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 3 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 4 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Lesson 5 Overview",
+        "script_level.level_keys": [
+          "CSD U1 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Lesson 6 Overview",
+        "script_level.level_keys": [
+          "CSD U1 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Lesson 7 Overview",
+        "script_level.level_keys": [
+          "CSD U1 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Lesson 8 Overview",
+        "script_level.level_keys": [
+          "CSD U1 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Problem Solving",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Lesson 9 Overview",
+        "script_level.level_keys": [
+          "CSD U1 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U1Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-2018.script_json
+++ b/dashboard/config/scripts_json/csd1-2018.script_json
@@ -1,0 +1,597 @@
+{
+  "script": {
+    "name": "csd1-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit1"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd1"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd1",
+    "seeding_key": {
+      "script.name": "csd1-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "csd1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: The Problem Solving Process"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Discoveries Pre-survey",
+      "name": "CS Discoveries Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Apps and Storage",
+      "name": "Apps and Storage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "key": "Project - Propose an App",
+      "name": "Project - Propose an App",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "csd-pre-survey-2017-levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L01 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L02 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L03 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L04 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L05 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L06 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L07 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "CSD U1L09 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U1Ch2_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L02 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L03 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L04 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_2018",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L05 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L06 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L07 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L09 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U1Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-2019.script_json
+++ b/dashboard/config/scripts_json/csd1-2019.script_json
@@ -1,0 +1,682 @@
+{
+  "script": {
+    "name": "csd1-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit1/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit1"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd1",
+    "seeding_key": {
+      "script.name": "csd1-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "csd1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: The Problem Solving Process"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Discoveries Pre-survey",
+      "name": "CS Discoveries Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Apps and Storage",
+      "name": "Apps and Storage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Project - Propose an App",
+      "name": "Project - Propose an App",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "csd-pre-survey-levelgroup_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L01 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L02 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD Problem Solving Process Video"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L03 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L04 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L05 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L06 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L07 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1L09 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      },
+      "level_keys": [
+        "CSD U1 Test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L02 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Problem Solving Process Video",
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L03 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L04 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_2019",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L05 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L06 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L07 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L09 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test",
+        "script_level.level_keys": [
+          "CSD U1 Test"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-2020.script_json
+++ b/dashboard/config/scripts_json/csd1-2020.script_json
@@ -1,0 +1,1493 @@
+{
+  "script": {
+    "name": "csd1-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit1/{LESSON}",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit1"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd1-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "csd1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: The Problem Solving Process"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "csd1_3",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Alternate Lessons"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Discoveries Pre-survey",
+      "name": "CS Discoveries Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Storage",
+      "name": "Storage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Project - Propose an App",
+      "name": "Project - Propose an App",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)",
+      "name": "Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)",
+      "name": "Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving - Paper Tower (Alternate Lesson 1)",
+      "name": "Intro to Problem Solving - Paper Tower (Alternate Lesson 1)",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving - Paper Tower (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving - Animals Theme (Alternate Lesson 3)",
+      "name": "Exploring Problem Solving - Animals Theme (Alternate Lesson 3)",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving - Animals Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving - Games Theme (Alternate Lesson 3)",
+      "name": "Exploring Problem Solving - Games Theme (Alternate Lesson 3)",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving - Games Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "csd-pre-survey-levelgroup_2019_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L01 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L02 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Problem Solving Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD Problem Solving Process Video_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L03 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L04 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: What Makes a Computer, a Computer?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L05 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Pet Chooser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 IO Pet Chooser"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Story Creator"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Story"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 IO Story"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Improved Pet Chooser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 IO Pet Chooser 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L06 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Is It Your Birthday?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing bday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing bday"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App: National Park Quiz"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing npark"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing npark"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App: How Many Countries..."
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing countries"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing countries"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "App: My Famous Birthday"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing writers"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing writers"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Stamp Notebook"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing notebook"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing notebook"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App: The Fastest Finger"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing fastest"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing fastest"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Guess the Number"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing guess"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing guess"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Where Should I Live?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing live"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 processing live"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L07 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Outfit Picker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage outfit"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 storage outfit"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Friend Finder"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage friends"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 storage friends"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Kids Movie Recommender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage movies"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 storage movies"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: IOSP Model"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 storage video"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L09 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1 Test_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01.1 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L01.1 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01.2 TFMD_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L01.2 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01.3 TFMD_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Paper Tower (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L01.3 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L12 TFMD_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving - Animals Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L12 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L13 TFMD_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving - Games Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      },
+      "level_keys": [
+        "CSD U1L13 TFMD_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-levelgroup_2019_2020",
+        "script_level.level_keys": [
+          "csd-pre-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L02 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Problem Solving Process Video_2020",
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L03 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L04 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_2020",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L05 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Pet Chooser",
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Story",
+        "script_level.level_keys": [
+          "CSD U1 IO Story"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Pet Chooser 2",
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L06 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing bday",
+        "script_level.level_keys": [
+          "CSD U1 processing bday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing npark",
+        "script_level.level_keys": [
+          "CSD U1 processing npark"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing countries",
+        "script_level.level_keys": [
+          "CSD U1 processing countries"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing writers",
+        "script_level.level_keys": [
+          "CSD U1 processing writers"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing notebook",
+        "script_level.level_keys": [
+          "CSD U1 processing notebook"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing fastest",
+        "script_level.level_keys": [
+          "CSD U1 processing fastest"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing guess",
+        "script_level.level_keys": [
+          "CSD U1 processing guess"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing live",
+        "script_level.level_keys": [
+          "CSD U1 processing live"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L07 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage outfit",
+        "script_level.level_keys": [
+          "CSD U1 storage outfit"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage friends",
+        "script_level.level_keys": [
+          "CSD U1 storage friends"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage movies",
+        "script_level.level_keys": [
+          "CSD U1 storage movies"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage video",
+        "script_level.level_keys": [
+          "CSD U1 storage video"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L09 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test_2020",
+        "script_level.level_keys": [
+          "CSD U1 Test_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01.1 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L01.1 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01.2 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L01.2 TFMD_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01.3 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L01.3 TFMD_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving - Paper Tower (Alternate Lesson 1)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L12 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L12 TFMD_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving - Animals Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L13 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L13 TFMD_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving - Games Theme (Alternate Lesson 3)",
+        "lesson_group.key": "csd1_3",
+        "script.name": "csd1-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd1-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csd1-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd1-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 1 Deeper Learning Reflections",
+      "name": "Complete Unit 1 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "csd1dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "csd1dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      },
+      "level_keys": [
+        "csd1dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-q1",
+        "script_level.level_keys": [
+          "csd1dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-q2",
+        "script_level.level_keys": [
+          "csd1dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-q3",
+        "script_level.level_keys": [
+          "csd1dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-dlp.script_json
+++ b/dashboard/config/scripts_json/csd1-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd1-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd1-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 1 Deeper Learning Reflections",
+      "name": "Complete Unit 1 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "csd1dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "csd1dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd1dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      },
+      "level_keys": [
+        "csd1dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-lessons",
+        "script_level.level_keys": [
+          "csd1dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-tools",
+        "script_level.level_keys": [
+          "csd1dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd1dlp-assessment",
+        "script_level.level_keys": [
+          "csd1dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd1-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-old.script_json
+++ b/dashboard/config/scripts_json/csd1-old.script_json
@@ -1,0 +1,897 @@
+{
+  "script": {
+    "name": "csd1-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd1-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Representing Information",
+      "name": "Representing Information",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Processing with Bits",
+      "name": "Processing with Bits",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Human vs Computer Processing",
+      "name": "Human vs Computer Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Human vs Computer Processing",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Processing with Apps",
+      "name": "Processing with Apps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "key": "Project: Apps and Problem Solving",
+      "name": "Project: Apps and Problem Solving",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Apps and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 1 Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 2 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 3 Overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 4 Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 5 Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 6 Overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter 1x1 intro"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter 1x1 intro"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Filter Intro"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter Filter Intro"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Mushroom"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter Mushroom"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Filter Revisit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter Filter Revisit"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Mario"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter Mario"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter UnFilter"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter UnFilter"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter FreePlay"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 - PixFilter FreePlay"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Human vs Computer Processing",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 7 Overview"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 8 Overview"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Input Output Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 Input Output Intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Input Output C1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 Input Output C1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Input Output C2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 Input Output C2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Input Output C3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 Input Output C3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Input Output C4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "CSD U1 Input Output C4"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project: Apps and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      },
+      "level_keys": [
+        "Unit 1 Lesson 9 Overview"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 1 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 2 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 3 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 4 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 5 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 6 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter 1x1 intro",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter 1x1 intro"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter Filter Intro",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Filter Intro"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter Mushroom",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Mushroom"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter Filter Revisit",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Filter Revisit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter Mario",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter Mario"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter UnFilter",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter UnFilter"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 - PixFilter FreePlay",
+        "script_level.level_keys": [
+          "CSD U1 - PixFilter FreePlay"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Processing with Bits",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 7 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Human vs Computer Processing",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 8 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Input Output Intro",
+        "script_level.level_keys": [
+          "CSD U1 Input Output Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Input Output C1",
+        "script_level.level_keys": [
+          "CSD U1 Input Output C1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Input Output C2",
+        "script_level.level_keys": [
+          "CSD U1 Input Output C2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Input Output C3",
+        "script_level.level_keys": [
+          "CSD U1 Input Output C3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Input Output C4",
+        "script_level.level_keys": [
+          "CSD U1 Input Output C4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Processing with Apps",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Lesson 9 Overview",
+        "script_level.level_keys": [
+          "Unit 1 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project: Apps and Problem Solving",
+        "lesson_group.key": "",
+        "script.name": "csd1-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd1-pilot.script_json
+++ b/dashboard/config/scripts_json/csd1-pilot.script_json
@@ -1,0 +1,1150 @@
+{
+  "script": {
+    "name": "csd1-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit1/{LESSON}",
+      "pilot_experiment": "csd-piloters",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit1"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd1-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "csd1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: The Problem Solving Process"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Discoveries Pre-survey",
+      "name": "CS Discoveries Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "Intro to Problem Solving",
+      "name": "Intro to Problem Solving",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "The Problem Solving Process",
+      "name": "The Problem Solving Process",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "Exploring Problem Solving",
+      "name": "Exploring Problem Solving",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "key": "Apps and Storage",
+      "name": "Apps and Storage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "csd-pre-survey-2017-levelgroup_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L01 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L02 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD Problem Solving Process Video_pilot"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L03 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search big"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP word search big"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating big"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP seating big"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L04 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L05 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 IO Pet Chooser"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Story"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 IO Story"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 IO Pet Chooser 2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L06 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Is It Your Birthday?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing bday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing bday"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App: National Park Quiz"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing npark"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing npark"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App: How Many Countries..."
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing countries"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing countries"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "App: My Famous Birthday"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing writers"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing writers"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Stamp Notebook"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing notebook"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing notebook"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App: The Fastest Finger"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing fastest"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing fastest"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Guess the Number"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing guess"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing guess"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App: Where Should I Live?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 processing live"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 processing live"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1L07 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage outfit"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 storage outfit"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage friends"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 storage friends"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage movies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 storage movies"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 storage video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      },
+      "level_keys": [
+        "CSD U1 storage video"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csd-pre-survey-2017-levelgroup_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pre-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L01 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L02 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Problem Solving Process Video_pilot",
+        "script_level.level_keys": [
+          "CSD Problem Solving Process Video_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "The Problem Solving Process",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L03 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP word search big",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search big"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP seating big",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating big"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Problem Solving",
+        "lesson_group.key": "csd1_1",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L04 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_2020",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L05 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Pet Chooser",
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Story",
+        "script_level.level_keys": [
+          "CSD U1 IO Story"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 IO Pet Chooser 2",
+        "script_level.level_keys": [
+          "CSD U1 IO Pet Chooser 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L06 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing bday",
+        "script_level.level_keys": [
+          "CSD U1 processing bday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing npark",
+        "script_level.level_keys": [
+          "CSD U1 processing npark"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing countries",
+        "script_level.level_keys": [
+          "CSD U1 processing countries"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing writers",
+        "script_level.level_keys": [
+          "CSD U1 processing writers"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing notebook",
+        "script_level.level_keys": [
+          "CSD U1 processing notebook"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing fastest",
+        "script_level.level_keys": [
+          "CSD U1 processing fastest"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing guess",
+        "script_level.level_keys": [
+          "CSD U1 processing guess"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 processing live",
+        "script_level.level_keys": [
+          "CSD U1 processing live"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L07 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage outfit",
+        "script_level.level_keys": [
+          "CSD U1 storage outfit"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage friends",
+        "script_level.level_keys": [
+          "CSD U1 storage friends"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage movies",
+        "script_level.level_keys": [
+          "CSD U1 storage movies"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 storage video",
+        "script_level.level_keys": [
+          "CSD U1 storage video"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd1-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-2017.script_json
+++ b/dashboard/config/scripts_json/csd2-2017.script_json
@@ -1,0 +1,3967 @@
+{
+  "script": {
+    "name": "csd2-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd2"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit2/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd/unit2/code/"
+        ]
+      ]
+    },
+    "new_name": "csd2-2017",
+    "family_name": "csd2",
+    "seeding_key": {
+      "script.name": "csd2-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Web Content and HTML"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "csd2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Styling and CSS"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd2-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Websites",
+      "name": "Exploring Websites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Lists",
+      "name": "Lists",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Intellectual Property and Images",
+      "name": "Intellectual Property and Images",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Clean Code and Debugging",
+      "name": "Clean Code and Debugging",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Project - Multi-Page Websites",
+      "name": "Project - Multi-Page Websites",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Sources and Search Engines",
+      "name": "Sources and Search Engines",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "RGB Colors and Classes",
+      "name": "RGB Colors and Classes",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "Project - Personal Portfolio Website",
+      "name": "Project - Personal Portfolio Website",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "key": "CSD Post-Course Survey",
+      "name": "CSD Post-Course Survey",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd2-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L1 Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L2 Overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L3 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L3 Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 HTML Tags Map"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L4 Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L4 Overview"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD Header Size MC"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Headers map"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Headers map"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 PSP Programming"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Design Project"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Design Project"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Project Start"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Project Start"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L5 Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L5 Overview"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Social Sleuth"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L6 Overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L6 Overview"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 lists intro"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 ordered list"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 ordered list"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 unordered list"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 unordered list"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists match"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 lists match"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists map"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 lists map"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 expand project"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 expand project"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 new page"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 new page"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L7 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L7 Overview"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 images map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 images map"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 CC Search Map"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Attribution"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Info Page Final Touches"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Lesson 6 Overview"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 commenting"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 commenting"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 formatting map"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 formatting map"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 challenge"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 challenge"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Lesson 9 Overview"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 a tag map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 a tag map"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 link demo"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 navigation"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 navigation"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 project guide"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 create page"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 create page"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 upload images"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 add content"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 header footer"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 header footer"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 project review"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 project share"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch1"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 7 Overview"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Video: Intro to CSS"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style h1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style h3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Style Sheet Map"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style size"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style font family"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style font family"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style decoration"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style decoration"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style text align"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style text align"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Text Properties Map"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 add file"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 text style freeplay"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 8 Overview"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSS U2 Body Map"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSS U2 Body Map"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style body"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style border"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style border"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style borderradius"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style float"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style width"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style margin"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style margin"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 Layout Properties Map"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 layout style freeplay"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 L12 Overview"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 L12 Overview"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 10 Overview"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 10 Overview"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB winter"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 RGB winter"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB summer"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 RGB summer"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB others"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 RGB others"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 classes sample"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 CSS Classes Map"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 classes modify"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 classes spring"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSD U2 classes summer"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Class Style Personal Site"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 16 Overview"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 16 Overview"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Final Personal Website"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "Final Personal Website"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch2"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd2-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L1 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L2 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L3 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L3 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Tags Map",
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L4 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L4 Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC",
+        "script_level.level_keys": [
+          "CSD Header Size MC"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Headers map",
+        "script_level.level_keys": [
+          "CSD U2 Headers map"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 PSP Programming",
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Design Project",
+        "script_level.level_keys": [
+          "CSD U2 Design Project"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Project Start",
+        "script_level.level_keys": [
+          "CSD U2 Project Start"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L5 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L5 Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth",
+        "script_level.level_keys": [
+          "Social Sleuth"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L6 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L6 Overview"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists intro",
+        "script_level.level_keys": [
+          "CSD U2 lists intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 ordered list",
+        "script_level.level_keys": [
+          "CSD U2 ordered list"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 unordered list",
+        "script_level.level_keys": [
+          "CSD U2 unordered list"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists match",
+        "script_level.level_keys": [
+          "CSD U2 lists match"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists map",
+        "script_level.level_keys": [
+          "CSD U2 lists map"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 expand project",
+        "script_level.level_keys": [
+          "CSD U2 expand project"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 new page",
+        "script_level.level_keys": [
+          "CSD U2 new page"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L7 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L7 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 images map",
+        "script_level.level_keys": [
+          "CSD U2 images map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CC Search Map",
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Attribution",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Info Page Final Touches",
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Lesson 6 Overview",
+        "script_level.level_keys": [
+          "CSD U2 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 1",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 2",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 3",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 4",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 commenting",
+        "script_level.level_keys": [
+          "CSD U2 commenting"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 formatting map",
+        "script_level.level_keys": [
+          "CSD U2 formatting map"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 challenge",
+        "script_level.level_keys": [
+          "CSD U2 challenge"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Lesson 9 Overview",
+        "script_level.level_keys": [
+          "CSD U2 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 a tag map",
+        "script_level.level_keys": [
+          "CSD U2 a tag map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo",
+        "script_level.level_keys": [
+          "CSD U2 link demo"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 navigation",
+        "script_level.level_keys": [
+          "CSD U2 navigation"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide",
+        "script_level.level_keys": [
+          "CSD U2 project guide"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 create page",
+        "script_level.level_keys": [
+          "CSD U2 create page"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images",
+        "script_level.level_keys": [
+          "CSD U2 upload images"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content",
+        "script_level.level_keys": [
+          "CSD U2 add content"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 header footer",
+        "script_level.level_keys": [
+          "CSD U2 header footer"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review",
+        "script_level.level_keys": [
+          "CSD U2 project review"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share",
+        "script_level.level_keys": [
+          "CSD U2 project share"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 7 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS",
+        "script_level.level_keys": [
+          "Video: Intro to CSS"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1",
+        "script_level.level_keys": [
+          "CSD U2 text style h1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3",
+        "script_level.level_keys": [
+          "CSD U2 text style h3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Style Sheet Map",
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size",
+        "script_level.level_keys": [
+          "CSD U2 text style size"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style font family",
+        "script_level.level_keys": [
+          "CSD U2 text style font family"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style decoration",
+        "script_level.level_keys": [
+          "CSD U2 text style decoration"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style text align",
+        "script_level.level_keys": [
+          "CSD U2 text style text align"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Text Properties Map",
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file",
+        "script_level.level_keys": [
+          "CSD U2 add file"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style freeplay",
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 8 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSS U2 Body Map",
+        "script_level.level_keys": [
+          "CSS U2 Body Map"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body",
+        "script_level.level_keys": [
+          "CSD U2 layout style body"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style border",
+        "script_level.level_keys": [
+          "CSD U2 layout style border"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style borderradius",
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float",
+        "script_level.level_keys": [
+          "CSD U2 layout style float"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width",
+        "script_level.level_keys": [
+          "CSD U2 layout style width"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style margin",
+        "script_level.level_keys": [
+          "CSD U2 layout style margin"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Layout Properties Map",
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style freeplay",
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 L12 Overview",
+        "script_level.level_keys": [
+          "CSD U2 L12 Overview"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 10 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 10 Overview"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB winter",
+        "script_level.level_keys": [
+          "CSD U2 RGB winter"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB summer",
+        "script_level.level_keys": [
+          "CSD U2 RGB summer"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB others",
+        "script_level.level_keys": [
+          "CSD U2 RGB others"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample",
+        "script_level.level_keys": [
+          "CSD U2 classes sample"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS Classes Map",
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify",
+        "script_level.level_keys": [
+          "CSD U2 classes modify"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring",
+        "script_level.level_keys": [
+          "CSD U2 classes spring"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer",
+        "script_level.level_keys": [
+          "CSD U2 classes summer"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Class Style Personal Site",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 16 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 16 Overview"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Final Personal Website",
+        "script_level.level_keys": [
+          "Final Personal Website"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd2-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-2018.script_json
+++ b/dashboard/config/scripts_json/csd2-2018.script_json
@@ -1,0 +1,3977 @@
+{
+  "script": {
+    "name": "csd2-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes. Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csd-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd2"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit2/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-18/unit2/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd2",
+    "seeding_key": {
+      "script.name": "csd2-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Web Content and HTML"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "csd2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Styling and CSS"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Websites",
+      "name": "Exploring Websites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Lists",
+      "name": "Lists",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Intellectual Property and Images",
+      "name": "Intellectual Property and Images",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Clean Code and Debugging",
+      "name": "Clean Code and Debugging",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Project - Multi-Page Websites",
+      "name": "Project - Multi-Page Websites",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Sources and Search Engines",
+      "name": "Sources and Search Engines",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "RGB Colors and Classes",
+      "name": "RGB Colors and Classes",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "Project - Personal Portfolio Website",
+      "name": "Project - Personal Portfolio Website",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries Post-Course Survey",
+      "name": "CS Discoveries Post-Course Survey",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L01 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L02 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L03 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 HTML Tags Map_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L04 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD Header Size MC_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Headers map_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Headers map_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 PSP Programming_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Design Project_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Design Project_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Project Start_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Project Start_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L05 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Social Sleuth_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L06 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists intro_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 lists intro_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 ordered list_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 ordered list_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 unordered list_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 unordered list_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists match_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 lists match_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists map_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 lists map_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 expand project_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 expand project_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 new page_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 new page_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L07 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 images map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 images map_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 CC Search Map_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Attribution_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Info Page Final Touches_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L08 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 1_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 3_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 4_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 commenting_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 commenting_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 formatting map_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 formatting map_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 challenge_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 challenge_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L09 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 a tag map_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 a tag map_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 link demo_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 navigation_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 navigation_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 project guide_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 create page_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 create page_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 upload images_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 add content_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 header footer_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 header footer_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 project review_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 project share_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L10 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style h1_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style h3_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Style Sheet Map_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style size_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style font family_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style font family_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style decoration_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style decoration_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style text align_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style text align_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Text Properties Map_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 add file_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 text style freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L11 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSS U2 Body Map_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSS U2 Body Map_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style body_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style border_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style border_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style borderradius_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style float_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style width_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style margin_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style margin_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 Layout Properties Map_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 layout style freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L12 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L13 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB winter_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 RGB winter_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB summer_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 RGB summer_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB others_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 RGB others_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 classes sample_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 CSS Classes Map_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 classes modify_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 classes spring_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2 classes summer_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Class Style Personal Site_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "CSD U2L14 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Final Personal Website_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "Final Personal Website_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L01 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites_2018",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L02 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars_2018",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L03 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything_2018",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_2018",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up_2018",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_2018",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Tags Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs_2018",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2_2018",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs_2018",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L04 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video_2018",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo_2018",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes_2018",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC_2018",
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test_2018",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Headers map_2018",
+        "script_level.level_keys": [
+          "CSD U2 Headers map_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 PSP Programming_2018",
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Design Project_2018",
+        "script_level.level_keys": [
+          "CSD U2 Design Project_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Project Start_2018",
+        "script_level.level_keys": [
+          "CSD U2 Project Start_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L05 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth_2018",
+        "script_level.level_keys": [
+          "Social Sleuth_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L06 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists intro_2018",
+        "script_level.level_keys": [
+          "CSD U2 lists intro_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 ordered list_2018",
+        "script_level.level_keys": [
+          "CSD U2 ordered list_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 unordered list_2018",
+        "script_level.level_keys": [
+          "CSD U2 unordered list_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists match_2018",
+        "script_level.level_keys": [
+          "CSD U2 lists match_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists map_2018",
+        "script_level.level_keys": [
+          "CSD U2 lists map_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 expand project_2018",
+        "script_level.level_keys": [
+          "CSD U2 expand project_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 new page_2018",
+        "script_level.level_keys": [
+          "CSD U2 new page_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L07 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 images map_2018",
+        "script_level.level_keys": [
+          "CSD U2 images map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1_2018",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug_2018",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2_2018",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CC Search Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Attribution_2018",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Info Page Final Touches_2018",
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L08 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 1_2018",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 2_2018",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 3_2018",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 4_2018",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 commenting_2018",
+        "script_level.level_keys": [
+          "CSD U2 commenting_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 formatting map_2018",
+        "script_level.level_keys": [
+          "CSD U2 formatting map_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 challenge_2018",
+        "script_level.level_keys": [
+          "CSD U2 challenge_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L09 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 a tag map_2018",
+        "script_level.level_keys": [
+          "CSD U2 a tag map_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo_2018",
+        "script_level.level_keys": [
+          "CSD U2 link demo_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 navigation_2018",
+        "script_level.level_keys": [
+          "CSD U2 navigation_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide_2018",
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 create page_2018",
+        "script_level.level_keys": [
+          "CSD U2 create page_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images_2018",
+        "script_level.level_keys": [
+          "CSD U2 upload images_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content_2018",
+        "script_level.level_keys": [
+          "CSD U2 add content_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 header footer_2018",
+        "script_level.level_keys": [
+          "CSD U2 header footer_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review_2018",
+        "script_level.level_keys": [
+          "CSD U2 project review_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share_2018",
+        "script_level.level_keys": [
+          "CSD U2 project share_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch1_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L10 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS_2018",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_2018",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Style Sheet Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style size_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style font family_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style font family_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style decoration_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style decoration_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style text align_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style text align_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Text Properties Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_2018",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file_2018",
+        "script_level.level_keys": [
+          "CSD U2 add file_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L11 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSS U2 Body Map_2018",
+        "script_level.level_keys": [
+          "CSS U2 Body Map_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style border_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style border_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style borderradius_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style margin_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style margin_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Layout Properties Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L12 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L13 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro_2018",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB winter_2018",
+        "script_level.level_keys": [
+          "CSD U2 RGB winter_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB summer_2018",
+        "script_level.level_keys": [
+          "CSD U2 RGB summer_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB others_2018",
+        "script_level.level_keys": [
+          "CSD U2 RGB others_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample_2018",
+        "script_level.level_keys": [
+          "CSD U2 classes sample_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS Classes Map_2018",
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify_2018",
+        "script_level.level_keys": [
+          "CSD U2 classes modify_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring_2018",
+        "script_level.level_keys": [
+          "CSD U2 classes spring_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer_2018",
+        "script_level.level_keys": [
+          "CSD U2 classes summer_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Class Style Personal Site_2018",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L14 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Final Personal Website_2018",
+        "script_level.level_keys": [
+          "Final Personal Website_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-2019.script_json
+++ b/dashboard/config/scripts_json/csd2-2019.script_json
@@ -1,0 +1,4195 @@
+{
+  "script": {
+    "name": "csd2-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit2/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit2/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-19/unit2/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd2",
+    "seeding_key": {
+      "script.name": "csd2-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Web Content and HTML"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "csd2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Styling and CSS"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Websites",
+      "name": "Exploring Websites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Lists",
+      "name": "Lists",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Intellectual Property and Images",
+      "name": "Intellectual Property and Images",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Clean Code and Debugging",
+      "name": "Clean Code and Debugging",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Project - Multi-Page Websites",
+      "name": "Project - Multi-Page Websites",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Sources and Search Engines",
+      "name": "Sources and Search Engines",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "RGB Colors and Classes",
+      "name": "RGB Colors and Classes",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Project - Personal Portfolio Website",
+      "name": "Project - Personal Portfolio Website",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L01 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L02 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars_2018_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L03 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 HTML Tags Map_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L04 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD Header Size MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Headers map_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Headers map_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 PSP Programming_2018_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Design Project_2018_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Design Project_2018_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Project Start_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Project Start_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L05 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Social Sleuth_2018_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L06 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists intro_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 lists intro_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 unordered list_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 unordered list_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 ordered list_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 ordered list_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists match_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 lists match_2018_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 un_ordered lists"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 un_ordered lists"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 lists map_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 lists map_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 expand project_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 expand project_2018_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Expanding Personal Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 new page_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 new page_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L07 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 image debug match"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 image debug match"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 images map_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 images map_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 CC Search Map_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Attribution_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Attribution"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Info Page Final Touches_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L08 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 1_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 2_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 3_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Debugging 4_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 commenting_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 commenting_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 formatting map_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 formatting map_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 challenge_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 challenge_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L09 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 link demo_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 navigation_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 navigation_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 a tag map_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 a tag map_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 project guide_2018_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 create page_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 create page_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 upload images_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 add content_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 header footer_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 header footer_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 project review_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 publish video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 publish video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Publishing Your Website"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 project share_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L10 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style h1_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style h3_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Style Sheet Map_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style size_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style font family_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style font family_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style decoration_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style decoration_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Fonts and Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style text align_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style text align_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Text Properties Map_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 add file_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 text style freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L11 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSS U2 Body Map_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSS U2 Body Map_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style body_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style border_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style border_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style borderradius_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style float_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style width_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style margin_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style margin_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add style_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 add style_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 Layout Properties Map_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 layout style freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L12 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L13 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB winter_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 RGB winter_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB summer_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 RGB summer_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB others_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 RGB others_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 classes sample_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 CSS Classes Map_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 classes modify_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 classes spring_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2 classes summer_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Class Style Personal Site_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD U2L14 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Final Personal Website_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "Final Personal Website_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "CSD Web Development Post-Project Test"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L01 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L02 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L03 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything_2019",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_2019",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up_2019",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_2019",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Tags Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 HTML Tags Map_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs_2019",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2_2019",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs_2019",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L04 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video_2019",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo_2019",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes_2019",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC_2018_2019",
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test_2019",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Headers map_2019",
+        "script_level.level_keys": [
+          "CSD U2 Headers map_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 PSP Programming_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 PSP Programming_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Design Project_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 Design Project_2018_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Project Start_2019",
+        "script_level.level_keys": [
+          "CSD U2 Project Start_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L05 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth_2018_2019",
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L06 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists intro_2019",
+        "script_level.level_keys": [
+          "CSD U2 lists intro_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 unordered list_2019",
+        "script_level.level_keys": [
+          "CSD U2 unordered list_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 ordered list_2019",
+        "script_level.level_keys": [
+          "CSD U2 ordered list_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists match_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 lists match_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 un_ordered lists",
+        "script_level.level_keys": [
+          "CSD U2 un_ordered lists"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 lists map_2019",
+        "script_level.level_keys": [
+          "CSD U2 lists map_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 expand project_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 expand project_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 new page_2019",
+        "script_level.level_keys": [
+          "CSD U2 new page_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L07 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1_2019",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug_2019",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 image debug match",
+        "script_level.level_keys": [
+          "CSD U2 image debug match"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2_2019",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 images map_2019",
+        "script_level.level_keys": [
+          "CSD U2 images map_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CC Search Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 CC Search Map_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Attribution_2019",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Attribution_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Info Page Final Touches_2019",
+        "script_level.level_keys": [
+          "CSD U2 Info Page Final Touches_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Intellectual Property and Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L08 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 1_2019",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 2_2019",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 3_2019",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Debugging 4_2019",
+        "script_level.level_keys": [
+          "CSD U2 Debugging 4_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 commenting_2019",
+        "script_level.level_keys": [
+          "CSD U2 commenting_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 formatting map_2019",
+        "script_level.level_keys": [
+          "CSD U2 formatting map_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 challenge_2019",
+        "script_level.level_keys": [
+          "CSD U2 challenge_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L09 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo_2019",
+        "script_level.level_keys": [
+          "CSD U2 link demo_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 navigation_2019",
+        "script_level.level_keys": [
+          "CSD U2 navigation_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 a tag map_2019",
+        "script_level.level_keys": [
+          "CSD U2 a tag map_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide_2018_2019",
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 create page_2019",
+        "script_level.level_keys": [
+          "CSD U2 create page_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images_2019",
+        "script_level.level_keys": [
+          "CSD U2 upload images_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content_2019",
+        "script_level.level_keys": [
+          "CSD U2 add content_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 header footer_2019",
+        "script_level.level_keys": [
+          "CSD U2 header footer_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review_2019",
+        "script_level.level_keys": [
+          "CSD U2 project review_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 publish video",
+        "script_level.level_keys": [
+          "CSD U2 publish video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share_2019",
+        "script_level.level_keys": [
+          "CSD U2 project share_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Project - Multi-Page Websites",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L10 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS_2019",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_2019",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Style Sheet Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 Style Sheet Map_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style size_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style font family_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style font family_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style decoration_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style decoration_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style text align_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style text align_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Text Properties Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 Text Properties Map_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_2019",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file_2019",
+        "script_level.level_keys": [
+          "CSD U2 add file_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L11 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSS U2 Body Map_2019",
+        "script_level.level_keys": [
+          "CSS U2 Body Map_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style border_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style border_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style borderradius_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style margin_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style margin_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add style_2019",
+        "script_level.level_keys": [
+          "CSD U2 add style_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Layout Properties Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 Layout Properties Map_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L12 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L13 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro_2019",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB winter_2019",
+        "script_level.level_keys": [
+          "CSD U2 RGB winter_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB summer_2019",
+        "script_level.level_keys": [
+          "CSD U2 RGB summer_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB others_2019",
+        "script_level.level_keys": [
+          "CSD U2 RGB others_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample_2019",
+        "script_level.level_keys": [
+          "CSD U2 classes sample_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS Classes Map_2019",
+        "script_level.level_keys": [
+          "CSD U2 CSS Classes Map_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify_2019",
+        "script_level.level_keys": [
+          "CSD U2 classes modify_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring_2019",
+        "script_level.level_keys": [
+          "CSD U2 classes spring_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer_2019",
+        "script_level.level_keys": [
+          "CSD U2 classes summer_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Class Style Personal Site_2019",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 11,
+        "lesson.key": "RGB Colors and Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L14 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Final Personal Website_2019",
+        "script_level.level_keys": [
+          "Final Personal Website_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Portfolio Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Development Post-Project Test",
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-2020.script_json
+++ b/dashboard/config/scripts_json/csd2-2020.script_json
@@ -1,0 +1,4465 @@
+{
+  "script": {
+    "name": "csd2-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit2/{LESSON}",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1v2",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Creating Webpages"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "csd2_2v2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Multi-page Websites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Web Pages",
+      "name": "Exploring Web Pages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: HTML Web Page",
+      "name": "Mini-Project: HTML Web Page",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: Your Personal Style",
+      "name": "Mini-Project: Your Personal Style",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Intellectual Property",
+      "name": "Intellectual Property",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Using Images",
+      "name": "Using Images",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Your Web Page - Prepare",
+      "name": "Your Web Page - Prepare",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Web Page - Prepare",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Project - Personal Web Page",
+      "name": "Project - Personal Web Page",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Websites for a Purpose",
+      "name": "Websites for a Purpose",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Team Problem Solving",
+      "name": "Team Problem Solving",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Sources and Research",
+      "name": "Sources and Research",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "CSS Classes",
+      "name": "CSS Classes",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Planning a Multi-page Website",
+      "name": "Planning a Multi-page Website",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Linking Pages",
+      "name": "Linking Pages",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Project - Website for a Purpose",
+      "name": "Project - Website for a Purpose",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Peer Review and Final Touches",
+      "name": "Peer Review and Final Touches",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 22,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L01 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Personal Web Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Sample Pages_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web Sample Pages_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L02 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to Web Lab - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore HTML"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to Web Lab - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L03 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Pair Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading debug_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Heading debug_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Header Size MC_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Debugging_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web Debugging_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings practice_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web Headings practice_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings challenge_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web Headings challenge_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L04a TFMD_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L04a TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Review: HTML"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD HTML project Review"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD HTML project Review"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD HTML project Lists"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD HTML project Lists"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Your Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web HTML project HTML"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web HTML project HTML"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web HTML project check"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web HTML project check"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L04 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Social Sleuth"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "Social Sleuth_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L05 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Sample CSS text"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Sample CSS text"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to CSS - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 text style h1_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 text style h3_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 text style size_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to CSS - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 add file_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 CSS practice_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web CSS Assessment_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 CSS challenge_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L07a TFMD_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L07a TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Review: CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD CSS project Review"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD CSS project Review"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: RGB Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD CSS project RGB"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD CSS project RGB"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Content and Structure to Your Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web CSS project HTML"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web CSS project HTML"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Style to Your Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web CSS project CSS"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web CSS project CSS"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web CSS project check"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web CSS project check"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L06 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L07 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image Credit_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image choose name_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image choose name_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image practice_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image assessment_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image assessment_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Image challenge_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L08 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Personal Websites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L09 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Sample CSS layout"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Sample CSS layout"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style body_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style float_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style width_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style practice_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add style_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 add style_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 layout style challenge_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Your Web Page - Prepare",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L10 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L11 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Guide"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 project guide_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 upload images_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 add content_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 CSS_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 project review_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Publishing Your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 publish video_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 publish video_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Publishing Your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 project share_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Websites for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L12 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Top Websites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Websites for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L13 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Teamwork"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd web teamwork video"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd web teamwork video"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Managing Disagreement"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd web disagreement video"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd web disagreement video"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L14 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L15 TFMD_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L15 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Web Page"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Sample classes"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 Sample classes"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes waterfalls"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 classes waterfalls"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes humors"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 classes humors"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web classes practice"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web classes practice"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes haikus"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 classes haikus"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web classes challenge"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web classes challenge"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L16 TFMD_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L16 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Upload Your Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web upload images multi_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web upload images multi_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L17 TFMD_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L17 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 link demo_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 making links_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 making links_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming links_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 naming links_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming pages_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 naming pages_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 nav bar_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 nav bar_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 adding pages_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 adding pages_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 links challenge"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2 links challenge"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L18 TFMD_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L18 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Your Team Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web create pages project"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web create pages project"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Content and HTML"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add html_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web add html_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web share html_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web share html_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add CSS_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web add CSS_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Share Your Stylesheets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web share CSS_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web share CSS_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web check_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 7,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD web check_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L19 TFMD_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD U2L19 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Final Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web incorporate feedback_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test_pilot_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "CSD Web Development Post-Project Test_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L01 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Sample Pages_2020",
+        "script_level.level_keys": [
+          "CSD Web Sample Pages_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L02 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything_2020",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_2020",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up_2020",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_2020",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs_2020",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2_2020",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs_2020",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L03 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video_2020",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading debug_2020",
+        "script_level.level_keys": [
+          "CSD U2 Heading debug_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo_2020",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes_2020",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Debugging_2020",
+        "script_level.level_keys": [
+          "CSD Web Debugging_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings practice_2020",
+        "script_level.level_keys": [
+          "CSD Web Headings practice_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test_2020",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings challenge_2020",
+        "script_level.level_keys": [
+          "CSD Web Headings challenge_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L04a TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L04a TFMD_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD HTML project Review",
+        "script_level.level_keys": [
+          "CSD HTML project Review"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD HTML project Lists",
+        "script_level.level_keys": [
+          "CSD HTML project Lists"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web HTML project HTML",
+        "script_level.level_keys": [
+          "CSD web HTML project HTML"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web HTML project check",
+        "script_level.level_keys": [
+          "CSD web HTML project check"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: HTML Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L04 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L05 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Sample CSS text",
+        "script_level.level_keys": [
+          "CSD U2 Sample CSS text"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS_2020",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_2020",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1_2020",
+        "script_level.level_keys": [
+          "CSD U2 text style h1_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3_2020",
+        "script_level.level_keys": [
+          "CSD U2 text style h3_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size_2020",
+        "script_level.level_keys": [
+          "CSD U2 text style size_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_2020",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file_2020",
+        "script_level.level_keys": [
+          "CSD U2 add file_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS practice_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web CSS Assessment_2020",
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS challenge_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L07a TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L07a TFMD_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD CSS project Review",
+        "script_level.level_keys": [
+          "CSD CSS project Review"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD CSS project RGB",
+        "script_level.level_keys": [
+          "CSD CSS project RGB"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web CSS project HTML",
+        "script_level.level_keys": [
+          "CSD web CSS project HTML"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web CSS project CSS",
+        "script_level.level_keys": [
+          "CSD web CSS project CSS"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web CSS project check",
+        "script_level.level_keys": [
+          "CSD web CSS project check"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Your Personal Style",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L06 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L07 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Credit_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image choose name_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image choose name_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image practice_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image assessment_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image assessment_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image challenge_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Using Images",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L08 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L09 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Sample CSS layout",
+        "script_level.level_keys": [
+          "CSD U2 Sample CSS layout"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style body_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style float_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style width_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style practice_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add style_2020",
+        "script_level.level_keys": [
+          "CSD U2 add style_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style challenge_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L10 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Your Web Page - Prepare",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L11 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images_2020",
+        "script_level.level_keys": [
+          "CSD U2 upload images_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content_2020",
+        "script_level.level_keys": [
+          "CSD U2 add content_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS_2020",
+        "script_level.level_keys": [
+          "CSD U2 CSS_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review_2020",
+        "script_level.level_keys": [
+          "CSD U2 project review_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 publish video_2020",
+        "script_level.level_keys": [
+          "CSD U2 publish video_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share_2020",
+        "script_level.level_keys": [
+          "CSD U2 project share_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Project - Personal Web Page",
+        "lesson_group.key": "csd2_1v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L12 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Websites for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Websites for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L13 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd web teamwork video",
+        "script_level.level_keys": [
+          "csd web teamwork video"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd web disagreement video",
+        "script_level.level_keys": [
+          "csd web disagreement video"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L14 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L15 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L15 TFMD_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Sample classes",
+        "script_level.level_keys": [
+          "CSD U2 Sample classes"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes waterfalls",
+        "script_level.level_keys": [
+          "CSD U2 classes waterfalls"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes humors",
+        "script_level.level_keys": [
+          "CSD U2 classes humors"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web classes practice",
+        "script_level.level_keys": [
+          "CSD web classes practice"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes haikus",
+        "script_level.level_keys": [
+          "CSD U2 classes haikus"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web classes challenge",
+        "script_level.level_keys": [
+          "CSD web classes challenge"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 7,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L16 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L16 TFMD_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web upload images multi_2020",
+        "script_level.level_keys": [
+          "CSD web upload images multi_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L17 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L17 TFMD_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo_2020",
+        "script_level.level_keys": [
+          "CSD U2 link demo_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 making links_2020",
+        "script_level.level_keys": [
+          "CSD U2 making links_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming links_2020",
+        "script_level.level_keys": [
+          "CSD U2 naming links_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming pages_2020",
+        "script_level.level_keys": [
+          "CSD U2 naming pages_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 nav bar_2020",
+        "script_level.level_keys": [
+          "CSD U2 nav bar_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 adding pages_2020",
+        "script_level.level_keys": [
+          "CSD U2 adding pages_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 links challenge",
+        "script_level.level_keys": [
+          "CSD U2 links challenge"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Linking Pages",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L18 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L18 TFMD_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web create pages project",
+        "script_level.level_keys": [
+          "CSD web create pages project"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add html_2020",
+        "script_level.level_keys": [
+          "CSD web add html_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web share html_2020",
+        "script_level.level_keys": [
+          "CSD web share html_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add CSS_2020",
+        "script_level.level_keys": [
+          "CSD web add CSS_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web share CSS_2020",
+        "script_level.level_keys": [
+          "CSD web share CSS_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 6,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web check_2020",
+        "script_level.level_keys": [
+          "CSD web check_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 7,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L19 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U2L19 TFMD_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web incorporate feedback_2020",
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 3,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Development Post-Project Test_pilot_2020",
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test_pilot_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2v2",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd2-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csd2-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 2 Deeper Learning Reflections",
+      "name": "Complete Unit 2 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "csd2dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "csd2dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      },
+      "level_keys": [
+        "csd2dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-q1",
+        "script_level.level_keys": [
+          "csd2dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-q2",
+        "script_level.level_keys": [
+          "csd2dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-q3",
+        "script_level.level_keys": [
+          "csd2dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-dlp.script_json
+++ b/dashboard/config/scripts_json/csd2-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd2-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 2 Deeper Learning Reflections",
+      "name": "Complete Unit 2 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "csd2dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "csd2dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd2dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      },
+      "level_keys": [
+        "csd2dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-lessons",
+        "script_level.level_keys": [
+          "csd2dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-tools",
+        "script_level.level_keys": [
+          "csd2dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd2dlp-assessment",
+        "script_level.level_keys": [
+          "csd2dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd2-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-old.script_json
+++ b/dashboard/config/scripts_json/csd2-old.script_json
@@ -1,0 +1,4460 @@
+{
+  "script": {
+    "name": "csd2-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Quality Websites",
+      "name": "Quality Websites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Quality Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Website Design",
+      "name": "Website Design",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Website Design",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Describing Web pages",
+      "name": "Describing Web pages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Describing Web pages",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Text on the Web",
+      "name": "Text on the Web",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Images in HTML",
+      "name": "Images in HTML",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Clean Code and Debugging",
+      "name": "Clean Code and Debugging",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Multi-Page Websites",
+      "name": "Multi-Page Websites",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Classes",
+      "name": "Classes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Peer Review",
+      "name": "Peer Review",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer Review",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Publishing a Website",
+      "name": "Publishing a Website",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Sources and Search Engines",
+      "name": "Sources and Search Engines",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Intellectual Property",
+      "name": "Intellectual Property",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "key": "Project: Personal Portfolio Website",
+      "name": "Project: Personal Portfolio Website",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Personal Portfolio Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Quality Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 1 Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rating Websites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Quality Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Rating Websites"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Website Design",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 2 Overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Personal Website Examples"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Website Design",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Personal Website Examples"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Describing Web pages",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 3 Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Design Instructions Site"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Describing Web pages",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD Design Instructions Site"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 4 Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Inspector Warm Up"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Inspector Warm Up"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to HTML"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Introduction to HTML"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - First-Weblab"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - First-Weblab"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Headers"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Headers"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Paragraphs 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Paragraphs 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size Prediction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD Header Size Prediction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Paragraphs 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Paragraphs 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Hobbies Page Example"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Hobbies Page Example"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - HobbiesPage"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 13,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - HobbiesPage"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Hobbies Page"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 14,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Stop: Hobbies Page"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Recipe Page Example"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 15,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Recipe Page Example"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Recipe Page Start"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 16,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Recipe Page Start"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Unordered Lists"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 17,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Unordered Lists"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - ordered Lists"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 18,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - ordered Lists"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Finish Recipe"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 19,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Finish Recipe"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 20,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 5 Overview"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Recipe Valid Update"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Recipe Valid Update"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - head and body tag intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - head and body tag intro"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Hobbies Valid Update"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Hobbies Valid Update"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Local Images"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Local Images"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Images"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Stop: Images"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - About Me Page start"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - About Me Page start"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 6 Overview"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Debugging 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Debugging 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Debugging 3"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Debugging 4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Creating Debugging Strat"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD Creating Debugging Strat"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 7 Overview"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Video: Intro to CSS"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style h1"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style h3"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explain"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 CSS explain"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style size"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style font family"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style font family"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style decoration"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style decoration"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style text align"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style text align"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style review"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style review"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file - OLD"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 add file - OLD"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay - OLD"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 text style freeplay - OLD"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 8 Overview"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 more CSS"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 more CSS"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style body"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style border"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style border"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style borderradius"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style float"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style width"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style margin"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style margin"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style review"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style review"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay - OLD"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 layout style freeplay - OLD"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 9 Overview"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Starting Personal Home Page"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Starting Personal Home Page"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Personal Home Page Warm Up"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Stop: Personal Home Page Warm Up"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Multi Site First"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Multi Site First"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - New Html Files"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - New Html Files"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Copy Code"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Copy Code"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - New Class Files"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - New Class Files"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Link and Nav"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Link and Nav"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Header of Page"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Header of Page"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Missing Home Link"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Missing Home Link"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Website Navigation"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Stop: Website Navigation"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Nav on Personal Website"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Nav on Personal Website"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Nav add to Personal Site"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Nav add to Personal Site"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Style to Personal Site"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Style to Personal Site"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 10 Overview"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 10 Overview"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB Colors"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 RGB Colors"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB winter"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 RGB winter"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB summer"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 RGB summer"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB others"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 RGB others"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 classes sample"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Classes Introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 Classes Introduction"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 classes modify"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 classes spring"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSD U2 classes summer"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Classes"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Stop: Classes"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Matching Class Style Checker"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - Matching Class Style Checker"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site - OLD"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Class Style Personal Site - OLD"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 11 Overview"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 11 Overview"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Peer Review: Personal Website"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Peer Review: Personal Website"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 12 Overview"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 12 Overview"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Social Sleuth"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 13 Overview"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 13 Overview"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing Check"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing Check"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing 2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing 3"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing 4"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing 5"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Pre Publishing 6"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 14 Overview"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 14 Overview"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Search Engine Optimizer"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Search Engine Optimizer"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Search Works"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 3,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "How Search Works"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - SEO 1"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 4,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - SEO 1"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - SEO 2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 5,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - SEO 2"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - SEO 3"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 6,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - SEO 3"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - SEO 5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 7,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - SEO 5"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - SEO Final"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 8,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 - SEO Final"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 15 Overview"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 15 Overview"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 IP Portfolio"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 IP Portfolio"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 IP Fair Use"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 IP Fair Use"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 IP Research Content"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 IP Research Content"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDu2 IP CC Search"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDu2 IP CC Search"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 IP Add Images"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 IP Add Images"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 IP Final Touches"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "CSDU2 IP Final Touches"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 16 Overview"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Project: Personal Portfolio Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 16 Overview"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Final Personal Website - OLD"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Project: Personal Portfolio Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      },
+      "level_keys": [
+        "Final Personal Website - OLD"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 1 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 1 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Quality Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rating Websites",
+        "script_level.level_keys": [
+          "Rating Websites"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Quality Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 2 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 2 Overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Website Design",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Personal Website Examples",
+        "script_level.level_keys": [
+          "Personal Website Examples"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Website Design",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 3 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 3 Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Describing Web pages",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Design Instructions Site",
+        "script_level.level_keys": [
+          "CSD Design Instructions Site"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Describing Web pages",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 4 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 4 Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Inspector Warm Up",
+        "script_level.level_keys": [
+          "CSDU2 - Inspector Warm Up"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to HTML",
+        "script_level.level_keys": [
+          "Introduction to HTML"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - First-Weblab",
+        "script_level.level_keys": [
+          "CSDU2 - First-Weblab"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Headers",
+        "script_level.level_keys": [
+          "CSDU2 - Headers"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Paragraphs 2",
+        "script_level.level_keys": [
+          "CSDU2 - Paragraphs 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size Prediction",
+        "script_level.level_keys": [
+          "CSD Header Size Prediction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Paragraphs 3",
+        "script_level.level_keys": [
+          "CSDU2 - Paragraphs 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Hobbies Page Example",
+        "script_level.level_keys": [
+          "Hobbies Page Example"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - HobbiesPage",
+        "script_level.level_keys": [
+          "CSDU2 - HobbiesPage"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 13,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Hobbies Page",
+        "script_level.level_keys": [
+          "Stop: Hobbies Page"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 14,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Recipe Page Example",
+        "script_level.level_keys": [
+          "Recipe Page Example"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 15,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Recipe Page Start",
+        "script_level.level_keys": [
+          "CSDU2 - Recipe Page Start"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 16,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Unordered Lists",
+        "script_level.level_keys": [
+          "CSDU2 - Unordered Lists"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 17,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - ordered Lists",
+        "script_level.level_keys": [
+          "CSDU2 - ordered Lists"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 18,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Finish Recipe",
+        "script_level.level_keys": [
+          "CSDU2 - Finish Recipe"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 19,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 3",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 20,
+        "lesson.key": "Text on the Web",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 5 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 5 Overview"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Recipe Valid Update",
+        "script_level.level_keys": [
+          "CSDU2 - Recipe Valid Update"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - head and body tag intro",
+        "script_level.level_keys": [
+          "CSDU2 - head and body tag intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Hobbies Valid Update",
+        "script_level.level_keys": [
+          "CSDU2 - Hobbies Valid Update"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Local Images",
+        "script_level.level_keys": [
+          "CSDU2 - Local Images"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Images",
+        "script_level.level_keys": [
+          "Stop: Images"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - About Me Page start",
+        "script_level.level_keys": [
+          "CSDU2 - About Me Page start"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Images in HTML",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 6 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 6 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Debugging 1",
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Debugging 2",
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Debugging 3",
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Debugging 4",
+        "script_level.level_keys": [
+          "CSDU2 - Debugging 4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Creating Debugging Strat",
+        "script_level.level_keys": [
+          "CSD Creating Debugging Strat"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Clean Code and Debugging",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 7 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS",
+        "script_level.level_keys": [
+          "Video: Intro to CSS"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1",
+        "script_level.level_keys": [
+          "CSD U2 text style h1"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3",
+        "script_level.level_keys": [
+          "CSD U2 text style h3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explain",
+        "script_level.level_keys": [
+          "CSD U2 CSS explain"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size",
+        "script_level.level_keys": [
+          "CSD U2 text style size"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style font family",
+        "script_level.level_keys": [
+          "CSD U2 text style font family"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style decoration",
+        "script_level.level_keys": [
+          "CSD U2 text style decoration"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style text align",
+        "script_level.level_keys": [
+          "CSD U2 text style text align"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style review",
+        "script_level.level_keys": [
+          "CSD U2 text style review"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file - OLD",
+        "script_level.level_keys": [
+          "CSD U2 add file - OLD"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style freeplay - OLD",
+        "script_level.level_keys": [
+          "CSD U2 text style freeplay - OLD"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 8 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 8 Overview"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 more CSS",
+        "script_level.level_keys": [
+          "CSD U2 more CSS"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body",
+        "script_level.level_keys": [
+          "CSD U2 layout style body"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style border",
+        "script_level.level_keys": [
+          "CSD U2 layout style border"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style borderradius",
+        "script_level.level_keys": [
+          "CSD U2 layout style borderradius"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float",
+        "script_level.level_keys": [
+          "CSD U2 layout style float"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width",
+        "script_level.level_keys": [
+          "CSD U2 layout style width"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style margin",
+        "script_level.level_keys": [
+          "CSD U2 layout style margin"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style review",
+        "script_level.level_keys": [
+          "CSD U2 layout style review"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style freeplay - OLD",
+        "script_level.level_keys": [
+          "CSD U2 layout style freeplay - OLD"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 9 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 9 Overview"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Starting Personal Home Page",
+        "script_level.level_keys": [
+          "CSDU2 - Starting Personal Home Page"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Personal Home Page Warm Up",
+        "script_level.level_keys": [
+          "Stop: Personal Home Page Warm Up"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Multi Site First",
+        "script_level.level_keys": [
+          "CSDU2 - Multi Site First"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - New Html Files",
+        "script_level.level_keys": [
+          "CSDU2 - New Html Files"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Copy Code",
+        "script_level.level_keys": [
+          "CSDU2 - Copy Code"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - New Class Files",
+        "script_level.level_keys": [
+          "CSDU2 - New Class Files"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Link and Nav",
+        "script_level.level_keys": [
+          "CSDU2 - Link and Nav"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Header of Page",
+        "script_level.level_keys": [
+          "CSDU2 - Header of Page"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Missing Home Link",
+        "script_level.level_keys": [
+          "CSDU2 - Missing Home Link"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Website Navigation",
+        "script_level.level_keys": [
+          "Stop: Website Navigation"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Nav on Personal Website",
+        "script_level.level_keys": [
+          "CSDU2 - Nav on Personal Website"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Nav add to Personal Site",
+        "script_level.level_keys": [
+          "CSDU2 - Nav add to Personal Site"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Style to Personal Site",
+        "script_level.level_keys": [
+          "CSDU2 - Style to Personal Site"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Multi-Page Websites",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 10 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 10 Overview"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB Colors",
+        "script_level.level_keys": [
+          "CSD U2 RGB Colors"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB winter",
+        "script_level.level_keys": [
+          "CSD U2 RGB winter"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB summer",
+        "script_level.level_keys": [
+          "CSD U2 RGB summer"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB others",
+        "script_level.level_keys": [
+          "CSD U2 RGB others"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample",
+        "script_level.level_keys": [
+          "CSD U2 classes sample"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Classes Introduction",
+        "script_level.level_keys": [
+          "CSD U2 Classes Introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify",
+        "script_level.level_keys": [
+          "CSD U2 classes modify"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring",
+        "script_level.level_keys": [
+          "CSD U2 classes spring"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer",
+        "script_level.level_keys": [
+          "CSD U2 classes summer"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Classes",
+        "script_level.level_keys": [
+          "Stop: Classes"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Matching Class Style Checker",
+        "script_level.level_keys": [
+          "CSDU2 - Matching Class Style Checker"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Class Style Personal Site - OLD",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Class Style Personal Site - OLD"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Classes",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 11 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 11 Overview"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Peer Review: Personal Website",
+        "script_level.level_keys": [
+          "Peer Review: Personal Website"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 12 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 12 Overview"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth",
+        "script_level.level_keys": [
+          "Social Sleuth"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 13 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 13 Overview"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing Check",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing Check"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing 2",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing 3",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 4,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing 4",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 5,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing 5",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 6,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Pre Publishing 6",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Pre Publishing 6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 7,
+        "lesson.key": "Publishing a Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 14 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 14 Overview"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Search Engine Optimizer",
+        "script_level.level_keys": [
+          "Search Engine Optimizer"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 2,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Search Works",
+        "script_level.level_keys": [
+          "How Search Works"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 3,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - SEO 1",
+        "script_level.level_keys": [
+          "CSDU2 - SEO 1"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 4,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - SEO 2",
+        "script_level.level_keys": [
+          "CSDU2 - SEO 2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 5,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - SEO 3",
+        "script_level.level_keys": [
+          "CSDU2 - SEO 3"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 6,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - SEO 5",
+        "script_level.level_keys": [
+          "CSDU2 - SEO 5"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 7,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - SEO Final",
+        "script_level.level_keys": [
+          "CSDU2 - SEO Final"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 8,
+        "lesson.key": "Sources and Search Engines",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 15 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 15 Overview"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 IP Portfolio",
+        "script_level.level_keys": [
+          "CSDU2 IP Portfolio"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 IP Fair Use",
+        "script_level.level_keys": [
+          "CSDU2 IP Fair Use"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 IP Research Content",
+        "script_level.level_keys": [
+          "CSDU2 IP Research Content"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDu2 IP CC Search",
+        "script_level.level_keys": [
+          "CSDu2 IP CC Search"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 IP Add Images",
+        "script_level.level_keys": [
+          "CSDU2 IP Add Images"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 IP Final Touches",
+        "script_level.level_keys": [
+          "CSDU2 IP Final Touches"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 16 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 16 Overview"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Project: Personal Portfolio Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Final Personal Website - OLD",
+        "script_level.level_keys": [
+          "Final Personal Website - OLD"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Project: Personal Portfolio Website",
+        "lesson_group.key": "",
+        "script.name": "csd2-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-pilot.script_json
+++ b/dashboard/config/scripts_json/csd2-pilot.script_json
@@ -1,0 +1,3753 @@
+{
+  "script": {
+    "name": "csd2-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit2/{LESSON}",
+      "pilot_experiment": "csd-piloters",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Web Content and HTML"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "csd2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Styling and CSS"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Web Pages",
+      "name": "Exploring Web Pages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Digital Footprint",
+      "name": "Digital Footprint",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Intellectual Property",
+      "name": "Intellectual Property",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Images",
+      "name": "Images",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Project - Planning Layout and Style",
+      "name": "Project - Planning Layout and Style",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Planning Layout and Style",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Project - Building a Webpage",
+      "name": "Project - Building a Webpage",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Purpose of a  Websites",
+      "name": "Purpose of a  Websites",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Purpose of a  Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Team Problem Solving",
+      "name": "Team Problem Solving",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Sources and Research",
+      "name": "Sources and Research",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "CSS Classes",
+      "name": "CSS Classes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Planning a Multi-page Website",
+      "name": "Planning a Multi-page Website",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Linking and Navigation",
+      "name": "Linking and Navigation",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Project - Website for a Purpose",
+      "name": "Project - Website for a Purpose",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Peer Review and Final Touches",
+      "name": "Peer Review and Final Touches",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 20,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 21,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L01 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Sample Pages"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web Sample Pages"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L02 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything_pilot"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_pilot"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up_pilot"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_pilot"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs_pilot"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2_pilot"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs_pilot"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L03 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_pilot"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Pair Programming Video_pilot"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading debug"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Heading debug"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_pilot"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo_pilot"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_pilot"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes_pilot"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Debugging"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web Debugging"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings practice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web Headings practice"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Header Size MC_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_pilot"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test_pilot"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings challenge"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web Headings challenge"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L04 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019_pilot"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "Social Sleuth_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L05 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_pilot"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS_pilot"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_pilot"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_pilot"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1_pilot"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 text style h1_pilot"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3_pilot"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 text style h3_pilot"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size_pilot"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 text style size_pilot"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_pilot"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_pilot"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file_pilot"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 add file_pilot"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 CSS practice_pilot"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web CSS Assessment"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 CSS challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L06 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L07 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_pilot"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1_pilot"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_pilot"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image Credit_pilot"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_pilot"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug_pilot"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image choose name"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image choose name"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_pilot"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2_pilot"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image practice_pilot"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image assessment"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image assessment"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Challenges"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Image challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_pilot"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L08 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L09 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_pilot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample_pilot"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_pilot"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor_pilot"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body_pilot"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style body_pilot"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float_pilot"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style float_pilot"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width_pilot"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style width_pilot"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style practice_pilot"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add style_pilot"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 add style_pilot"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 layout style challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_pilot"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Project - Planning Layout and Style",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L10 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_pilot"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L11 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 project guide_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images_pilot"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 upload images_pilot"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content_pilot"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 add content_pilot"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS_pilot"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 CSS_pilot"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review_pilot"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 project review_pilot"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 publish video_pilot"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 publish video_pilot"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Publishing Your Website"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share_pilot"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 project share_pilot"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_pilot"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Purpose of a  Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L12 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Purpose of a  Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_pilot"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L13 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_pilot"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L14 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L15 TFMD_pilot"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L15 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample_pilot"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 classes sample_pilot"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify_pilot"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 classes modify_pilot"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring_pilot"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 classes spring_pilot"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer_pilot"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 classes summer_pilot"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_pilot"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro_pilot"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L16 TFMD_pilot"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L16 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L17 TFMD_pilot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L17 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo_pilot"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 link demo_pilot"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 making links"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 making links"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming links"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 naming links"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 nav bar"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 nav bar"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 adding pages"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 adding pages"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming pages"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 naming pages"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: External Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 external links"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 external links"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L18 TFMD_pilot"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L18 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Upload Your Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web upload images multi_pilot"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD web upload images multi_pilot"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 create page_pilot"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2 create page_pilot"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Content"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add html"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD web add html"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add CSS"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD web add CSS"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web check"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD web check"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2L19 TFMD_pilot"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD U2L19 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web incorporate feedback"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 3,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test_pilot"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "CSD Web Development Post-Project Test_pilot"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_pilot"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L01 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Sample Pages",
+        "script_level.level_keys": [
+          "CSD Web Sample Pages"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L02 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything_pilot",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_pilot",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_pilot",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs_pilot",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2_pilot",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs_pilot",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L03 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Pair Programming Video_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Pair Programming Video_pilot"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading debug",
+        "script_level.level_keys": [
+          "CSD U2 Heading debug"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_pilot"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_pilot"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Debugging",
+        "script_level.level_keys": [
+          "CSD Web Debugging"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings practice",
+        "script_level.level_keys": [
+          "CSD Web Headings practice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_pilot"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings challenge",
+        "script_level.level_keys": [
+          "CSD Web Headings challenge"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L04 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Social Sleuth_2018_2019_pilot",
+        "script_level.level_keys": [
+          "Social Sleuth_2018_2019_pilot"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Digital Footprint",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L05 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS_pilot",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_pilot"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_pilot",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_pilot"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1_pilot",
+        "script_level.level_keys": [
+          "CSD U2 text style h1_pilot"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3_pilot",
+        "script_level.level_keys": [
+          "CSD U2 text style h3_pilot"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size_pilot",
+        "script_level.level_keys": [
+          "CSD U2 text style size_pilot"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_pilot",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_pilot"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file_pilot",
+        "script_level.level_keys": [
+          "CSD U2 add file_pilot"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS practice_pilot",
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web CSS Assessment",
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L06 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L07 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_pilot"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Credit_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_pilot"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_pilot"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image choose name",
+        "script_level.level_keys": [
+          "CSD U2 Image choose name"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_pilot"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image practice_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image assessment",
+        "script_level.level_keys": [
+          "CSD U2 Image assessment"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L08 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L08 TFMD_pilot"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L09 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_pilot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_pilot"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style body_pilot"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style float_pilot"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style width_pilot"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style practice_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add style_pilot",
+        "script_level.level_keys": [
+          "CSD U2 add style_pilot"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L10 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L10 TFMD_pilot"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Project - Planning Layout and Style",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L11 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L11 TFMD_pilot"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images_pilot",
+        "script_level.level_keys": [
+          "CSD U2 upload images_pilot"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content_pilot",
+        "script_level.level_keys": [
+          "CSD U2 add content_pilot"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS_pilot",
+        "script_level.level_keys": [
+          "CSD U2 CSS_pilot"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review_pilot",
+        "script_level.level_keys": [
+          "CSD U2 project review_pilot"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 publish video_pilot",
+        "script_level.level_keys": [
+          "CSD U2 publish video_pilot"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share_pilot",
+        "script_level.level_keys": [
+          "CSD U2 project share_pilot"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L12 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L12 TFMD_pilot"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Purpose of a  Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Purpose of a  Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L13 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L13 TFMD_pilot"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Team Problem Solving",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L14 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L14 TFMD_pilot"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sources and Research",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L15 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L15 TFMD_pilot"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample_pilot",
+        "script_level.level_keys": [
+          "CSD U2 classes sample_pilot"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify_pilot",
+        "script_level.level_keys": [
+          "CSD U2 classes modify_pilot"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring_pilot",
+        "script_level.level_keys": [
+          "CSD U2 classes spring_pilot"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer_pilot",
+        "script_level.level_keys": [
+          "CSD U2 classes summer_pilot"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro_pilot",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_pilot"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L16 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L16 TFMD_pilot"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Planning a Multi-page Website",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L17 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L17 TFMD_pilot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo_pilot",
+        "script_level.level_keys": [
+          "CSD U2 link demo_pilot"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 making links",
+        "script_level.level_keys": [
+          "CSD U2 making links"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming links",
+        "script_level.level_keys": [
+          "CSD U2 naming links"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 nav bar",
+        "script_level.level_keys": [
+          "CSD U2 nav bar"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 adding pages",
+        "script_level.level_keys": [
+          "CSD U2 adding pages"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming pages",
+        "script_level.level_keys": [
+          "CSD U2 naming pages"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 external links",
+        "script_level.level_keys": [
+          "CSD U2 external links"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L18 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L18 TFMD_pilot"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web upload images multi_pilot",
+        "script_level.level_keys": [
+          "CSD web upload images multi_pilot"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 create page_pilot",
+        "script_level.level_keys": [
+          "CSD U2 create page_pilot"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add html",
+        "script_level.level_keys": [
+          "CSD web add html"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add CSS",
+        "script_level.level_keys": [
+          "CSD web add CSS"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web check",
+        "script_level.level_keys": [
+          "CSD web check"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 6,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2L19 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U2L19 TFMD_pilot"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web incorporate feedback",
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 3,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Development Post-Project Test_pilot",
+        "script_level.level_keys": [
+          "CSD Web Development Post-Project Test_pilot"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_pilot",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd2-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-projects-temp.script_json
+++ b/dashboard/config/scripts_json/csd2-projects-temp.script_json
@@ -1,0 +1,133 @@
+{
+  "script": {
+    "name": "csd2-projects-temp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "pilot_experiment": "csd-noaccess"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-projects-temp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "HTML  Project",
+      "name": "HTML  Project",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "HTML  Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      }
+    },
+    {
+      "key": "CSS Project",
+      "name": "CSS Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSS Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML miniproject choices"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "HTML  Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      },
+      "level_keys": [
+        "CSD U2 HTML miniproject choices"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS miniproject choices"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "CSS Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      },
+      "level_keys": [
+        "CSD U2 CSS miniproject choices"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML miniproject choices",
+        "script_level.level_keys": [
+          "CSD U2 HTML miniproject choices"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "HTML  Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS miniproject choices",
+        "script_level.level_keys": [
+          "CSD U2 CSS miniproject choices"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "CSS Project",
+        "lesson_group.key": "",
+        "script.name": "csd2-projects-temp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd2-virtual.script_json
+++ b/dashboard/config/scripts_json/csd2-virtual.script_json
@@ -1,0 +1,2703 @@
+{
+  "script": {
+    "name": "csd2-virtual",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd2-virtual"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Web Content and HTML"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "csd2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Styling and CSS"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Exploring Web Pages",
+      "name": "Exploring Web Pages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Intro to HTML",
+      "name": "Intro to HTML",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Headings",
+      "name": "Headings",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Styling Text with CSS",
+      "name": "Styling Text with CSS",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Images",
+      "name": "Images",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Websites for Expression ",
+      "name": "Websites for Expression ",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Styling Elements with CSS",
+      "name": "Styling Elements with CSS",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Project - Building a Webpage",
+      "name": "Project - Building a Webpage",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Purpose of a Websites",
+      "name": "Purpose of a Websites",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Purpose of a Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "CSS Classes",
+      "name": "CSS Classes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Linking and Navigation",
+      "name": "Linking and Navigation",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Project - Website for a Purpose",
+      "name": "Project - Website for a Purpose",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "key": "Peer Review and Final Touches",
+      "name": "Peer Review and Final Touches",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Sample Pages_2020_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web Sample Pages_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment with Web Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSDU2 - Type Anything_virtual"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 1_virtual"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Inspector Warm Up_virtual"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "Intro to Web Lab - Part 2_virtual"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs_virtual"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 HTML Adding Paragraphs pt 2_virtual"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Debugging_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web Debugging_virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 HTML Debug Paragraphs_virtual"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using HTML Tags"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading debug_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Heading debug_virtual"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Heading Demo_virtual"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Heading Sizes_virtual"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings practice_2020_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web Headings practice_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Header Size MC_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Headings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Heading Test_virtual"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web Headings challenge_2020_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web Headings challenge_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 CSS explore CSS_virtual"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "Video: Intro to CSS_virtual"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h1_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 text style h1_virtual"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style h3_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 text style h3_virtual"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 text style size_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 text style size_virtual"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "Video: Intro to CSS Part 2_virtual"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling your Website"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add file_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 add file_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 CSS practice_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web CSS Assessment_virtual"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 CSS challenge_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 1_virtual"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image Credit_virtual"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag Debug_virtual"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image choose name_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image choose name_virtual"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image Tag 2_virtual"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image practice_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image assessment_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image assessment_virtual"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Challenges"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Image challenge_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Expression Exemplars_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style sample_virtual"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring more CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style bgcolor_virtual"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style body_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style body_virtual"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style float_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style float_virtual"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style width_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style width_virtual"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style practice_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add style_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 add style_virtual"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Layout with CSS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 layout style challenge_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 project guide_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 upload images_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 upload images_virtual"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 add content_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 add content_virtual"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 CSS_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 CSS_virtual"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Website Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project review_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 project review_virtual"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 publish video_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 publish video_virtual"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Publishing Your Website"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 project share_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 project share_virtual"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Purpose of a Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 Top Websites_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes sample_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 classes sample_virtual"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes modify_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 classes modify_virtual"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes spring_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 classes spring_virtual"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Styling with Classes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 classes summer_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 classes summer_virtual"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 RGB intro_virtual"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 link demo_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 link demo_virtual"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 making links_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 making links_virtual"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming links_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 naming links_virtual"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Links and Navigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 nav bar_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 nav bar_virtual"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 adding pages_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 adding pages_virtual"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 naming pages_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 naming pages_virtual"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: External Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 external links_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 external links_virtual"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Upload Your Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web upload images multi_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD web upload images multi_virtual"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Pages"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U2 create page_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD U2 create page_virtual"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Content"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add html_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD web add html_virtual"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Style"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web add CSS_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD web add CSS_virtual"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web check_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD web check_virtual"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      },
+      "level_keys": [
+        "CSD Web incorporate feedback_virtual"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Sample Pages_2020_virtual",
+        "script_level.level_keys": [
+          "CSD Web Sample Pages_2020_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Web Pages",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Type Anything_virtual",
+        "script_level.level_keys": [
+          "CSDU2 - Type Anything_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 1_virtual",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 1_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Inspector Warm Up_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Inspector Warm Up_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Web Lab - Part 2_virtual",
+        "script_level.level_keys": [
+          "Intro to Web Lab - Part 2_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs_virtual",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Adding Paragraphs pt 2_virtual",
+        "script_level.level_keys": [
+          "CSD U2 HTML Adding Paragraphs pt 2_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Debugging_virtual",
+        "script_level.level_keys": [
+          "CSD Web Debugging_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 HTML Debug Paragraphs_virtual",
+        "script_level.level_keys": [
+          "CSD U2 HTML Debug Paragraphs_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading debug_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Heading debug_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Intro to HTML",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Demo_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Heading Demo_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Sizes_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Heading Sizes_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings practice_2020_virtual",
+        "script_level.level_keys": [
+          "CSD Web Headings practice_2020_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Header Size MC_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD Header Size MC_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Heading Test_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Heading Test_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web Headings challenge_2020_virtual",
+        "script_level.level_keys": [
+          "CSD Web Headings challenge_2020_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Headings",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS explore CSS_virtual",
+        "script_level.level_keys": [
+          "CSD U2 CSS explore CSS_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS_virtual",
+        "script_level.level_keys": [
+          "Video: Intro to CSS_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h1_virtual",
+        "script_level.level_keys": [
+          "CSD U2 text style h1_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style h3_virtual",
+        "script_level.level_keys": [
+          "CSD U2 text style h3_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 text style size_virtual",
+        "script_level.level_keys": [
+          "CSD U2 text style size_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video: Intro to CSS Part 2_virtual",
+        "script_level.level_keys": [
+          "Video: Intro to CSS Part 2_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add file_virtual",
+        "script_level.level_keys": [
+          "CSD U2 add file_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS practice_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 CSS practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web CSS Assessment_virtual",
+        "script_level.level_keys": [
+          "CSD Web CSS Assessment_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS challenge_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 CSS challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Styling Text with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 1_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 1_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Credit_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image Credit_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag Debug_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag Debug_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image choose name_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image choose name_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image Tag 2_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image Tag 2_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image practice_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image assessment_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image assessment_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Image challenge_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Image challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Images",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Expression Exemplars_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Expression Exemplars_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Websites for Expression ",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style sample_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style sample_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style bgcolor_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style bgcolor_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style body_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style body_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style float_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style float_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style width_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style width_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style practice_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style practice_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add style_virtual",
+        "script_level.level_keys": [
+          "CSD U2 add style_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 layout style challenge_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 layout style challenge_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Styling Elements with CSS",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project guide_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 project guide_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 upload images_virtual",
+        "script_level.level_keys": [
+          "CSD U2 upload images_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 add content_virtual",
+        "script_level.level_keys": [
+          "CSD U2 add content_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 CSS_virtual",
+        "script_level.level_keys": [
+          "CSD U2 CSS_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project review_virtual",
+        "script_level.level_keys": [
+          "CSD U2 project review_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 publish video_virtual",
+        "script_level.level_keys": [
+          "CSD U2 publish video_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 project share_virtual",
+        "script_level.level_keys": [
+          "CSD U2 project share_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Project - Building a Webpage",
+        "lesson_group.key": "csd2_1",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 Top Websites_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U2 Top Websites_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Purpose of a Websites",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes sample_virtual",
+        "script_level.level_keys": [
+          "CSD U2 classes sample_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes modify_virtual",
+        "script_level.level_keys": [
+          "CSD U2 classes modify_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes spring_virtual",
+        "script_level.level_keys": [
+          "CSD U2 classes spring_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 classes summer_virtual",
+        "script_level.level_keys": [
+          "CSD U2 classes summer_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 RGB intro_virtual",
+        "script_level.level_keys": [
+          "CSD U2 RGB intro_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "CSS Classes",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 link demo_virtual",
+        "script_level.level_keys": [
+          "CSD U2 link demo_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 making links_virtual",
+        "script_level.level_keys": [
+          "CSD U2 making links_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming links_virtual",
+        "script_level.level_keys": [
+          "CSD U2 naming links_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 nav bar_virtual",
+        "script_level.level_keys": [
+          "CSD U2 nav bar_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 adding pages_virtual",
+        "script_level.level_keys": [
+          "CSD U2 adding pages_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 naming pages_virtual",
+        "script_level.level_keys": [
+          "CSD U2 naming pages_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 external links_virtual",
+        "script_level.level_keys": [
+          "CSD U2 external links_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Linking and Navigation",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web upload images multi_virtual",
+        "script_level.level_keys": [
+          "CSD web upload images multi_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U2 create page_virtual",
+        "script_level.level_keys": [
+          "CSD U2 create page_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add html_virtual",
+        "script_level.level_keys": [
+          "CSD web add html_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web add CSS_virtual",
+        "script_level.level_keys": [
+          "CSD web add CSS_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web check_virtual",
+        "script_level.level_keys": [
+          "CSD web check_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Project - Website for a Purpose",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Web incorporate feedback_virtual",
+        "script_level.level_keys": [
+          "CSD Web incorporate feedback_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Peer Review and Final Touches",
+        "lesson_group.key": "csd2_2",
+        "script.name": "csd2-virtual"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-1819draft.script_json
+++ b/dashboard/config/scripts_json/csd3-1819draft.script_json
@@ -1,0 +1,9939 @@
+{
+  "script": {
+    "name": "csd3-1819draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-1819draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-1819draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Shapes and Randomization",
+      "name": "Shapes and Randomization",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "The Counter Pattern Unplugged",
+      "name": "The Counter Pattern Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Booleans Unplugged",
+      "name": "Booleans Unplugged",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Other Forms of Input",
+      "name": "Other Forms of Input",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "key": "CS Discoveries End of Semester Survey",
+      "name": "CS Discoveries End of Semester Survey",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-1819draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 rect"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 fill"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 sequence"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 ellipse"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 debug"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 plotting shapes map"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 picture"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 picture"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge face"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 challenge face"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 challenge new shape"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L3 Freeplay"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "New Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 shape size map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 shape size map"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random background"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random background2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud-2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud-2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse-2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse-2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random Number Map Level"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2-2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2-2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake-2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake-2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L4 Freeplay"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Map"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables change circle size"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 naming map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 naming map"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2-2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2-2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Challenge"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Variables Challenge"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L5 Freeplay"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Map"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro predict"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Animation Tab"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Animation Tab Map"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug-2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text debug-2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example-2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example-2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L6 Freeplay"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 7"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 7"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 The Draw Loop Map"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Properties Map"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animate Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged update your scene"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L7 Freeplay"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 8"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 9"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD Counter Pattern Map"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Watchers Map"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Predict"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Debug"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Movement Gears"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Challenges"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Movement Challenges"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L9 Freeplay"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 10"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 11"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Booleans Map"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD Booleans Map"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple-2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple-2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Statements Map"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD If Statements Map"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2-2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2-2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2-2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2-2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L11 Freeplay"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 12"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 12"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean-2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean-2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional-2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional-2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW-2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW-2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Fish"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Input Fish"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows-2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows-2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Animation Edit Map"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations-2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations-2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge-2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Keyboard Input Challenge-2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L12 Freeplay"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 13"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 13"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 1"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Else Map"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD If Else Map"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Else"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 If Else"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L13 Freeplay"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 14"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 14"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Velocity"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 velocity map"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 velocity map"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump-2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump-2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Collision Detection"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 istouching map"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 istouching map"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 complex sprite movement SFLP"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 acceleration map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 acceleration map"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Collisions SFLP"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions types"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 interactions map"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 interactions map"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions SFLP"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 functions review"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Defender SFLP"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Using the Game Design Process SLFP"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform intro"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform background1"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform background2"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform items1"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform items2"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform items3"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform player1"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform player2"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform player3"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform player4"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 Project Build a Game SFLP"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game intro"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game variables"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game display boards"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game choose background"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game animations"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game user controls"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 game interactions"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-1819draft"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 1",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 2",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 3",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect",
+        "script_level.level_keys": [
+          "CSD U3 rect"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill",
+        "script_level.level_keys": [
+          "CSD U3 fill"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence",
+        "script_level.level_keys": [
+          "CSD U3 sequence"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse",
+        "script_level.level_keys": [
+          "CSD U3 ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug",
+        "script_level.level_keys": [
+          "CSD U3 debug"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 plotting shapes map",
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 picture",
+        "script_level.level_keys": [
+          "CSD U3 picture"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge face",
+        "script_level.level_keys": [
+          "CSD U3 challenge face"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge new shape",
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L3 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 4",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 shape size map",
+        "script_level.level_keys": [
+          "CSD U3 shape size map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background",
+        "script_level.level_keys": [
+          "CSD U3 Random background"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2",
+        "script_level.level_keys": [
+          "CSD U3 Random background2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud-2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud-2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse-2018",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse-2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Number Map Level",
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2-2018",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2-2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake-2018",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake-2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L4 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 5",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Map",
+        "script_level.level_keys": [
+          "CSD U3 Variables Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables change circle size",
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 naming map",
+        "script_level.level_keys": [
+          "CSD U3 naming map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2-2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2-2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L5 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 6",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Map",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro predict",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab",
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Tab Map",
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 2",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 3",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text debug-2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug-2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example-2018",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example-2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L6 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 7",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 7"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 The Draw Loop Map",
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Properties Map",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite rotation",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged update your scene",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L7 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 8",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 9",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Counter Pattern Map",
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watchers Map",
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Predict",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Debug",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Gears",
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 1",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 2",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Challenges",
+        "script_level.level_keys": [
+          "CSD U3 Movement Challenges"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L9 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 10",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 11",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Booleans Map",
+        "script_level.level_keys": [
+          "CSD Booleans Map"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple-2018",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple-2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Statements Map",
+        "script_level.level_keys": [
+          "CSD If Statements Map"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2-2018",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2-2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2-2018",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2-2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L11 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 12",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 12"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean-2018",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean-2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional-2018",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional-2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW-2018",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW-2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Fish",
+        "script_level.level_keys": [
+          "CSD U3 Input Fish"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows-2018",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows-2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Edit Map",
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations-2018",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations-2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keyboard Input Challenge-2018",
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge-2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L12 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 13",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 13"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 1",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 2",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Else Map",
+        "script_level.level_keys": [
+          "CSD If Else Map"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else",
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else",
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L13 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 14",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 14"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Velocity",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 velocity map",
+        "script_level.level_keys": [
+          "CSD U3 velocity map"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump-2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump-2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collision Detection",
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 istouching map",
+        "script_level.level_keys": [
+          "CSD U3 istouching map"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 complex sprite movement SFLP",
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 acceleration map",
+        "script_level.level_keys": [
+          "CSD U3 acceleration map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collisions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types",
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 interactions map",
+        "script_level.level_keys": [
+          "CSD U3 interactions map"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review",
+        "script_level.level_keys": [
+          "CSD U3 functions review"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Defender SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Using the Game Design Process SLFP",
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro",
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1",
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2",
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1",
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2",
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3",
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1",
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2",
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3",
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4",
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Project Build a Game SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro",
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables",
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards",
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background",
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations",
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls",
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions",
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-1819draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-1819draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-2017.script_json
+++ b/dashboard/config/scripts_json/csd3-2017.script_json
@@ -1,0 +1,10029 @@
+{
+  "script": {
+    "name": "csd3-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit3/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit3/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd/unit3/code/"
+        ]
+      ]
+    },
+    "new_name": "csd3-2017",
+    "family_name": "csd3",
+    "seeding_key": {
+      "script.name": "csd3-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd3-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Shapes and Randomization",
+      "name": "Shapes and Randomization",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "The Counter Pattern Unplugged",
+      "name": "The Counter Pattern Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Booleans Unplugged",
+      "name": "Booleans Unplugged",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Other Forms of Input",
+      "name": "Other Forms of Input",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "CS Discoveries End of Semester Survey",
+      "name": "CS Discoveries End of Semester Survey",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "key": "CSD Post-Course Survey",
+      "name": "CSD Post-Course Survey",
+      "absolute_position": 24,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd3-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 rect"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 fill"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 sequence"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 ellipse"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 debug"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 plotting shapes map"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 picture"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 picture"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge face"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 challenge face"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 challenge new shape"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L3 Freeplay"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "New Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 shape size map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 shape size map"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random background"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random background2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random Number Map Level"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L4 Freeplay"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Map"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables change circle size"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 naming map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 naming map"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Challenge"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Variables Challenge"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L5 Freeplay"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Map"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro predict"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Animation Tab"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Animation Tab Map"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text debug"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L6 Freeplay"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 7"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 7"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 The Draw Loop Map"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Properties Map"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animate Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged update your scene"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L7 Freeplay"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 8"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 9"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD Counter Pattern Map"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Watchers Map"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Predict"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Debug"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Movement Gears"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Challenges"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Movement Challenges"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L9 Freeplay"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 10"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 11"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Booleans Map"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD Booleans Map"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Statements Map"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD If Statements Map"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L11 Freeplay"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 12"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 12"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Fish"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Input Fish"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Animation Edit Map"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Keyboard Input Challenge"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L12 Freeplay"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 13"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 13"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 1"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Else Map"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD If Else Map"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Else"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 If Else"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L13 Freeplay"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 14"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 14"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Velocity"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 velocity map"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 velocity map"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Collision Detection"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 istouching map"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 istouching map"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 complex sprite movement SFLP"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 acceleration map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 acceleration map"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Collisions SFLP"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions types"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 interactions map"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 interactions map"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions SFLP"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 functions review"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Defender SFLP"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Using the Game Design Process SLFP"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform intro"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform background1"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform background2"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform items1"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform items2"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform items3"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform player1"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform player2"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform player3"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform player4"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 Project Build a Game SFLP"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game intro"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game variables"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game display boards"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game choose background"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game animations"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game user controls"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 game interactions"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd3-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 1",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 2",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 3",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect",
+        "script_level.level_keys": [
+          "CSD U3 rect"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill",
+        "script_level.level_keys": [
+          "CSD U3 fill"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence",
+        "script_level.level_keys": [
+          "CSD U3 sequence"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse",
+        "script_level.level_keys": [
+          "CSD U3 ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug",
+        "script_level.level_keys": [
+          "CSD U3 debug"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 plotting shapes map",
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 picture",
+        "script_level.level_keys": [
+          "CSD U3 picture"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge face",
+        "script_level.level_keys": [
+          "CSD U3 challenge face"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge new shape",
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L3 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 4",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 shape size map",
+        "script_level.level_keys": [
+          "CSD U3 shape size map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background",
+        "script_level.level_keys": [
+          "CSD U3 Random background"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2",
+        "script_level.level_keys": [
+          "CSD U3 Random background2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Number Map Level",
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L4 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 5",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Map",
+        "script_level.level_keys": [
+          "CSD U3 Variables Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables change circle size",
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 naming map",
+        "script_level.level_keys": [
+          "CSD U3 naming map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L5 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 6",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Map",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro predict",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab",
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Tab Map",
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 2",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 3",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text debug",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L6 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 7",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 7"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 The Draw Loop Map",
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Properties Map",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite rotation",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged update your scene",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L7 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 8",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 8"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 9",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 9"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Counter Pattern Map",
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watchers Map",
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Predict",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Debug",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Gears",
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 1",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 2",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Challenges",
+        "script_level.level_keys": [
+          "CSD U3 Movement Challenges"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L9 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 10",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 10"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 11",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 11"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Booleans Map",
+        "script_level.level_keys": [
+          "CSD Booleans Map"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Statements Map",
+        "script_level.level_keys": [
+          "CSD If Statements Map"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L11 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 12",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 12"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Fish",
+        "script_level.level_keys": [
+          "CSD U3 Input Fish"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Edit Map",
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keyboard Input Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L12 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 13",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 13"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 1",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 2",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Else Map",
+        "script_level.level_keys": [
+          "CSD If Else Map"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else",
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else",
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L13 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 14",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 14"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Velocity",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 velocity map",
+        "script_level.level_keys": [
+          "CSD U3 velocity map"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collision Detection",
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 istouching map",
+        "script_level.level_keys": [
+          "CSD U3 istouching map"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 complex sprite movement SFLP",
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 acceleration map",
+        "script_level.level_keys": [
+          "CSD U3 acceleration map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collisions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types",
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 interactions map",
+        "script_level.level_keys": [
+          "CSD U3 interactions map"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review",
+        "script_level.level_keys": [
+          "CSD U3 functions review"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Defender SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Using the Game Design Process SLFP",
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro",
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1",
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2",
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1",
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2",
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3",
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1",
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2",
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3",
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4",
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Project Build a Game SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro",
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables",
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards",
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background",
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations",
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls",
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions",
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd3-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-2018.script_json
+++ b/dashboard/config/scripts_json/csd3-2018.script_json
@@ -1,0 +1,10174 @@
+{
+  "script": {
+    "name": "csd3-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true,
+      "announcements": [
+        {
+          "notice": "CS Discoveries Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes. Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csd-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit3/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit3/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-18/unit3/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd3",
+    "seeding_key": {
+      "script.name": "csd3-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Shapes and Randomization",
+      "name": "Shapes and Randomization",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "The Counter Pattern Unplugged",
+      "name": "The Counter Pattern Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Booleans Unplugged",
+      "name": "Booleans Unplugged",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Other Forms of Input",
+      "name": "Other Forms of Input",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries End of Semester Survey",
+      "name": "CS Discoveries End of Semester Survey",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries Post-Course Survey",
+      "name": "CS Discoveries Post-Course Survey",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L01 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L02 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L03 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 rect_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 fill_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 sequence_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 ellipse_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 debug_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 plotting shapes map_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 picture_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 picture_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge face_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 challenge face_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 challenge new shape_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L3 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L04 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "New Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 shape size map_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 shape size map_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random background_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random background2_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random Number Map Level_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L4 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L05 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Map_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables change circle size_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 naming map_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 naming map_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Challenge_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Variables Challenge_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L5 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L06 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Map_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro predict_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Animation Tab Map_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 2_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 3_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 drawSprites placement match"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text debug_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 20,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L6 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L07 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 The Draw Loop Map_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Properties Map_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite rotation_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animate Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged update your scene_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L7 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L08 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L09 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD Counter Pattern Map_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Watchers Map_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Predict_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Debug_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Movement Gears_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 1_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 2_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD sprite movement challenge_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish challenge_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L9 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L10 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L11 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Booleans Map_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD Booleans Map_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Statements Map_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD If Statements Map_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L11 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L12 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Input Fish_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Animation Edit Map_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Keyboard Input Challenge_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L12 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L13 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 1_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Follow the Mouse"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 2_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Else Map_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD If Else Map_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Else_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 If Else_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L13 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L14 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Card Examples_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L15 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 velocity map_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 velocity map_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L16 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_2018"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 istouching map_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 istouching map_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L17 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_2018"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_2018"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_2018"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up_2018"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_2018"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_2018"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping_2018"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter_2018"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2_2018"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin_2018"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin_2018"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own_2018"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 acceleration map_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 acceleration map_2018"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L18 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code_2018"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_2018"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions types_2018"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle_2018"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug_2018"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider_2018"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness_2018"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles_2018"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff_2018"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin_2018"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders_2018"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own_2018"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 interactions map_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 interactions map_2018"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L19 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_2018"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_2018"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_2018"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop_2018"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite_2018"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite_2018"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function_2018"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_2018"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_2018"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_2018"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 functions review_2018"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay_2018"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L20 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender_2018"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide_2018"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe_2018"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down_2018"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation_2018"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies_2018"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move_2018"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake_2018"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2018"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies_2018"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player_2018"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down_2018"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player_2018"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies_2018"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water_2018"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own_2018"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L21 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2018"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1_2018"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform intro_2018"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform background1_2018"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1_2018"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform background2_2018"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2018"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard_2018"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1_2018"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2_2018"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3_2018"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform items1_2018"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform items2_2018"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform items3_2018"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform player1_2018"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform player2_2018"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform player3_2018"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform player4_2018"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2_2018"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3_2018"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge_2018"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3L22 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game variables_2018"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_2018"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_2018"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_2018"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game animations_2018"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_2018"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2018"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_2018"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_2018"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_2018"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches_2018"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L01 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment_2018",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4_2018",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3_2018",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1_2018",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L02 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab_2018",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L03 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect_2018",
+        "script_level.level_keys": [
+          "CSD U3 rect_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_2018",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners_2018",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_2018",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill_2018",
+        "script_level.level_keys": [
+          "CSD U3 fill_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence_2018",
+        "script_level.level_keys": [
+          "CSD U3 sequence_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse_2018",
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug_2018",
+        "script_level.level_keys": [
+          "CSD U3 debug_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 plotting shapes map_2018",
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 picture_2018",
+        "script_level.level_keys": [
+          "CSD U3 picture_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge face_2018",
+        "script_level.level_keys": [
+          "CSD U3 challenge face_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge new shape_2018",
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L3 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L04 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 shape size map_2018",
+        "script_level.level_keys": [
+          "CSD U3 shape size map_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random background_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Number Map Level_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake_2018",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L4 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L05 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2018",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables change circle size_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 naming map_2018",
+        "script_level.level_keys": [
+          "CSD U3 naming map_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L5 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L06 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_2018",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro predict_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_2018",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Tab Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 3_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawSprites placement match",
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text debug_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example_2018",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L6 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 20,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L07 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_2018",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 The Draw Loop Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_2018",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Properties Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite rotation_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged update your scene_2018",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L7 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L08 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L09 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_2018",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Counter Pattern Map_2018",
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict_2018",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict_2018",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement_2018",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watchers Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Predict_2018",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Debug_2018",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish_2018",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Gears_2018",
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 1_2018",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD sprite movement challenge_2018",
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L9 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L10 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L11 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict_2018",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_2018",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Booleans Map_2018",
+        "script_level.level_keys": [
+          "CSD Booleans Map_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify_2018",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching_2018",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition_2018",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple_2018",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Statements Map_2018",
+        "script_level.level_keys": [
+          "CSD If Statements Map_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional_2018",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L11 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L12 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean_2018",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional_2018",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW_2018",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Fish_2018",
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears_2018",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows_2018",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Edit Map_2018",
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations_2018",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keyboard Input Challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L12 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L13 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 1_2018",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_2018",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Else Map_2018",
+        "script_level.level_keys": [
+          "CSD If Else Map_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else_2018",
+        "script_level.level_keys": [
+          "CSD U3 Else_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else_2018",
+        "script_level.level_keys": [
+          "CSD U3 If Else_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers_2018",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching_2018",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down_2018",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down_2018",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move_2018",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L13 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L14 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Card Examples_2018",
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final_2018",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L15 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_2018",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 velocity map_2018",
+        "script_level.level_keys": [
+          "CSD U3 velocity map_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L16 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 istouching map_2018",
+        "script_level.level_keys": [
+          "CSD U3 istouching map_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L17 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_2018",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own_2018",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 acceleration map_2018",
+        "script_level.level_keys": [
+          "CSD U3 acceleration map_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L18 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions types_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own_2018",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 interactions map_2018",
+        "script_level.level_keys": [
+          "CSD U3 interactions map_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L19 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_2018",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review_2018",
+        "script_level.level_keys": [
+          "CSD U3 functions review_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay_2018",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L20 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own_2018",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L21 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2018"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2018"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge_2018",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L22 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_2018",
+        "script_level.level_keys": [
+          "CSD U3 game variables_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_2018",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_2018",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_2018",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_2018",
+        "script_level.level_keys": [
+          "CSD U3 game animations_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_2018",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_2018",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2018"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_2018",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_2018",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches_2018",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries End of Semester Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-2019.script_json
+++ b/dashboard/config/scripts_json/csd3-2019.script_json
@@ -1,0 +1,10278 @@
+{
+  "script": {
+    "name": "csd3-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit3/{LESSON}",
+      "announcements": [
+        {
+          "notice": "Check out the new CS Discoveries resources for 2019-2020!",
+          "details": "Read more about our new teacher guides, learning frameworks, OneNote Journal, and Flipgrid Disco Library!",
+          "link": "https://forum.code.org/t/new-resources-for-2019-2020/30676",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit3/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit3/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-19/unit3/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd3",
+    "seeding_key": {
+      "script.name": "csd3-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Shapes and Randomization",
+      "name": "Shapes and Randomization",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "The Counter Pattern Unplugged",
+      "name": "The Counter Pattern Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Booleans Unplugged",
+      "name": "Booleans Unplugged",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Other Forms of Input",
+      "name": "Other Forms of Input",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 24,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L01 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L02 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L03 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 rect_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 fill_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 sequence_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 ellipse_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 debug_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 plotting shapes map_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 picture_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 picture_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge face_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 challenge face_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 challenge new shape_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L3 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L04 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "New Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random background_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random background2_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud_2018_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 shape size map_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 shape size map_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse_2018_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake_2018_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Random Number Map Level_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L4 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L05 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables change circle size_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Map_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Intro to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 naming map_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 naming map_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Challenge_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Variables Challenge_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L5 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L06 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Map_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro predict_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Animation Tab Map_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 2_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 3_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 drawSprites placement match_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text debug_2018_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example_2018_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 20,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L6 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L07 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 The Draw Loop Map_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Properties Map_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite rotation_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Animate Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged update your scene_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L7 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L08 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L09 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD Counter Pattern Map_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Predict_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Debug_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Movement Gears_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Watchers Map_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 1_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 2_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD sprite movement challenge_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish challenge_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L9 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L10 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L11 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching_2018_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple_2018_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Booleans Map_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD Booleans Map_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Statements Map_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD If Statements Map_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L11 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L12 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean_2018_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional_2018_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW_2018_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Input Fish_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows_2018_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Animation Edit Map_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations_2018_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Keyboard Input Challenge_2018_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L12 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L13 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 if else predict"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 if else predict"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 If Else_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Else_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD If Else Map_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD If Else Map_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 1_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 2_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching_2018_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 15,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L13 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L14 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Card Examples_2018_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L15 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_2019"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_2019"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 velocity map_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 velocity map_2019"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump_2018_2019"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed_2019"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping_2019"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L16 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_2019"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_2019"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_2019"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_2019"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2_2019"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_2019"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_2019"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard_2019"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2_2019"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 istouching map_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 istouching map_2019"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L17 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_2019"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_2019"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_2019"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up_2019"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_2019"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_2019"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping_2019"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter_2019"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2_2019"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin_2019"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin_2019"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own_2019"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 acceleration map_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 acceleration map_2019"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L18 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code_2019"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x_2019"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y_2019"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_2019"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_2019"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions types_2019"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle_2019"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug_2019"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider_2019"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness_2019"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles_2019"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff_2019"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin_2019"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders_2019"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own_2019"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 interactions map_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 interactions map_2019"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L19 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 function video"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 function video"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_2019"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_2019"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_2019"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop_2019"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite_2019"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite_2019"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function_2019"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_2019"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_2019"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_2019"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 functions review_2019"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L20 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender_2019"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide_2018_2019"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe_2019"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down_2019"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation_2019"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies_2019"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move_2019"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake_2019"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2019"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies_2019"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player_2019"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down_2019"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player_2019"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies_2019"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water_2019"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own_2019"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L21 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1_2019"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform intro_2018_2019"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform background1_2019"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1_2019"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform background2_2019"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard_2019"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1_2019"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2_2019"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3_2019"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform items1_2019"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform items2_2019"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform items3_2019"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform player1_2019"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform player2_2019"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform player3_2019"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform player4_2019"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2_2019"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3_2019"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge_2019"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3L22 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018_2019"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game variables_2019"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_2019"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_2019"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_2019"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game animations_2019"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_2019"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_2019"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_2019"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_2019"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches_2019"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "CSD Interactive Animations and Games Post-Project Test"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L01 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4_2019",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3_2019",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1_2019",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L02 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab_2019",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L03 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect_2019",
+        "script_level.level_keys": [
+          "CSD U3 rect_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_2019",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners_2019",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_2019",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill_2019",
+        "script_level.level_keys": [
+          "CSD U3 fill_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence_2019",
+        "script_level.level_keys": [
+          "CSD U3 sequence_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse_2019",
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug_2019",
+        "script_level.level_keys": [
+          "CSD U3 debug_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 plotting shapes map_2019",
+        "script_level.level_keys": [
+          "CSD U3 plotting shapes map_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 picture_2019",
+        "script_level.level_keys": [
+          "CSD U3 picture_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge face_2019",
+        "script_level.level_keys": [
+          "CSD U3 challenge face_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 challenge new shape_2019",
+        "script_level.level_keys": [
+          "CSD U3 challenge new shape_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L3 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L3 Freeplay_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L04 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random background_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 shape size map_2019",
+        "script_level.level_keys": [
+          "CSD U3 shape size map_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Number Map Level_2019",
+        "script_level.level_keys": [
+          "CSD U3 Random Number Map Level_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L4 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L4 Freeplay_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 13,
+        "lesson.key": "Shapes and Randomization",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L05 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2019",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables change circle size_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables change circle size_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 naming map_2019",
+        "script_level.level_keys": [
+          "CSD U3 naming map_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Challenge_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 Variables Challenge_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L5 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L5 Freeplay_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L06 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_2019",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Map_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro predict_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro predict_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_2019",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Tab Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Animation Tab Map_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 2_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 3_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 3_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawSprites placement match_2019",
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 13,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text debug_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 14,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 15,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 16,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 17,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 18,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 19,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L6 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L6 Freeplay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 20,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L07 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_2019",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 The Draw Loop Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 The Draw Loop Map_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_2019",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Properties Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Properties Map_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite rotation_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged update your scene_2019",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L7 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L08 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L09 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_2019",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict_2019",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict_2019",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement_2019",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Counter Pattern Map_2019",
+        "script_level.level_keys": [
+          "CSD Counter Pattern Map_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Predict_2019",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Debug_2019",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish_2019",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Gears_2019",
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watchers Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Watchers Map_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 1_2019",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD sprite movement challenge_2019",
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L9 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L10 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L11 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict_2019",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_2019",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify_2019",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition_2019",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Booleans Map_2019",
+        "script_level.level_keys": [
+          "CSD Booleans Map_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video_2019",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional_2019",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Statements Map_2019",
+        "script_level.level_keys": [
+          "CSD If Statements Map_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L11 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L12 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Fish_2019",
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears_2019",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Animation Edit Map_2019",
+        "script_level.level_keys": [
+          "CSD U3 Animation Edit Map_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keyboard Input Challenge_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L12 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L13 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 if else predict",
+        "script_level.level_keys": [
+          "CSD U3 if else predict"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_2019",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else_2019",
+        "script_level.level_keys": [
+          "CSD U3 If Else_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else_2019",
+        "script_level.level_keys": [
+          "CSD U3 Else_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD If Else Map_2019",
+        "script_level.level_keys": [
+          "CSD If Else Map_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 1_2019",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers_2019",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down_2019",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down_2019",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move_2019",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L13 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 15,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L14 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Card Examples_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final_2019",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L15 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_2019",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 velocity map_2019",
+        "script_level.level_keys": [
+          "CSD U3 velocity map_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 14,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L16 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 istouching map_2019",
+        "script_level.level_keys": [
+          "CSD U3 istouching map_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L17 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_2019",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own_2019",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 acceleration map_2019",
+        "script_level.level_keys": [
+          "CSD U3 acceleration map_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 15,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L18 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions types_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own_2019",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 interactions map_2019",
+        "script_level.level_keys": [
+          "CSD U3 interactions map_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 18,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L19 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 function video",
+        "script_level.level_keys": [
+          "CSD U3 function video"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_2019",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review_2019",
+        "script_level.level_keys": [
+          "CSD U3 functions review_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay_2019",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L20 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own_2019",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L21 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge_2019",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L22 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_2019",
+        "script_level.level_keys": [
+          "CSD U3 game variables_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_2019",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_2019",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_2019",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_2019",
+        "script_level.level_keys": [
+          "CSD U3 game animations_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_2019",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_2019",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_2019",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_2019",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches_2019",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Interactive Animations and Games Post-Project Test",
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-2020.script_json
+++ b/dashboard/config/scripts_json/csd3-2020.script_json
@@ -1,0 +1,9853 @@
+{
+  "script": {
+    "name": "csd3-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit3/{LESSON}",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit3/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit3/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-20/unit3/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Shapes and Parameters",
+      "name": "Shapes and Parameters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Random Numbers",
+      "name": "Random Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Sprite Properties",
+      "name": "Sprite Properties",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Text",
+      "name": "Text",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: Captioned Scenes",
+      "name": "Mini-Project: Captioned Scenes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: Animation",
+      "name": "Mini-Project: Animation",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Mouse Input",
+      "name": "Mouse Input",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: Side Scroller",
+      "name": "Mini-Project: Side Scroller",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Mini-Project: Flyer Game",
+      "name": "Mini-Project: Flyer Game",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 28,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 29,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L01 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring CS in Entertainment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L02 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L03 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Game Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 rect_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Drawing in Game Lab - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Grid"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Drawing in Game Lab - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 fill_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 sequence_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 ellipse_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 drawing practice choice_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 debug_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 drawing challenges_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L04 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random background_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random background2_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games parameters practice_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games parameters practice_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud_2018_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games Parameters challenge_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L05 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games variables practice_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables assessment_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables challenge_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games variables challenge_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L06 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse_2018_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Variables random reassign_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random practice_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games random practice_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake_2018_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random challenge_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games random challenge_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L07 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Exploration_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: The Animation Tab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites sequencing_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 drawSprites placement match_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites practice_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games Sprites practice_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites assessment_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games Sprites Challenges_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L08 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties predict_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games properties predict_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties xy_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games properties xy_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties new_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games properties new_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties practice_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games Properties practice_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties assessment_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games properties assessment_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties challenge_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Games Properties challenge_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L09 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text explore"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web text explore"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text size"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web text size"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text practice choice_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web text practice choice_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text assessment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web text assessment"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text challenge choice_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web text challenge choice_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L09a TFMD_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L09a TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example_2018_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create a Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD pilot_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L10 TFMD pilot_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web draw loop practice choice"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web draw loop practice choice"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web draw loop challenge choice"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web draw loop challenge choice"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L12 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Sprite Movement"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web movement practice choice"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web movement practice choice"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web movement challenge choice"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web movement challenge choice"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L13 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Animated Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated example"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated example"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Plan Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated plan"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated plan"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Draw a Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated background"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated background"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated sprites"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated sprites"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated text"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated text"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Movement"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated movement"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated movement"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Animated Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web project animated review"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web project animated review"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L14 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Booleans"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Quick Check"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Conditional Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals practice choice"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web conditionals practice choice"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals assessment"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web conditionals assessment"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals challenge choice"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web conditionals challenge choice"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L15 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean_2018_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional_2018_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW_2018_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web keyboard practice choice"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web keyboard practice choice"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows_2018_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web keyboard challenge choice"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web keyboard challenge choice"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L16 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 if else predict_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 if else predict_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: If/Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Else_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games mousedown intro"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games mousedown intro"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 If Else_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse practice choice"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web mouse practice choice"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse assessment"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web mouse assessment"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse challenge choice"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD web mouse challenge choice"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L17 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "interactive Card"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make an Interactive Card"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Card Examples_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L18 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity tennis"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games velocity tennis"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity practice choice"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games velocity practice choice"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_2020"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity challenge choice"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games velocity challenge choice"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L19 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_2020"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_2020"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_2020"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_2020"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_2020"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games istouching practice choice"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games istouching practice choice"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_2020"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games istouching challenge choice"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games istouching challenge choice"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L20 TFMD"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Side Scrollers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games side scroller demo"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games side scroller demo"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Draw Your Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games sidescroll background"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games sidescroll background"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed_2020"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Player Controls"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump_2018_2020"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping_2020"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2_2020"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Scoring & Scoreboard"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard_2020"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games sidescroll review"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 9,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games sidescroll review"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L20 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_2020"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_2020"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_2020"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_2020"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games movement2 practice choice"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games movement2 practice choice"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_2020"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games movement2 challenge choice"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games movement2 challenge choice"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L21 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code_2020"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x_2020"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y_2020"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_2020"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_2020"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions practice choice"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games collisions practice choice"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions assessment"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games collisions assessment"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions challenge choice"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games collisions challenge choice"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L23 TFMD"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games flyer demo"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games flyer demo"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2020"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin_2020"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Player Controls"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2020"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping_2020"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Player Controls"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2020"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter_2020"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Player Controls"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2020"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2_2020"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Movement"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2020"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles_2020"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2020"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin_2020"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2020"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 9,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff_2020"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2020"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L22 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 function video_2020"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 function video_2020"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2020"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_2020"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2020"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_2020"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2020"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_2020"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games functions practice choice"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games functions practice choice"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games functions assessment FR"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games functions assessment FR"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2020"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_2020"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2020"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_2020"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2020"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_2020"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games functions challenge choice"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games functions challenge choice"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD_2020"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L23 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Same Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2020"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender_2020"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Plan Your Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Set Up Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2020"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies_2020"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Set Up Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2020"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move_2020"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Control Your Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2020"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player_2020"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Control Your Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2020"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down_2020"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Control Your Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2020"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player_2020"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2020"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake_2020"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2020"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2020"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2020"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies_2020"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2020"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies_2020"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2020"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water_2020"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games cake challenge choice"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games cake challenge choice"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L24 TFMD_2020"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L24 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Platform Jumper Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2020"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1_2020"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Platform Jumper"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform intro_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2020"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform background1_2020"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2020"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1_2020"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2020"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform background2_2020"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2020"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard_2020"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2020"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1_2020"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2020"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2_2020"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2020"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3_2020"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2020"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform items1_2020"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2020"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform items2_2020"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2020"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform items3_2020"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2020"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform player1_2020"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2020"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform player2_2020"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2020"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform player3_2020"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2020"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform player4_2020"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Platform Jumper Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform review"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform review"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2020"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2_2020"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2020"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3_2020"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games platform challenge choice"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 21,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games platform challenge choice"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L25 TFMD_2020"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3L25 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_2020"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game variables_2020"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2020"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_2020"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2020"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_2020"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2020"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_2020"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_2020"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game animations_2020"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2020"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_2020"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2020"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_2020"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2020"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_2020"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2020"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_2020"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games project review"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD games project review"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test_pilot_2020"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "CSD Interactive Animations and Games Post-Project Test_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot_2020"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L01 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4_2020",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3_2020",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1_2020",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2_2020",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L02 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab_2020",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L03 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect_2020",
+        "script_level.level_keys": [
+          "CSD U3 rect_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_2020",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners_2020",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_2020",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill_2020",
+        "script_level.level_keys": [
+          "CSD U3 fill_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence_2020",
+        "script_level.level_keys": [
+          "CSD U3 sequence_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse_2020",
+        "script_level.level_keys": [
+          "CSD U3 ellipse_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing practice choice_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug_2020",
+        "script_level.level_keys": [
+          "CSD U3 debug_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing challenges_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L04 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random background_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random background2_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games parameters practice_2020",
+        "script_level.level_keys": [
+          "CSD Games parameters practice_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Parameters challenge_2020",
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L05 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2020",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables practice_2020",
+        "script_level.level_keys": [
+          "CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables assessment_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables challenge_2020",
+        "script_level.level_keys": [
+          "CSD Games variables challenge_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L06 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random reassign_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random practice_2020",
+        "script_level.level_keys": [
+          "CSD games random practice_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random challenge_2020",
+        "script_level.level_keys": [
+          "CSD games random challenge_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L07 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Exploration_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_2020",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_2020",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites sequencing_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawSprites placement match_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites practice_2020",
+        "script_level.level_keys": [
+          "CSD Games Sprites practice_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites assessment_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites Challenges_2020",
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 12,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L08 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties predict_2020",
+        "script_level.level_keys": [
+          "CSD Games properties predict_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties xy_2020",
+        "script_level.level_keys": [
+          "CSD Games properties xy_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties new_2020",
+        "script_level.level_keys": [
+          "CSD Games properties new_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties practice_2020",
+        "script_level.level_keys": [
+          "CSD Games Properties practice_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties assessment_2020",
+        "script_level.level_keys": [
+          "CSD Games properties assessment_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties challenge_2020",
+        "script_level.level_keys": [
+          "CSD Games Properties challenge_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L09 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text explore",
+        "script_level.level_keys": [
+          "CSD web text explore"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text size",
+        "script_level.level_keys": [
+          "CSD web text size"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text practice choice_2020",
+        "script_level.level_keys": [
+          "CSD web text practice choice_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text assessment",
+        "script_level.level_keys": [
+          "CSD web text assessment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text challenge choice_2020",
+        "script_level.level_keys": [
+          "CSD web text challenge choice_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Text",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L09a TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L09a TFMD_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L10 TFMD pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD pilot_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_2020",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_2020",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web draw loop practice choice",
+        "script_level.level_keys": [
+          "CSD web draw loop practice choice"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web draw loop challenge choice",
+        "script_level.level_keys": [
+          "CSD web draw loop challenge choice"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L12 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_2020",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement_2020",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web movement practice choice",
+        "script_level.level_keys": [
+          "CSD web movement practice choice"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish_2020",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web movement challenge choice",
+        "script_level.level_keys": [
+          "CSD web movement challenge choice"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L13 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated example",
+        "script_level.level_keys": [
+          "CSD web project animated example"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated plan",
+        "script_level.level_keys": [
+          "CSD web project animated plan"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated background",
+        "script_level.level_keys": [
+          "CSD web project animated background"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated sprites",
+        "script_level.level_keys": [
+          "CSD web project animated sprites"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated text",
+        "script_level.level_keys": [
+          "CSD web project animated text"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated movement",
+        "script_level.level_keys": [
+          "CSD web project animated movement"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web project animated review",
+        "script_level.level_keys": [
+          "CSD web project animated review"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Animation",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L14 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict_2020",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video_2020",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals practice choice",
+        "script_level.level_keys": [
+          "CSD web conditionals practice choice"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals assessment",
+        "script_level.level_keys": [
+          "CSD web conditionals assessment"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals challenge choice",
+        "script_level.level_keys": [
+          "CSD web conditionals challenge choice"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L15 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears_2020",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web keyboard practice choice",
+        "script_level.level_keys": [
+          "CSD web keyboard practice choice"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web keyboard challenge choice",
+        "script_level.level_keys": [
+          "CSD web keyboard challenge choice"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L16 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 if else predict_2020",
+        "script_level.level_keys": [
+          "CSD U3 if else predict_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else_2020",
+        "script_level.level_keys": [
+          "CSD U3 Else_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games mousedown intro",
+        "script_level.level_keys": [
+          "CSD games mousedown intro"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down_2020",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else_2020",
+        "script_level.level_keys": [
+          "CSD U3 If Else_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse practice choice",
+        "script_level.level_keys": [
+          "CSD web mouse practice choice"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse assessment",
+        "script_level.level_keys": [
+          "CSD web mouse assessment"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse challenge choice",
+        "script_level.level_keys": [
+          "CSD web mouse challenge choice"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L17 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Card Examples_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final_2020",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L18 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_2020",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity tennis",
+        "script_level.level_keys": [
+          "CSD games velocity tennis"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity practice choice",
+        "script_level.level_keys": [
+          "CSD games velocity practice choice"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity challenge choice",
+        "script_level.level_keys": [
+          "CSD games velocity challenge choice"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L19 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games istouching practice choice",
+        "script_level.level_keys": [
+          "CSD games istouching practice choice"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games istouching challenge choice",
+        "script_level.level_keys": [
+          "CSD games istouching challenge choice"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L20 TFMD",
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games side scroller demo",
+        "script_level.level_keys": [
+          "CSD games side scroller demo"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games sidescroll background",
+        "script_level.level_keys": [
+          "CSD games sidescroll background"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump_2018_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games sidescroll review",
+        "script_level.level_keys": [
+          "CSD games sidescroll review"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 9,
+        "lesson.key": "Mini-Project: Side Scroller",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L20 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_2020",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games movement2 practice choice",
+        "script_level.level_keys": [
+          "CSD games movement2 practice choice"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games movement2 challenge choice",
+        "script_level.level_keys": [
+          "CSD games movement2 challenge choice"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L21 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions practice choice",
+        "script_level.level_keys": [
+          "CSD games collisions practice choice"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions assessment",
+        "script_level.level_keys": [
+          "CSD games collisions assessment"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions challenge choice",
+        "script_level.level_keys": [
+          "CSD games collisions challenge choice"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L23 TFMD",
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games flyer demo",
+        "script_level.level_keys": [
+          "CSD games flyer demo"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_2020"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_2020"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 4,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_2020"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 5,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_2020"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 6,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_2020"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 7,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_2020"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 8,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_2020"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 9,
+        "lesson.key": "Mini-Project: Flyer Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L22 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_2020"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 function video_2020",
+        "script_level.level_keys": [
+          "CSD U3 function video_2020"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_2020"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_2020"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_2020"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games functions practice choice",
+        "script_level.level_keys": [
+          "CSD games functions practice choice"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games functions assessment FR",
+        "script_level.level_keys": [
+          "CSD games functions assessment FR"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_2020"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_2020"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_2020"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games functions challenge choice",
+        "script_level.level_keys": [
+          "CSD games functions challenge choice"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L23 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD_2020"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_2020"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_2020"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_2020"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_2020"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_2020"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_2020"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_2020"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_2020"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_2020"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_2020"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water_2020",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_2020"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games cake challenge choice",
+        "script_level.level_keys": [
+          "CSD games cake challenge choice"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L24 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L24 TFMD_2020"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_2020"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform background1_2020"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_2020"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform background2_2020"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_2020"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_2020"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_2020"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_2020"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform items1_2020"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform items2_2020"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform items3_2020"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform player1_2020"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform player2_2020"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform player3_2020"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform player4_2020"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform review",
+        "script_level.level_keys": [
+          "CSD U3 platform review"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_2020"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3_2020",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_2020"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games platform challenge choice",
+        "script_level.level_keys": [
+          "CSD games platform challenge choice"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 21,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L25 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U3L25 TFMD_2020"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_2020",
+        "script_level.level_keys": [
+          "CSD U3 game variables_2020"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_2020",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_2020"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_2020",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_2020"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_2020",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_2020"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_2020",
+        "script_level.level_keys": [
+          "CSD U3 game animations_2020"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_2020",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_2020"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_2020",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_2020"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_2020",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_2020"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_2020",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_2020"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games project review",
+        "script_level.level_keys": [
+          "CSD games project review"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Interactive Animations and Games Post-Project Test_pilot_2020",
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test_pilot_2020"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot_2020"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd3-dlp-18.script_json
@@ -1,0 +1,329 @@
+{
+  "script": {
+    "name": "csd3-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 3 Deeper Learning Reflections",
+      "name": "Complete Unit 3 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "csd3dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "csd3dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      },
+      "level_keys": [
+        "csd3dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-q1",
+        "script_level.level_keys": [
+          "csd3dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-q2",
+        "script_level.level_keys": [
+          "csd3dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-q3",
+        "script_level.level_keys": [
+          "csd3dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-dlp.script_json
+++ b/dashboard/config/scripts_json/csd3-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd3-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 3 Deeper Learning Reflections",
+      "name": "Complete Unit 3 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "csd3dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "csd3dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd3dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      },
+      "level_keys": [
+        "csd3dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-lessons",
+        "script_level.level_keys": [
+          "csd3dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-tools",
+        "script_level.level_keys": [
+          "csd3dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd3dlp-assessment",
+        "script_level.level_keys": [
+          "csd3dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd3-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-old.script_json
+++ b/dashboard/config/scripts_json/csd3-old.script_json
@@ -1,0 +1,8933 @@
+{
+  "script": {
+    "name": "csd3-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Draw Loop and Randomization",
+      "name": "Draw Loop and Randomization",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Variables Unplugged",
+      "name": "Variables Unplugged",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Unplugged",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Variables and Animation",
+      "name": "Variables and Animation",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Sprites and Properties",
+      "name": "Sprites and Properties",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Sprites and Images",
+      "name": "Sprites and Images",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Booleans and Conditionals",
+      "name": "Booleans and Conditionals",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans and Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Conditionals and Keyboard Input",
+      "name": "Conditionals and Keyboard Input",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Complex Conditionals",
+      "name": "Complex Conditionals",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Project: Interactive Card",
+      "name": "Project: Interactive Card",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "key": "Project: Design a Game",
+      "name": "Project: Design a Game",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Simple Drawing"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD-U3-SFLP Simple Drawing"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Rectangle"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Rectangle Width and Height"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - X and Y values"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - X and Y values"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Order of Blocks"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Fill"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Oval"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Oval"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Simple Shape Drawing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Simple Shape Drawing"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Ellipse and No Fill"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Ellipse and No Fill"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Stroke and Stroke Weight"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Stroke and Stroke Weight"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - No Fill"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - No Fill"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Comments"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Comments"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Rects and Color"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Road Rects and Color"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Road Ellipse"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - regular polygon"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - regular polygon"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - text"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - text"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Plan Personal Drawing"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Plan Personal Drawing"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Personal Drawing"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Personal Drawing"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Draw Loop"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD-U3-SFLP Draw Loop"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Choice"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Choice"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Min Max"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Min Max"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Width Height"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Width Height"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Color"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Color"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Stop"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Stop"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Discuss"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Discuss"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Experiment"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Background Discuss"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Background Discuss"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Background Experiment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Background Experiment"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Animation"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Random Animation"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Frame Rate"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Frame Rate"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Background"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 15,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Simple Drawing - Background"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Animation"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 16,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Simple Drawing - Animation"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Animation 2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 17,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Simple Drawing - Animation 2"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Personal Animation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 18,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Simple Drawing - Personal Animation"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables2 SFLP"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Variables Unplugged",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables2 SFLP"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Variables"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD-U3-SFLP Variables"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Variables Video 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD Variables Video 1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables make a square"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables make a square"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables make a big square"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables make a big square"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables random assignment"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables STOP misconceptions prediction"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Variables STOP misconceptions prediction"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Variables misconceptions try it"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 Variables misconceptions try it"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters explaining counters"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters explaining counters"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counter square movement"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters counter square movement"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counter subtraction"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters counter subtraction"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counter colors"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters counter colors"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counters expressions"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters counters expressions"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters watchers"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters watchers"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counters sunset"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters counters sunset"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters match outputs"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Counters match outputs"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Sunset with Counters"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 17,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "Challenge: Sunset with Counters"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Sprites and Mod"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD-U3-SFLP Sprites and Mod"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites motivation"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites motivation"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites setting properties"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites setting properties"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug dot notation"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug dot notation"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites shapeColor"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites shapeColor"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites width height"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites width height"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites sprites vs rects"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites sprites vs rects"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites make your own sprite"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites make your own sprite"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites STOP sprites and variables"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites STOP sprites and variables"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites createSprite params"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites createSprite params"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 13,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites animating with sprites"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 14,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites animating with sprites"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug watchers"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 15,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug watchers"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug background"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 16,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug background"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites race create sprites"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 17,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites race create sprites"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites race movement"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 18,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites race movement"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites race random"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 19,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites race random"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites race finish"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 20,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Sprites race finish"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Sprites and Images"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Sprites and Images"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Animation Tab"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - first sprite with image"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - first sprite with image"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - changing scene"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - changing scene"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - race images"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - race images"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Sprite Rotation"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Sprites and Mod - Sprite Rotation"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - image - Rotation Random Amount"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - image - Rotation Random Amount"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - random movement"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - random movement"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Rotation Direction"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Sprites and Mod - Rotation Direction"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Mouse X and Y"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Sprites and Mod - Mouse X and Y"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Rand Around Mouse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - Sprites and Mod - Rand Around Mouse"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - setAnimation"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - setAnimation"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - scale"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 13,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - scale"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - kiteFlying"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 14,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - kiteFlying"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - pick your final work"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 15,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - pick your final work"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - image - wheel free play"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 16,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - image - wheel free play"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - fish free play"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 17,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - fish free play"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - images - gears free play"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 18,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - images - gears free play"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - images - bee free play"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 19,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "U3 - images - bee free play"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - kite free play"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 20,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - kite free play"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans - 1"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Booleans and Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans - 1"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Conditionals"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Conditionals"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition 2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 -conditionals - stop booleans"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 -conditionals - stop booleans"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - fish with arrows"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - images - fish with arrows"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - arrows and gears"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - arrows and gears"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex conditionals - SFLP"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex conditionals - SFLP"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Else"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 If Else"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Stop"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Stop"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - nested conditional"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex - nested conditional"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - compound conditionals"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 - complex - compound conditionals"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditional Predict"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Conditional Predict"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditional Project"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Conditional Project"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Card Project"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Card Project"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Velocity"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Collision Detection"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 complex sprite movement SFLP"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Collisions SFLP"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions types"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions SFLP"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Introduction"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Functions Introduction"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Defender SFLP"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Using the Game Design Process SLFP"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform intro"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform background1"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform background2"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform items1"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform items2"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform items3"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform player1"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform player2"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform player3"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform player4"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 1,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 Project Build a Game SFLP"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 2,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game intro"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 3,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game variables"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 4,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 5,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game display boards"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 6,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game choose background"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 7,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game animations"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 8,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 9,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 10,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game user controls"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 11,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 game interactions"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 12,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD-U3-SFLP Simple Drawing",
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Simple Drawing"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Rectangle",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Rectangle Width and Height",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - X and Y values",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - X and Y values"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Order of Blocks",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Oval",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Oval"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Simple Shape Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Simple Shape Drawing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Ellipse and No Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Ellipse and No Fill"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Stroke and Stroke Weight",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Stroke and Stroke Weight"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - No Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - No Fill"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Comments",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Comments"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Road Rects and Color",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Rects and Color"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Road Ellipse",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Ellipse"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - regular polygon",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - regular polygon"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - text",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - text"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Plan Personal Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Plan Personal Drawing"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Personal Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Personal Drawing"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U3-SFLP Draw Loop",
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Draw Loop"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Intro",
+        "script_level.level_keys": [
+          "CSD U3 Random Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Choice",
+        "script_level.level_keys": [
+          "CSD U3 Random Choice"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Min Max",
+        "script_level.level_keys": [
+          "CSD U3 Random Min Max"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Width Height",
+        "script_level.level_keys": [
+          "CSD U3 Random Width Height"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Color",
+        "script_level.level_keys": [
+          "CSD U3 Random Color"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Stop",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Stop"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Discuss",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Discuss"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Experiment",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Background Discuss",
+        "script_level.level_keys": [
+          "CSD U3 Background Discuss"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Background Experiment",
+        "script_level.level_keys": [
+          "CSD U3 Background Experiment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 12,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Animation",
+        "script_level.level_keys": [
+          "CSD U3 Random Animation"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 13,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Frame Rate",
+        "script_level.level_keys": [
+          "CSD U3 Frame Rate"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 14,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Simple Drawing - Background",
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Background"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 15,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Simple Drawing - Animation",
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Animation"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 16,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Simple Drawing - Animation 2",
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Animation 2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 17,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Simple Drawing - Personal Animation",
+        "script_level.level_keys": [
+          "CSD U3 Simple Drawing - Personal Animation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 18,
+        "lesson.key": "Draw Loop and Randomization",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables2 SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Variables2 SFLP"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Variables Unplugged",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U3-SFLP Variables",
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Variables"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Variables Video 1",
+        "script_level.level_keys": [
+          "CSD Variables Video 1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables make a square",
+        "script_level.level_keys": [
+          "CSD U3 Variables make a square"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables make a big square",
+        "script_level.level_keys": [
+          "CSD U3 Variables make a big square"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random assignment",
+        "script_level.level_keys": [
+          "CSD U3 Variables random assignment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables STOP misconceptions prediction",
+        "script_level.level_keys": [
+          "CSD U3 Variables STOP misconceptions prediction"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Variables misconceptions try it",
+        "script_level.level_keys": [
+          "U3 Variables misconceptions try it"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters explaining counters",
+        "script_level.level_keys": [
+          "CSD U3 Counters explaining counters"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counter square movement",
+        "script_level.level_keys": [
+          "CSD U3 Counters counter square movement"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counter subtraction",
+        "script_level.level_keys": [
+          "CSD U3 Counters counter subtraction"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counter colors",
+        "script_level.level_keys": [
+          "CSD U3 Counters counter colors"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counters expressions",
+        "script_level.level_keys": [
+          "CSD U3 Counters counters expressions"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters watchers",
+        "script_level.level_keys": [
+          "CSD U3 Counters watchers"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counters sunset",
+        "script_level.level_keys": [
+          "CSD U3 Counters counters sunset"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters match outputs",
+        "script_level.level_keys": [
+          "CSD U3 Counters match outputs"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Sunset with Counters",
+        "script_level.level_keys": [
+          "Challenge: Sunset with Counters"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 17,
+        "lesson.key": "Variables and Animation",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U3-SFLP Sprites and Mod",
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Sprites and Mod"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites motivation",
+        "script_level.level_keys": [
+          "CSD U3 Sprites motivation"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites setting properties",
+        "script_level.level_keys": [
+          "CSD U3 Sprites setting properties"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug dot notation",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug dot notation"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites shapeColor",
+        "script_level.level_keys": [
+          "CSD U3 Sprites shapeColor"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites width height",
+        "script_level.level_keys": [
+          "CSD U3 Sprites width height"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites sprites vs rects",
+        "script_level.level_keys": [
+          "CSD U3 Sprites sprites vs rects"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites make your own sprite",
+        "script_level.level_keys": [
+          "CSD U3 Sprites make your own sprite"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites STOP sprites and variables",
+        "script_level.level_keys": [
+          "CSD U3 Sprites STOP sprites and variables"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites createSprite params",
+        "script_level.level_keys": [
+          "CSD U3 Sprites createSprite params"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 13,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites animating with sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites animating with sprites"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 14,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug watchers",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug watchers"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 15,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug background",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug background"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 16,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites race create sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites race create sprites"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 17,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites race movement",
+        "script_level.level_keys": [
+          "CSD U3 Sprites race movement"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 18,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites race random",
+        "script_level.level_keys": [
+          "CSD U3 Sprites race random"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 19,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites race finish",
+        "script_level.level_keys": [
+          "CSD U3 Sprites race finish"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 20,
+        "lesson.key": "Sprites and Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Sprites and Images",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Sprites and Images"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab",
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - first sprite with image",
+        "script_level.level_keys": [
+          "CSD U3 - images - first sprite with image"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - changing scene",
+        "script_level.level_keys": [
+          "CSD U3 - images - changing scene"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - race images",
+        "script_level.level_keys": [
+          "CSD U3 - images - race images"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Sprites and Mod - Sprite Rotation",
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Sprite Rotation"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - image - Rotation Random Amount",
+        "script_level.level_keys": [
+          "U3 - image - Rotation Random Amount"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - random movement",
+        "script_level.level_keys": [
+          "CSD U3 - images - random movement"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Sprites and Mod - Rotation Direction",
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Rotation Direction"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Sprites and Mod - Mouse X and Y",
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Mouse X and Y"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Sprites and Mod - Rand Around Mouse",
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Rand Around Mouse"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - setAnimation",
+        "script_level.level_keys": [
+          "CSD U3 - images - setAnimation"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - scale",
+        "script_level.level_keys": [
+          "CSD U3 - images - scale"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 13,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - kiteFlying",
+        "script_level.level_keys": [
+          "CSD U3 - images - kiteFlying"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 14,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - pick your final work",
+        "script_level.level_keys": [
+          "CSD U3 - images - pick your final work"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 15,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - image - wheel free play",
+        "script_level.level_keys": [
+          "U3 - image - wheel free play"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 16,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - fish free play",
+        "script_level.level_keys": [
+          "CSD U3 - images - fish free play"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 17,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - images - gears free play",
+        "script_level.level_keys": [
+          "U3 - images - gears free play"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 18,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - images - bee free play",
+        "script_level.level_keys": [
+          "U3 - images - bee free play"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 19,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - kite free play",
+        "script_level.level_keys": [
+          "CSD U3 - images - kite free play"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 20,
+        "lesson.key": "Sprites and Images",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans - 1",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans - 1"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Booleans and Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Conditionals",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Conditionals"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition 2",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 -conditionals - stop booleans",
+        "script_level.level_keys": [
+          "CSD U3 -conditionals - stop booleans"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - fish with arrows",
+        "script_level.level_keys": [
+          "CSD U3 - images - fish with arrows"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - arrows and gears",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - arrows and gears"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 16,
+        "lesson.key": "Conditionals and Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex conditionals - SFLP",
+        "script_level.level_keys": [
+          "CSD U3 - complex conditionals - SFLP"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else",
+        "script_level.level_keys": [
+          "CSD U3 Else"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else",
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Stop",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Stop"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - nested conditional",
+        "script_level.level_keys": [
+          "CSD U3 - complex - nested conditional"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - compound conditionals",
+        "script_level.level_keys": [
+          "CSD U3 - complex - compound conditionals"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditional Predict",
+        "script_level.level_keys": [
+          "CSD U3 Conditional Predict"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditional Project",
+        "script_level.level_keys": [
+          "CSD U3 Conditional Project"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Complex Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Card Project",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Card Project"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Velocity",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Velocity"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collision Detection",
+        "script_level.level_keys": [
+          "CSD U3 Collision Detection"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 complex sprite movement SFLP",
+        "script_level.level_keys": [
+          "CSD U3 complex sprite movement SFLP"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Collisions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Collisions SFLP"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types",
+        "script_level.level_keys": [
+          "CSD U3 collisions types"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Functions SFLP"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Introduction",
+        "script_level.level_keys": [
+          "CSD U3 Functions Introduction"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Defender SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Defender SFLP"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Using the Game Design Process SLFP",
+        "script_level.level_keys": [
+          "CSD U3 Using the Game Design Process SLFP"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro",
+        "script_level.level_keys": [
+          "CSD U3 platform intro"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1",
+        "script_level.level_keys": [
+          "CSD U3 platform background1"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2",
+        "script_level.level_keys": [
+          "CSD U3 platform background2"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1",
+        "script_level.level_keys": [
+          "CSD U3 platform items1"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2",
+        "script_level.level_keys": [
+          "CSD U3 platform items2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3",
+        "script_level.level_keys": [
+          "CSD U3 platform items3"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1",
+        "script_level.level_keys": [
+          "CSD U3 platform player1"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2",
+        "script_level.level_keys": [
+          "CSD U3 platform player2"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3",
+        "script_level.level_keys": [
+          "CSD U3 platform player3"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4",
+        "script_level.level_keys": [
+          "CSD U3 platform player4"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Project Build a Game SFLP",
+        "script_level.level_keys": [
+          "CSD U3 Project Build a Game SFLP"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 1,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro",
+        "script_level.level_keys": [
+          "CSD U3 game intro"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 2,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables",
+        "script_level.level_keys": [
+          "CSD U3 game variables"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 3,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 4,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards",
+        "script_level.level_keys": [
+          "CSD U3 game display boards"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 5,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background",
+        "script_level.level_keys": [
+          "CSD U3 game choose background"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 6,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations",
+        "script_level.level_keys": [
+          "CSD U3 game animations"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 7,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 8,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 9,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls",
+        "script_level.level_keys": [
+          "CSD U3 game user controls"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 10,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions",
+        "script_level.level_keys": [
+          "CSD U3 game interactions"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 11,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 12,
+        "lesson.key": "Project: Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-pilot.script_json
+++ b/dashboard/config/scripts_json/csd3-pilot.script_json
@@ -1,0 +1,10085 @@
+{
+  "script": {
+    "name": "csd3-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "gamelab",
+        "weblab"
+      ],
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit3/{LESSON}",
+      "pilot_experiment": "csd-piloters",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit3/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit3/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-20/unit3/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Images and Animations"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming for Entertainment",
+      "name": "Programming for Entertainment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Shapes and Parameters",
+      "name": "Shapes and Parameters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Random Numbers",
+      "name": "Random Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Sprites and Animations",
+      "name": "Sprites and Animations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Sprite Properties",
+      "name": "Sprite Properties",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Text and Captioned Scenes",
+      "name": "Text and Captioned Scenes",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "The Counter Pattern Unplugged",
+      "name": "The Counter Pattern Unplugged",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Booleans Unplugged",
+      "name": "Booleans Unplugged",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Other Forms of Input",
+      "name": "Other Forms of Input",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Project - Interactive Card",
+      "name": "Project - Interactive Card",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 26,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 27,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L01 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 4_pilot"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 3_pilot"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1_pilot"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2_pilot"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L02 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Plotting Shapes Shape Lab_pilot"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L03 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 rect_pilot"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_pilot"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_pilot"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_pilot"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners_pilot"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_pilot"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_pilot"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill_pilot"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 fill_pilot"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence_pilot"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 sequence_pilot"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse_pilot"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 ellipse_pilot"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 drawing practice choice"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug_pilot"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 debug_pilot"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 drawing challenges"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L04 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "New Shapes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_pilot"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle_pilot"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_pilot"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background_pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random background_pilot"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2_pilot"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random background2_pilot"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_pilot"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_pilot"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games parameters practice"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games parameters practice"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "More Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_pilot"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games Parameters challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 parameters shape scene"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 parameters shape scene"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L05 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_pilot"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X_pilot"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_pilot"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_pilot"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_pilot"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY_pilot"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_pilot"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_pilot"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy_pilot"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables practice"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games variables practice"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables assessment"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables challenge"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games variables challenge"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L06 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_pilot"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_pilot"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_pilot"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment_pilot"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Variables random reassign"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random practice"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD games random practice"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_pilot"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD games random challenge"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L07 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Exploration"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_pilot"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_pilot"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_pilot"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites_pilot"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_pilot"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug_pilot"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_pilot"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1_pilot"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_pilot"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_pilot"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites sequencing"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites practice"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games Sprites practice"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 drawSprites placement match_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Adding Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites assessment"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games Sprites Challenges"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_pilot"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L08 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties predict"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games properties predict"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties xy"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games properties xy"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties new"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games properties new"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties practice"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games Properties practice"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Sprite Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties assessment"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games properties assessment"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties challenge"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Games Properties challenge"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L09 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_pilot"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Scene Example_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_pilot"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text_pilot"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018_pilot"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text debug_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_pilot"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene drawing_pilot"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_pilot"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene sprites_pilot"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Scenes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_pilot"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene text_pilot"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_pilot"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprites scene challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD pilot"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L10 TFMD pilot"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_pilot"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_pilot"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_pilot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 1_pilot"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_pilot"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green_pilot"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Shapes and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_pilot"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2_pilot"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_pilot"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_pilot"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_pilot"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x_pilot"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_pilot"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y_pilot"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprites and the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_pilot"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite rotation_pilot"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Animate Your Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_pilot"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged update your scene_pilot"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_pilot"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L7 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_pilot"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L11 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_pilot"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L12 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_pilot"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_pilot"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_pilot"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict_pilot"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_pilot"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right_pilot"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_pilot"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left_pilot"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_pilot"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict_pilot"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Movement with the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_pilot"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement_pilot"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_pilot"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Predict_pilot"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_pilot"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Watcher Debug_pilot"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_pilot"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish_pilot"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Animating Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_pilot"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Movement Gears_pilot"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_pilot"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 1_pilot"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Create Your Own Animation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_pilot"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Movement Your Own 2_pilot"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_pilot"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD sprite movement challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_pilot"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_pilot"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L9 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_pilot"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L13 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_pilot"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L14 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_pilot"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict_pilot"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_pilot"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_pilot"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_pilot"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify_pilot"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_pilot"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition_pilot"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Comparison"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018_pilot"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_pilot"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video_pilot"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_pilot"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional_pilot"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Basic Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_pilot"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018_pilot"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional 2_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_pilot"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L11 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_pilot"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L15 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_pilot"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_pilot"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_pilot"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_pilot"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Input Fish_pilot"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_pilot"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears_pilot"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_pilot"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Keyboard Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018_pilot"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Direction Animations_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018_pilot"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Keyboard Input Challenge_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_pilot"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L12 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_pilot"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L16 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 if else predict_pilot"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 if else predict_pilot"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_pilot"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_pilot"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else_pilot"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 If Else_pilot"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Input with If-Else"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else_pilot"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Else_pilot"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_pilot"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 1_pilot"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_pilot"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Mouse Input Bee 2_pilot"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_pilot"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers_pilot"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018_2019_pilot"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_pilot"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down_pilot"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_pilot"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - complex - key up and down_pilot"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "More Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_pilot"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse move_pilot"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_pilot"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Compound Nested Challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_pilot"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L13 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_pilot"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L17 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_pilot"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar_pilot"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019_pilot"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Card Examples_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_pilot"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background_pilot"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_pilot"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites_pilot"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_pilot"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input_pilot"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_pilot"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals_pilot"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_pilot"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final_pilot"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_pilot"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L18 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_pilot"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_pilot"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_pilot"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_pilot"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_pilot"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_pilot"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_pilot"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_pilot"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_pilot"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_pilot"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_pilot"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control_pilot"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_pilot"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_pilot"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_pilot"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_pilot"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_pilot"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump_2018_pilot"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_pilot"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed_pilot"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_pilot"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping_pilot"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_pilot"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_pilot"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L19 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_pilot"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_pilot"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_pilot"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_pilot"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_pilot"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_pilot"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_pilot"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_pilot"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_pilot"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2_pilot"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_pilot"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_pilot"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_pilot"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_pilot"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_pilot"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard_pilot"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_pilot"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2_pilot"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_pilot"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_pilot"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L20 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_pilot"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_pilot"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_pilot"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_pilot"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_pilot"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_pilot"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_pilot"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up_pilot"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_pilot"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_pilot"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_pilot"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_pilot"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_pilot"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping_pilot"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_pilot"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter_pilot"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_pilot"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2_pilot"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_pilot"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin_pilot"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_pilot"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin_pilot"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_pilot"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own_pilot"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_pilot"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_pilot"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L21 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_pilot"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code_pilot"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_pilot"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x_pilot"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_pilot"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y_pilot"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_pilot"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_pilot"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_pilot"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_pilot"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types_pilot"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions types_pilot"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_pilot"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle_pilot"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_pilot"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug_pilot"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_pilot"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider_pilot"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_pilot"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness_pilot"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_pilot"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles_pilot"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_pilot"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff_pilot"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_pilot"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin_pilot"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_pilot"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders_pilot"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_pilot"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own_pilot"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_pilot"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_pilot"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L22 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 function video_pilot"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 function video_pilot"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_pilot"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_pilot"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_pilot"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_pilot"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_pilot"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_pilot"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_pilot"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop_pilot"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_pilot"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite_pilot"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_pilot"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite_pilot"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_pilot"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function_pilot"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_pilot"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_pilot"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_pilot"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_pilot"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_pilot"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_pilot"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review_pilot"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 functions review_pilot"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_pilot"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 14,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay_pilot"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD_pilot"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L23 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_pilot"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender_pilot"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_pilot"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe_pilot"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_pilot"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down_pilot"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_pilot"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation_pilot"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_pilot"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies_pilot"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_pilot"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move_pilot"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_pilot"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake_pilot"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_pilot"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2_pilot"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_pilot"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies_pilot"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_pilot"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player_pilot"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_pilot"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down_pilot"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_pilot"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player_pilot"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_pilot"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies_pilot"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_pilot"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water_pilot"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_pilot"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own_pilot"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L24 TFMD_pilot"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L24 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_pilot"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1_pilot"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform intro_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1_pilot"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform background1_pilot"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_pilot"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1_pilot"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2_pilot"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform background2_pilot"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_pilot"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard_pilot"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_pilot"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1_pilot"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_pilot"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2_pilot"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_pilot"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3_pilot"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1_pilot"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform items1_pilot"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2_pilot"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform items2_pilot"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3_pilot"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform items3_pilot"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1_pilot"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform player1_pilot"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2_pilot"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform player2_pilot"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3_pilot"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform player3_pilot"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4_pilot"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform player4_pilot"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_pilot"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2_pilot"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_pilot"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3_pilot"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_pilot"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge_pilot"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L25 TFMD_pilot"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3L25 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_pilot"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game variables_pilot"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_pilot"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_pilot"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_pilot"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_pilot"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_pilot"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_pilot"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_pilot"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game animations_pilot"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_pilot"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_pilot"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_pilot"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_pilot"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_pilot"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_pilot"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_pilot"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_pilot"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_pilot"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches_pilot"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test_pilot"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "CSD Interactive Animations and Games Post-Project Test_pilot"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_pilot"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      },
+      "level_keys": [
+        "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L01 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L01 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment_2018_2019_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 4_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 4_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 3_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 3_pilot"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_pilot"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Programming for Entertainment",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L02 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L02 TFMD_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Plotting Shapes Shape Lab_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Plotting Shapes Shape Lab_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L03 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L03 TFMD_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect_pilot",
+        "script_level.level_keys": [
+          "CSD U3 rect_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_pilot",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_pilot"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_pilot"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_pilot",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_pilot"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill_pilot",
+        "script_level.level_keys": [
+          "CSD U3 fill_pilot"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence_pilot",
+        "script_level.level_keys": [
+          "CSD U3 sequence_pilot"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse_pilot",
+        "script_level.level_keys": [
+          "CSD U3 ellipse_pilot"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing practice choice",
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug_pilot",
+        "script_level.level_keys": [
+          "CSD U3 debug_pilot"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing challenges",
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L04 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_pilot"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_pilot"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random background_pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random background2_pilot"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_pilot"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games parameters practice",
+        "script_level.level_keys": [
+          "CSD Games parameters practice"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_pilot"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Parameters challenge",
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 parameters shape scene",
+        "script_level.level_keys": [
+          "CSD U3 parameters shape scene"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L05 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_pilot"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_pilot",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_pilot"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_pilot"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_pilot"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_pilot"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables practice",
+        "script_level.level_keys": [
+          "CSD Games variables practice"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables assessment",
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables challenge",
+        "script_level.level_keys": [
+          "CSD Games variables challenge"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L06 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_pilot"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_pilot"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_pilot"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random reassign",
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random practice",
+        "script_level.level_keys": [
+          "CSD games random practice"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_pilot"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random challenge",
+        "script_level.level_keys": [
+          "CSD games random challenge"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L07 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Exploration",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_pilot",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_pilot"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_pilot"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_pilot"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_pilot"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_pilot",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_pilot"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites sequencing",
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites practice",
+        "script_level.level_keys": [
+          "CSD Games Sprites practice"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawSprites placement match_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites assessment",
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites Challenges",
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Sprites and Animations",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L08 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L08 TFMD_pilot"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties predict",
+        "script_level.level_keys": [
+          "CSD Games properties predict"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties xy",
+        "script_level.level_keys": [
+          "CSD Games properties xy"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties new",
+        "script_level.level_keys": [
+          "CSD Games properties new"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties practice",
+        "script_level.level_keys": [
+          "CSD Games Properties practice"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties assessment",
+        "script_level.level_keys": [
+          "CSD Games properties assessment"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties challenge",
+        "script_level.level_keys": [
+          "CSD Games Properties challenge"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L09 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Scene Example_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Scene Example_2018_pilot"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_pilot"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text debug_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text debug_2018_pilot"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene drawing_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene drawing_pilot"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene sprites_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene sprites_pilot"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene text_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene text_pilot"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites scene challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprites scene challenge_pilot"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Text and Captioned Scenes",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L10 TFMD pilot",
+        "script_level.level_keys": [
+          "CSD U3L10 TFMD pilot"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_pilot",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_pilot"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 1_pilot"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_pilot"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_pilot"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_pilot",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_pilot"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_pilot"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_pilot"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite rotation_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite rotation_pilot"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged update your scene_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged update your scene_pilot"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L7 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L7 Freeplay_pilot"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L11 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L11 TFMD_pilot"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Counter Pattern Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L12 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_pilot"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_pilot",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_pilot"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_pilot"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_pilot"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_pilot"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_pilot"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_pilot"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Predict_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Predict_pilot"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Watcher Debug_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Watcher Debug_pilot"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_pilot"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Gears_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Movement Gears_pilot"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 1_pilot"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Your Own 2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Movement Your Own 2_pilot"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD sprite movement challenge_pilot",
+        "script_level.level_keys": [
+          "CSD sprite movement challenge_pilot"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish challenge_pilot"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 15,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L9 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L9 Freeplay_pilot"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 16,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L13 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L13 TFMD_pilot"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Booleans Unplugged",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L14 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L14 TFMD_pilot"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_pilot"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_pilot"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify_pilot"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_pilot"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple_2018_pilot"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video_pilot",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_pilot"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_pilot"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_pilot"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional 2_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional 2_2018_pilot"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L11 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L11 Freeplay_pilot"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L15 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L15 TFMD_pilot"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_pilot"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_pilot"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_pilot"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Fish_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Input Fish_pilot"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_pilot"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_pilot"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Animations_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Direction Animations_2018_pilot"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keyboard Input Challenge_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Keyboard Input Challenge_2018_pilot"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L12 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L12 Freeplay_pilot"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L16 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L16 TFMD_pilot"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 if else predict_pilot",
+        "script_level.level_keys": [
+          "CSD U3 if else predict_pilot"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_pilot"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else_pilot",
+        "script_level.level_keys": [
+          "CSD U3 If Else_pilot"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Else_pilot"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 1_pilot"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Mouse Input Bee 2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Mouse Input Bee 2_pilot"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers_pilot"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching_2018_2019_pilot"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_pilot"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - key up and down_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - complex - key up and down_pilot"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse move_pilot",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse move_pilot"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Compound Nested Challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Compound Nested Challenge_pilot"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L13 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L13 Freeplay_pilot"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 14,
+        "lesson.key": "Other Forms of Input",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L17 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L17 TFMD_pilot"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar_pilot"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Card Examples_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Card Examples_2018_2019_pilot"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background_pilot"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites_pilot"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input_pilot"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals_pilot"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final_pilot"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch1_2018_2019_pilot"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Project - Interactive Card",
+        "lesson_group.key": "csd3_1",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L18 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L18 TFMD_pilot"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_pilot",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_pilot"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_pilot"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_pilot"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_pilot"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_pilot"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_pilot"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_pilot"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_pilot"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump_2018_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_pilot"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_pilot"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_pilot"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_pilot"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L19 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L19 TFMD_pilot"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_pilot"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_pilot"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_pilot"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_pilot"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_pilot"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_pilot"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_pilot"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_pilot"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_pilot"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_pilot"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L20 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L20 TFMD_pilot"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_pilot"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_pilot"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_pilot"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_pilot"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_pilot"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_pilot"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_pilot"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_pilot"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_pilot"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_pilot"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_pilot"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own_pilot",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_pilot"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_pilot"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 14,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L21 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L21 TFMD_pilot"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_pilot"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_pilot"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_pilot"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_pilot"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_pilot"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions types_pilot"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_pilot"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_pilot"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_pilot"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_pilot"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_pilot"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_pilot"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_pilot"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_pilot"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own_pilot",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_pilot"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_pilot"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 17,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L22 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L22 TFMD_pilot"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 function video_pilot",
+        "script_level.level_keys": [
+          "CSD U3 function video_pilot"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_pilot"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_pilot"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_pilot"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_pilot"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_pilot"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_pilot"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_pilot"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_pilot"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_pilot"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_pilot",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_pilot"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review_pilot",
+        "script_level.level_keys": [
+          "CSD U3 functions review_pilot"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay_pilot",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_pilot"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 14,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L23 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L23 TFMD_pilot"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_pilot"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_pilot"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_pilot"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_pilot"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_pilot"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_pilot"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_pilot"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_pilot"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_pilot"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_pilot"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_pilot"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_pilot"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_pilot"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_pilot"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own_pilot",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_pilot"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 17,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L24 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L24 TFMD_pilot"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_pilot"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform background1_pilot"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_pilot"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform background2_pilot"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_pilot"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_pilot"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_pilot"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_pilot"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform items1_pilot"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform items2_pilot"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform items3_pilot"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform player1_pilot"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform player2_pilot"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform player3_pilot"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform player4_pilot"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_pilot"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_pilot"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge_pilot",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_pilot"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 20,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L25 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U3L25 TFMD_pilot"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018_2019_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game variables_pilot"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_pilot"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_pilot"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_pilot"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game animations_pilot"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_pilot"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_pilot"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_pilot"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_pilot",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_pilot"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches_pilot",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_pilot"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U3Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 13,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Interactive Animations and Games Post-Project Test_pilot",
+        "script_level.level_keys": [
+          "CSD Interactive Animations and Games Post-Project Test_pilot"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd3_2",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_pilot",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_pilot"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2017-levelgroup_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-post-survey-2017-levelgroup_2018_2019_pilot"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd3-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd3-virtual.script_json
+++ b/dashboard/config/scripts_json/csd3-virtual.script_json
@@ -1,0 +1,5769 @@
+{
+  "script": {
+    "name": "csd3-virtual",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit3/{LESSON}",
+      "has_verified_resources": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd3"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd3-virtual"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Shapes and Parameters",
+      "name": "Shapes and Parameters",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Random Numbers",
+      "name": "Random Numbers",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Sprite Properties",
+      "name": "Sprite Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Text",
+      "name": "Text",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "The Draw Loop",
+      "name": "The Draw Loop",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Sprite Movement",
+      "name": "Sprite Movement",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Keyboard Input",
+      "name": "Keyboard Input",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Mouse Input",
+      "name": "Mouse Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 samples_virtual_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 samples_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Game Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 rect_virtual_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 rect_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Drawing in Game Lab - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_virtual_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Grid"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_virtual_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Drawing Squares to Corners_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Drawing in Game Lab - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_virtual_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 fill_virtual_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 fill_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 sequence_virtual_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 sequence_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 ellipse_virtual_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 ellipse_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 drawing practice choice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 debug_virtual_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 debug_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges_2020_virtual_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 drawing challenges_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_virtual_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random Taller Rectangle_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_virtual_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random Ellipse Behind_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background_virtual_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random background_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random background2_virtual_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random background2_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_virtual_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Grass_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games parameters practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games parameters practice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_virtual_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random Debug Cloud_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games Parameters challenge_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_virtual_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where X_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_virtual_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_virtual_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables Predict Where XY_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 naming md_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 naming md_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables naming rules v2_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_virtual_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables Draw Poppy_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games variables practice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment_virtual_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games variables challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games variables challenge_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_virtual_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random random ellipse2_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_virtual_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables random with assignment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign_virtual_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Variables random reassign_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games random practice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_virtual_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Random rainbow snake_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games random challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games random challenge_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration_virtual_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites Exploration_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to Sprites"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_virtual_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_virtual_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_virtual_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro debug_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_virtual_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites anitab 1_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: The Animation Tab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab_virtual_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Animation Tab_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing_virtual_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites sequencing_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 drawSprites placement match_2019_pilot_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games Sprites practice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment_virtual_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges_2020_virtual_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games Sprites Challenges_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties predict_virtual_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games properties predict_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties xy_virtual_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games properties xy_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties new_virtual_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games properties new_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games Properties practice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games properties assessment_virtual_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games properties assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Games Properties challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD Games Properties challenge_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text explore_virtual_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web text explore_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_virtual_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprites text_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text size_virtual_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web text size_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text practice choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web text practice choice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text assessment_virtual_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web text assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web text challenge choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web text challenge choice_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Introduction to the Draw Loop"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_virtual_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_virtual_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged orange and green_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_virtual_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged predict 2_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_virtual_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_virtual_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite x_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web draw loop practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web draw loop practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_virtual_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Draw Loop Plugged wiggle sprite y_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web draw loop challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web draw loop challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_virtual_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - Simple Counter Predict_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Sprite Movement"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_virtual_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Animating Sprite Movement_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_virtual_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Right_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_virtual_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Left_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_virtual_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Diagonal Movement_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_virtual_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Sprite Movement Predict_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web movement practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web movement practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_virtual_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Movement Fish_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web movement challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web movement challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_virtual_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Predict_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Booleans"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_virtual_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Quick Check"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching_2018_2019_pilot_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_virtual_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - transition_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_virtual_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - first conditional_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Conditional Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_virtual_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "csd U3 conditional statements video_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Conditionals Apple 2_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web conditionals practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals assessment_virtual_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web conditionals assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web conditionals challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web conditionals challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_virtual_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_virtual_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 keydown conditional_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_virtual_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_virtual_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Input Gears_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web keyboard practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web keyboard practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_virtual_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows_2018_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web keyboard challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web keyboard challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 if else predict_virtual_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 if else predict_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: If/Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_virtual_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - Conditionals Video_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Else_virtual_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Else_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games mousedown intro_virtual_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games mousedown intro_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_virtual_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 - complex - mouse down_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else_virtual_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 If Else_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web mouse practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse assessment_virtual_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web mouse assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD web mouse challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD web mouse challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_virtual_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_virtual_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_virtual_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_virtual_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_virtual_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_virtual_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity tennis_virtual_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games velocity tennis_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games velocity practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_virtual_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games velocity challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games velocity challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_virtual_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_virtual_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_virtual_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_virtual_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_virtual_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games istouching practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games istouching practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_virtual_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games istouching challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games istouching challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_virtual_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_virtual_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_virtual_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_virtual_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games movement2 practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games movement2 practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_virtual_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games movement2 challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games movement2 challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_virtual_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_virtual_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games collisions practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions assessment_virtual_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games collisions assessment_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games collisions challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games collisions challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 function video_virtual_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 function video_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_virtual_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_virtual_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Predict"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_virtual_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games functions practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games functions practice choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_virtual_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_virtual_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_virtual_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenges"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games functions challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games functions challenge choice_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018_2019_pilot_2020_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_virtual_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game variables_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_virtual_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_virtual_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_virtual_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_virtual_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game animations_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_virtual_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_virtual_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_virtual_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_virtual_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Review Your Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games project review_virtual_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games project review_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Congratulations!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD games project share_virtual_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      },
+      "level_keys": [
+        "CSD games project share_virtual_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 samples_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 samples_virtual_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 rect_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 rect_virtual_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1_virtual_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Drawing Squares to Corners_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Drawing Squares to Corners_virtual_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2_virtual_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 fill_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 fill_virtual_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 sequence_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 sequence_virtual_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 ellipse_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 ellipse_virtual_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing practice choice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawing practice choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 debug_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 debug_virtual_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing challenges_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawing challenges_2020_virtual_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Taller Rectangle_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Taller Rectangle_virtual_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Ellipse Behind_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Ellipse Behind_2018_virtual_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random background_virtual_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random background2_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random background2_virtual_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Grass_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Grass_virtual_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games parameters practice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games parameters practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Debug Cloud_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random Debug Cloud_2018_virtual_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Parameters challenge_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games Parameters challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Shapes and Parameters",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where X_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where X_virtual_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_virtual_2020",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_virtual_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Predict Where XY_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Predict Where XY_virtual_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 naming md_virtual",
+        "script_level.level_keys": [
+          "CSD U3 naming md_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables naming rules v2_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables naming rules v2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables Draw Poppy_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables Draw Poppy_virtual_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables practice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games variables practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables assessment_virtual_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games variables challenge_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games variables challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse_2018_virtual_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random random ellipse2_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random random ellipse2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random with assignment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables random with assignment_virtual_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables random reassign_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Variables random reassign_virtual_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random practice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games random practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random rainbow snake_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Random rainbow snake_2018_virtual_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games random challenge_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games random challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites Exploration_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites Exploration_virtual_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab_virtual_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites_virtual_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro debug_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro debug_virtual_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites anitab 1_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites anitab 1_virtual_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Animation Tab_virtual_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites sequencing_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites sequencing_virtual_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawSprites placement match_2019_pilot_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 drawSprites placement match_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites practice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games Sprites practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites assessment_virtual_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Sprites Challenges_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games Sprites Challenges_2020_virtual_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties predict_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games properties predict_virtual_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties xy_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games properties xy_virtual_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties new_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games properties new_virtual_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties practice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games Properties practice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games properties assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games properties assessment_virtual_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Games Properties challenge_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD Games Properties challenge_2020_virtual_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Properties",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text explore_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web text explore_virtual_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites text_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprites text_virtual_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text size_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web text size_virtual_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text practice choice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web text practice choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web text assessment_virtual_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web text challenge choice_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web text challenge choice_2020_virtual_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Text",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop_virtual_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged orange and green_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged orange and green_virtual_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged predict 2_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged predict 2_virtual_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_virtual_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite x_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite x_virtual_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web draw loop practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web draw loop practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Draw Loop Plugged wiggle sprite y_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Draw Loop Plugged wiggle sprite y_virtual_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web draw loop challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web draw loop challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "The Draw Loop",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Simple Counter Predict_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Simple Counter Predict_virtual_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animating Sprite Movement_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Animating Sprite Movement_virtual_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Right_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Right_virtual_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Left_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Left_virtual_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Diagonal Movement_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Diagonal Movement_virtual_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprite Movement Predict_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Sprite Movement Predict_virtual_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web movement practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web movement practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Movement Fish_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Movement Fish_virtual_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web movement challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web movement challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Predict_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Predict_virtual_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video_virtual_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching_2018_2019_pilot_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching_2018_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - transition_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - transition_virtual_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - first conditional_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - first conditional_virtual_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd U3 conditional statements video_virtual_2020",
+        "script_level.level_keys": [
+          "csd U3 conditional statements video_virtual_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Conditionals Apple 2_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Conditionals Apple 2_2018_virtual_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web conditionals practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web conditionals assessment_virtual_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web conditionals challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web conditionals challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean_2018_virtual_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 keydown conditional_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 keydown conditional_2018_virtual_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW_2018_virtual_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Input Gears_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Input Gears_virtual_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web keyboard practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web keyboard practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows_2018_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows_2018_virtual_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web keyboard challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web keyboard challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Keyboard Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 if else predict_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 if else predict_virtual_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Conditionals Video_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - Conditionals Video_virtual_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Else_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Else_virtual_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games mousedown intro_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games mousedown intro_virtual_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - complex - mouse down_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 - complex - mouse down_virtual_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 If Else_virtual_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web mouse practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web mouse assessment_virtual_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD web mouse challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD web mouse challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Mouse Input",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_virtual_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_virtual_2020",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_virtual_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_virtual_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_virtual_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_virtual_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_virtual_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity tennis_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games velocity tennis_virtual_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games velocity practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_virtual_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games velocity challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games velocity challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_virtual_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_virtual_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_virtual_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_virtual_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_virtual_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games istouching practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games istouching practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_virtual_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games istouching challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games istouching challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_virtual_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_virtual_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_virtual_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_virtual_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games movement2 practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games movement2 practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_virtual_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games movement2 challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games movement2 challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_virtual_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_virtual_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games collisions practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions assessment_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games collisions assessment_virtual_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games collisions challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games collisions challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 function video_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 function video_virtual_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_virtual_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_virtual_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_virtual_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games functions practice choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games functions practice choice_virtual_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_virtual_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_virtual_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_virtual_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games functions challenge choice_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games functions challenge choice_virtual_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018_2019_pilot_2020_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020_virtual_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game variables_virtual_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_virtual_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_virtual_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_virtual_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game animations_virtual_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_virtual_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_virtual_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_virtual_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_virtual_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games project review_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games project review_virtual_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD games project share_virtual_2020",
+        "script_level.level_keys": [
+          "CSD games project share_virtual_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 12,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "",
+        "script.name": "csd3-virtual"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-2017.script_json
+++ b/dashboard/config/scripts_json/csd4-2017.script_json
@@ -1,0 +1,2103 @@
+{
+  "script": {
+    "name": "csd4-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd4"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit4/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd/unit4/code/"
+        ]
+      ]
+    },
+    "new_name": "csd4-2017",
+    "family_name": "csd4",
+    "seeding_key": {
+      "script.name": "csd4-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd4-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "User Interfaces",
+      "name": "User Interfaces",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Feedback and Testing",
+      "name": "Feedback and Testing",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "Project - App Presentation",
+      "name": "Project - App Presentation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "key": "CSD Post-Course Survey",
+      "name": "CSD Post-Course Survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd4-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "Example App Types"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 Design Mode Map"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 Design Elements Map"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 6"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Design 7"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "Design a Screen for your App"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 Mult Screen Map"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 Importing Screens Map"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 User Input Map"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 User Input Map"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4 Change Screen Map"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "U4 Model Program 5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Project Import"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Project Events"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L15 SFLP"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L16 SFLP"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "CSD U4L17 SFLP"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd4-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types",
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Mode Map",
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1",
+        "script_level.level_keys": [
+          "U4 Model Design 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2",
+        "script_level.level_keys": [
+          "U4 Model Design 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3",
+        "script_level.level_keys": [
+          "U4 Model Design 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4",
+        "script_level.level_keys": [
+          "U4 Model Design 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Elements Map",
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5",
+        "script_level.level_keys": [
+          "U4 Model Design 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6",
+        "script_level.level_keys": [
+          "U4 Model Design 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7",
+        "script_level.level_keys": [
+          "U4 Model Design 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App",
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Mult Screen Map",
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1",
+        "script_level.level_keys": [
+          "U4 Model Program 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Importing Screens Map",
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2",
+        "script_level.level_keys": [
+          "U4 Model Program 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 User Input Map",
+        "script_level.level_keys": [
+          "CSD U4 User Input Map"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3",
+        "script_level.level_keys": [
+          "U4 Model Program 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Change Screen Map",
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4",
+        "script_level.level_keys": [
+          "U4 Model Program 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5",
+        "script_level.level_keys": [
+          "U4 Model Program 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import",
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events",
+        "script_level.level_keys": [
+          "CSDU4 Project Events"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L17 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd4-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-2018.script_json
+++ b/dashboard/config/scripts_json/csd4-2018.script_json
@@ -1,0 +1,2113 @@
+{
+  "script": {
+    "name": "csd4-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Discoveries Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes. Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csd-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd4"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit4/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-18/unit4/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd4",
+    "seeding_key": {
+      "script.name": "csd4-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "User Interfaces",
+      "name": "User Interfaces",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Feedback and Testing",
+      "name": "Feedback and Testing",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "Project - App Presentation",
+      "name": "Project - App Presentation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries Post-Course Survey",
+      "name": "CS Discoveries Post-Course Survey",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L01 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L02 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L03 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L04 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L05 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L06 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L07 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L08 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L09 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L10 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "Example App Types_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L11 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L12 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 Design Mode Map_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 1_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 2_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 3_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 4_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 Design Elements Map_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 5_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 6_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Design 7_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "Design a Screen for your App_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L13 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 Mult Screen Map_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 1_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 Importing Screens Map_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 2_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 User Input Map_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 3_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4 Change Screen Map_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 4_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "U4 Model Program 5_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Project Import_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Project Events_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L14 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L15 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "CSD U4L16 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types_2018",
+        "script_level.level_keys": [
+          "Example App Types_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo_2018",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo_2018",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo_2018",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo_2018",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Mode Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video_2018",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 1_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 2_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 3_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 4_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Elements Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 5_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 6_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 7_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App_2018",
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project_2018",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Mult Screen Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Importing Screens Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 2_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 User Input Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 3_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Change Screen Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 4_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 5_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import_2018",
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events_2018",
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L14 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature_2018",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-2019.script_json
+++ b/dashboard/config/scripts_json/csd4-2019.script_json
@@ -1,0 +1,2198 @@
+{
+  "script": {
+    "name": "csd4-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit4/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit4/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-19/unit4/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd4",
+    "seeding_key": {
+      "script.name": "csd4-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "User Interfaces",
+      "name": "User Interfaces",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Feedback and Testing",
+      "name": "Feedback and Testing",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Project - App Presentation",
+      "name": "Project - App Presentation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L01 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L02 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L03 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L04 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L05 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L06 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L07 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L08 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L09 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L10 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "Example App Types_2018_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L11 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L12 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 1_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 2_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 3_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 4_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 Design Mode Map_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 5_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 6_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Design 7_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 Design Elements Map_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "Design a Screen for your App_2018_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L13 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 1_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 2_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 Mult Screen Map_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 Importing Screens Map_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 3_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 4_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "U4 Model Program 5_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 User Input Map_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4 Change Screen Map_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Project Import_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Combining Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Project Events_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L14 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L15 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD U4L16 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD User Centered Design Post-Project Test"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "CSD User Centered Design Post-Project Test"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types_2018_2019",
+        "script_level.level_keys": [
+          "Example App Types_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo_2019",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo_2019",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo_2019",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo_2019",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video_2019",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 1_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 3_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 4_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Mode Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 5_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 6_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7_2019",
+        "script_level.level_keys": [
+          "U4 Model Design 7_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Elements Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App_2018_2019",
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project_2019",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Mult Screen Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Importing Screens Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 3_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 4_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5_2019",
+        "script_level.level_keys": [
+          "U4 Model Program 5_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 User Input Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Change Screen Map_2019",
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import_2019",
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events_2019",
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L14 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature_2019",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD User Centered Design Post-Project Test",
+        "script_level.level_keys": [
+          "CSD User Centered Design Post-Project Test"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-2020.script_json
+++ b/dashboard/config/scripts_json/csd4-2020.script_json
@@ -1,0 +1,1987 @@
+{
+  "script": {
+    "name": "csd4-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit4/{LESSON}",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit4/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-20/unit4/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "User Interfaces",
+      "name": "User Interfaces",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Feedback and Testing",
+      "name": "Feedback and Testing",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Project - App Presentation",
+      "name": "Project - App Presentation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L01 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L02 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L03 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L04 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L05 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L06 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L07 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L08 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L09 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L10 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types_2018_2019_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "Example App Types_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L11 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L12 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 1_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 2_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 3_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 4_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 5_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 6_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Design 7_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018_2019_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "Design a Screen for your App_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L13 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 1_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 2_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 3_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 4_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Events and Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "U4 Model Program 5_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Project Import_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Combining Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Project Events_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L14 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L15 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD U4L16 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD User Centered Design Post-Project Test_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "CSD User Centered Design Post-Project Test_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L01 autoSFLP_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L02 autoSFLP_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L03 autoSFLP_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L04 autoSFLP_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L05 autoSFLP_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L06 autoSFLP_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L07 autoSFLP_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L08 autoSFLP_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L09 autoSFLP_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L10 autoSFLP_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types_2018_2019_2020",
+        "script_level.level_keys": [
+          "Example App Types_2018_2019_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo_2020",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo_2020",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo_2020",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo_2020",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L11 autoSFLP_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video_2020",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 1_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 2_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 3_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 4_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 5_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 6_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7_2020",
+        "script_level.level_keys": [
+          "U4 Model Design 7_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App_2018_2019_2020",
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018_2019_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project_2020",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 2_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 3_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 4_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5_2020",
+        "script_level.level_keys": [
+          "U4 Model Program 5_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import_2020",
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events_2020",
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L14 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L14 autoSFLP_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L15 autoSFLP_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature_2020",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U4L16 autoSFLP_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Project - App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD User Centered Design Post-Project Test_2020",
+        "script_level.level_keys": [
+          "CSD User Centered Design Post-Project Test_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd4-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd4-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csd4-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 4 Deeper Learning Reflections",
+      "name": "Complete Unit 4 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "csd4dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "csd4dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      },
+      "level_keys": [
+        "csd4dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-q1",
+        "script_level.level_keys": [
+          "csd4dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-q2",
+        "script_level.level_keys": [
+          "csd4dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-q3",
+        "script_level.level_keys": [
+          "csd4dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-dlp.script_json
+++ b/dashboard/config/scripts_json/csd4-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd4-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 4 Deeper Learning Reflections",
+      "name": "Complete Unit 4 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "csd4dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "csd4dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd4dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      },
+      "level_keys": [
+        "csd4dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-lessons",
+        "script_level.level_keys": [
+          "csd4dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-tools",
+        "script_level.level_keys": [
+          "csd4dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd4dlp-assessment",
+        "script_level.level_keys": [
+          "csd4dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd4-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-draft.script_json
+++ b/dashboard/config/scripts_json/csd4-draft.script_json
@@ -1,0 +1,2013 @@
+{
+  "script": {
+    "name": "csd4-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "User Interface and Prototype Testing",
+      "name": "User Interface and Prototype Testing",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Feedback and Prototypes",
+      "name": "Feedback and Prototypes",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "key": "App Presentation",
+      "name": "App Presentation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "Example App Types"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 Design Mode Map"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 Design Elements Map"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 6"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Design 7"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "Design a Screen for your App"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 Mult Screen Map"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 Importing Screens Map"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 User Input Map"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 User Input Map"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4 Change Screen Map"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "U4 Model Program 5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Project Import"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Project Events"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L15 SFLP"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L16 SFLP"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "CSD U4L17 SFLP"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types",
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Mode Map",
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1",
+        "script_level.level_keys": [
+          "U4 Model Design 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2",
+        "script_level.level_keys": [
+          "U4 Model Design 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3",
+        "script_level.level_keys": [
+          "U4 Model Design 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4",
+        "script_level.level_keys": [
+          "U4 Model Design 4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Elements Map",
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5",
+        "script_level.level_keys": [
+          "U4 Model Design 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6",
+        "script_level.level_keys": [
+          "U4 Model Design 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7",
+        "script_level.level_keys": [
+          "U4 Model Design 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App",
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Mult Screen Map",
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1",
+        "script_level.level_keys": [
+          "U4 Model Program 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Importing Screens Map",
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2",
+        "script_level.level_keys": [
+          "U4 Model Program 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 User Input Map",
+        "script_level.level_keys": [
+          "CSD U4 User Input Map"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3",
+        "script_level.level_keys": [
+          "U4 Model Program 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Change Screen Map",
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4",
+        "script_level.level_keys": [
+          "U4 Model Program 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5",
+        "script_level.level_keys": [
+          "U4 Model Program 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import",
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events",
+        "script_level.level_keys": [
+          "CSDU4 Project Events"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L17 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-old.script_json
+++ b/dashboard/config/scripts_json/csd4-old.script_json
@@ -1,0 +1,2561 @@
+{
+  "script": {
+    "name": "csd4-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: User Centered Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "csd4_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: App Prototyping"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Analysis of Design",
+      "name": "Analysis of Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Understanding Your User",
+      "name": "Understanding Your User",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "User-Centered Design Micro Activity",
+      "name": "User-Centered Design Micro Activity",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "User Interface and Prototype Testing",
+      "name": "User Interface and Prototype Testing",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Feedback and Prototypes",
+      "name": "Feedback and Prototypes",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Identifying User Needs",
+      "name": "Identifying User Needs",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Project - Paper Prototype",
+      "name": "Project - Paper Prototype",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Designing Apps for Good",
+      "name": "Designing Apps for Good",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Market Research",
+      "name": "Market Research",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Paper Prototypes",
+      "name": "Paper Prototypes",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Prototype Testing",
+      "name": "Prototype Testing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Event Driven Programming",
+      "name": "Event Driven Programming",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Basic App Functionality",
+      "name": "Basic App Functionality",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Testing the App",
+      "name": "Testing the App",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "Improving and Iterating",
+      "name": "Improving and Iterating",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "key": "App Presentation",
+      "name": "App Presentation",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Example App Types"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Quiz App Demo"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Decision App Demo"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 List App Demo"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Demo Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Crowdsource App Demo"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Building a UI with Design Mode"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Building a UI with Design Mode"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 15"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 15"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choosing Good IDs"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Choosing Good IDs"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Designing Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Text"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Text"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Designing Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Input Widgets"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Input Widgets"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Designing Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Designing Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode Icons"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode Icons"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Designing Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 18"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 18"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Design a Screen for your App"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Responding to User Input"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Responding to User Input"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 16"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 16"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "User Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 17"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 17"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Multi-Screen Apps"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Multi-Screen Apps"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Connecting Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 19"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 19"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Connecting Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 20"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 20"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Connecting Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Connecting Screens"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Connecting Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens Getting Back"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Connecting Screens Getting Back"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Importing Screens"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Importing Screens"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Project Import"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L14 SFLP"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L14 SFLP"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Changing Design Elements with Code"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Changing Design Elements with Code"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText button"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText button"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText input"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText input"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText quiz 1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText quiz 2"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality visible"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality visible"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Text"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Functionality setText quiz 3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Getting Better User Input"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Getting Better User Input"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Forms of Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 24"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 24"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Forms of Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 25"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 25"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Forms of Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 26"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 26"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Forms of Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 27"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 27"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Forms of Input"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 28"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 - Design Mode - 28"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Adding Functionality to your App"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 16,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "Adding Functionality to your App"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Functionality"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 17,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Project Functionality"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L15 SFLP"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L16 SFLP"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSDU4 Project Bug Feature"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "CSD U4L17 SFLP"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U4Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L01 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Analysis of Design",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L02 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L02 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Your User",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L03 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L03 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "User-Centered Design Micro Activity",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L04 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L04 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "User Interface and Prototype Testing",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L05 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L05 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Feedback and Prototypes",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L06 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L06 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Identifying User Needs",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L07 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L07 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Project - Paper Prototype",
+        "lesson_group.key": "csd4_1",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L08 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L08 SFLP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Designing Apps for Good",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L09 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Market Research",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L10 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L10 SFLP"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Example App Types",
+        "script_level.level_keys": [
+          "Example App Types"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Quiz App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Quiz App Demo"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Decision App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Decision App Demo"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 List App Demo",
+        "script_level.level_keys": [
+          "CSDU4 List App Demo"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Crowdsource App Demo",
+        "script_level.level_keys": [
+          "CSDU4 Crowdsource App Demo"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Paper Prototypes",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L11 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L11 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Prototype Testing",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L12 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Building a UI with Design Mode",
+        "script_level.level_keys": [
+          "Building a UI with Design Mode"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 15",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 15"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 4",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choosing Good IDs",
+        "script_level.level_keys": [
+          "Choosing Good IDs"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Text",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Text"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Input Widgets",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Input Widgets"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 21",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode Icons",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode Icons"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 18",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 18"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App",
+        "script_level.level_keys": [
+          "Design a Screen for your App"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L13 SFLP"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Responding to User Input",
+        "script_level.level_keys": [
+          "Responding to User Input"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 16",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 16"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 3",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 17",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 17"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Multi-Screen Apps",
+        "script_level.level_keys": [
+          "Multi-Screen Apps"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 19",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 19"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 20",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 20"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Connecting Screens",
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Connecting Screens Getting Back",
+        "script_level.level_keys": [
+          "CSDU4 Connecting Screens Getting Back"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Importing Screens",
+        "script_level.level_keys": [
+          "Importing Screens"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import",
+        "script_level.level_keys": [
+          "CSDU4 Project Import"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L14 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L14 SFLP"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Changing Design Elements with Code",
+        "script_level.level_keys": [
+          "Changing Design Elements with Code"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText button",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText button"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText input",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText input"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText quiz 1",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText quiz 2",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality visible",
+        "script_level.level_keys": [
+          "CSDU4 Functionality visible"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Functionality setText quiz 3",
+        "script_level.level_keys": [
+          "CSDU4 Functionality setText quiz 3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Getting Better User Input",
+        "script_level.level_keys": [
+          "Getting Better User Input"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 24",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 24"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 25",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 25"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 26",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 26"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 27",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 27"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 - Design Mode - 28",
+        "script_level.level_keys": [
+          "CSDU4 - Design Mode - 28"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Adding Functionality to your App",
+        "script_level.level_keys": [
+          "Adding Functionality to your App"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 16,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Functionality",
+        "script_level.level_keys": [
+          "CSDU4 Project Functionality"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 17,
+        "lesson.key": "Basic App Functionality",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L15 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L15 SFLP"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Testing the App",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L16 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L16 SFLP"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Bug Feature",
+        "script_level.level_keys": [
+          "CSDU4 Project Bug Feature"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Improving and Iterating",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L17 SFLP",
+        "script_level.level_keys": [
+          "CSD U4L17 SFLP"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U4Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U4Ch2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "App Presentation",
+        "lesson_group.key": "csd4_2",
+        "script.name": "csd4-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd4-pilot.script_json
+++ b/dashboard/config/scripts_json/csd4-pilot.script_json
@@ -1,0 +1,471 @@
+{
+  "script": {
+    "name": "csd4-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "pilot_experiment": "csd-piloters"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd4-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd1_2",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 2: Computers and Problem Solving"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "key": "Input and Output",
+      "name": "Input and Output",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "key": "Processing",
+      "name": "Processing",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "key": "Apps and Storage",
+      "name": "Apps and Storage",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "key": "Project - Propose an App",
+      "name": "Project - Propose an App",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1L04 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video_pilot"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1L05 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd wiac pet chooser"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "csd wiac pet chooser"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd wiac mad libs"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "csd wiac mad libs"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1L06 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1L07 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1L09 TFMD_pilot"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_pilot"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U1 Test_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      },
+      "level_keys": [
+        "CSD U1 Test_pilot"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L04 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L04 TFMD_pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video_pilot",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video_pilot"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L05 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L05 TFMD_pilot"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd wiac pet chooser",
+        "script_level.level_keys": [
+          "csd wiac pet chooser"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd wiac mad libs",
+        "script_level.level_keys": [
+          "csd wiac mad libs"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Input and Output",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L06 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L06 TFMD_pilot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Processing",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L07 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L07 TFMD_pilot"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Apps and Storage",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1L09 TFMD_pilot",
+        "script_level.level_keys": [
+          "CSD U1L09 TFMD_pilot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_pilot",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U1Ch2_2018_2019_pilot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Project - Propose an App",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U1 Test_pilot",
+        "script_level.level_keys": [
+          "CSD U1 Test_pilot"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd1_2",
+        "script.name": "csd4-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-2017.script_json
+++ b/dashboard/config/scripts_json/csd5-2017.script_json
@@ -1,0 +1,1767 @@
+{
+  "script": {
+    "name": "csd5-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit5/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd5"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit5/vocab"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit5/standards/"
+        ]
+      ]
+    },
+    "new_name": "csd5-2017",
+    "family_name": "csd5",
+    "seeding_key": {
+      "script.name": "csd5-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd5-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Keeping Data Secret",
+      "name": "Keeping Data Secret",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Structuring Data",
+      "name": "Structuring Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "Project - Solve a Data Problem",
+      "name": "Project - Solve a Data Problem",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "key": "CSD Post-Course Survey",
+      "name": "CSD Post-Course Survey",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd5-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representation Matters"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Patterns and Representation"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP ASCII and Binary Representation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Images"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 4-new"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 5-new"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 6-new"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary 7-new"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary video"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 binary video"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Combining Representations"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U3 combining rep"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 student record"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Create a Representation"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving and Data"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving with Big Data"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Netflix Data Video"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Interpreting Data"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 data visualization"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Pizza"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Making Decisions with Data"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 L13 SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 L13 SFLP Interpreting Data"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD U5 crosstab warmup"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Automating Data Decisions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Solve a Data Problem"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd5-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representation Matters",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Patterns and Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP ASCII and Binary Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Images",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 1",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 1",
+        "script_level.level_keys": [
+          "CSD U5 binary 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 2",
+        "script_level.level_keys": [
+          "CSD U5 binary 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 4-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 5-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 6-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 7-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary video",
+        "script_level.level_keys": [
+          "CSD U5 binary video"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 2",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 2",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 1",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Combining Representations",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep",
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record",
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Create a Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving and Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving with Big Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Netflix Data Video",
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Interpreting Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization",
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza",
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Making Decisions with Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 L13 SFLP Interpreting Data",
+        "script_level.level_keys": [
+          "CSD U5 L13 SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 crosstab warmup",
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Automating Data Decisions",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Solve a Data Problem",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd5-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-2018.script_json
+++ b/dashboard/config/scripts_json/csd5-2018.script_json
@@ -1,0 +1,1812 @@
+{
+  "script": {
+    "name": "csd5-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Discoveries Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes. Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csd-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit5/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd5"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit5/vocab"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit5/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd5",
+    "seeding_key": {
+      "script.name": "csd5-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Keeping Data Secret",
+      "name": "Keeping Data Secret",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Structuring Data",
+      "name": "Structuring Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "Project - Solve a Data Problem",
+      "name": "Project - Solve a Data Problem",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries Post-Course Survey",
+      "name": "CS Discoveries Post-Course Survey",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L01 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L02 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L03 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L04 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L05 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 1_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 2_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 4-new_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 5-new_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 6-new_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary 7-new_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary video_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 binary video_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L06 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 2_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 1_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L07 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U3 combining rep_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 student record_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L08 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L09 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L10 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Netflix Data Video_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L11 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 data visualization_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Pizza_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L12 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L13 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5 crosstab warmup_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L14 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "CSD U5L15 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd u5 recommender sample"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "csd u5 recommender sample"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L01 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L02 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L03 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L04 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation_2018",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2_2018",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3_2018",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4_2018",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5_2018",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L05 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 1_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 2_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 4-new_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 5-new_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 6-new_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 7-new_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary video_2018",
+        "script_level.level_keys": [
+          "CSD U5 binary video_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L06 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 2_2018",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 1_2018",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L07 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep_2018",
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record_2018",
+        "script_level.level_keys": [
+          "CSD U5 student record_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L08 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L09 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L10 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Netflix Data Video_2018",
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video_2018",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video_2018",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L11 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization_2018",
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza_2018",
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2_2018",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L12 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L13 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 crosstab warmup_2018",
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L14 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L15 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd u5 recommender sample",
+        "script_level.level_keys": [
+          "csd u5 recommender sample"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-2019.script_json
+++ b/dashboard/config/scripts_json/csd5-2019.script_json
@@ -1,0 +1,1887 @@
+{
+  "script": {
+    "name": "csd5-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit5/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit5/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit5/vocab"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit5/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd5",
+    "seeding_key": {
+      "script.name": "csd5-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Keeping Data Secret",
+      "name": "Keeping Data Secret",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Structuring Data",
+      "name": "Structuring Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Project - Solve a Data Problem",
+      "name": "Project - Solve a Data Problem",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L01 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L02 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L03 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L04 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L05 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 1_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 2_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 4-new_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 5-new_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 6-new_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary 7-new_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary video_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 binary video_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L06 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L07 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U3 combining rep_2018_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 student record_2018_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L08 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L09 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L10 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Netflix Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L11 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 data visualization_2018_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Pizza_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L12 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L13 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 crosstab warmup_2018_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L14 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5L15 autoSFLP_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd u5 recommender sample_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "csd u5 recommender sample_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 test"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "CSD U5 test"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L01 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L02 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L03 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L04 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation_2019",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2_2019",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3_2019",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4_2019",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5_2019",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L05 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 1_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 2_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 4-new_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 5-new_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 6-new_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 7-new_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary video_2019",
+        "script_level.level_keys": [
+          "CSD U5 binary video_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L06 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 2_2018_2019",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 1_2018_2019",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L07 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep_2018_2019",
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record_2018_2019",
+        "script_level.level_keys": [
+          "CSD U5 student record_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L08 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L09 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L10 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Netflix Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video_2019",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L11 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization_2018_2019",
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza_2019",
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2_2019",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L12 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L13 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 crosstab warmup_2018_2019",
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L14 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L15 autoSFLP_2019",
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd u5 recommender sample_2019",
+        "script_level.level_keys": [
+          "csd u5 recommender sample_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 test",
+        "script_level.level_keys": [
+          "CSD U5 test"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-2020.script_json
+++ b/dashboard/config/scripts_json/csd5-2020.script_json
@@ -1,0 +1,1886 @@
+{
+  "script": {
+    "name": "csd5-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit5/{LESSON}",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit5/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit5/vocab"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit5/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd5-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Keeping Data Secret",
+      "name": "Keeping Data Secret",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Structuring Data",
+      "name": "Structuring Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Project - Make a Recommendation",
+      "name": "Project - Make a Recommendation",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L01 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L02 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L03 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L04 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L05 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 1_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 2_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 4-new_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 5-new_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 6-new_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary 7-new_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary video_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 binary video_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L06 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018_2019_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 2_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Keeping Data Secret"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018_2019_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Encryption 1_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L07 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018_2019_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U3 combining rep_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record_2018_2019_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 student record_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L08 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L09 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L10 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Netflix Data Video_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L11 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018_2019_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 data visualization_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Pizza_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L12 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L13 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018_2019_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 crosstab warmup_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L14 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5L15 autoSFLP_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd u5 recommender sample_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "csd u5 recommender sample_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 test_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "CSD U5 test_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L01 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L01 autoSFLP_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L02 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L02 autoSFLP_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L03 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L03 autoSFLP_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L04 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L04 autoSFLP_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation_2020",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2_2020",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3_2020",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4_2020",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5_2020",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L05 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L05 autoSFLP_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 1_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 1_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 2_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 2_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 4-new_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 5-new_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 6-new_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 7-new_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary video_2020",
+        "script_level.level_keys": [
+          "CSD U5 binary video_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L06 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L06 autoSFLP_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 2_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 2_2018_2019_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Encryption 1_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U5 Encryption 1_2018_2019_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Keeping Data Secret",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L07 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L07 autoSFLP_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U3 combining rep_2018_2019_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U5 student record_2018_2019_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L08 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L08 autoSFLP_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L09 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L09 autoSFLP_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L10 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L10 autoSFLP_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Netflix Data Video_2020",
+        "script_level.level_keys": [
+          "CSD U5 Netflix Data Video_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video_2020",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video_2020",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L11 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L11 autoSFLP_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U5 data visualization_2018_2019_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza_2020",
+        "script_level.level_keys": [
+          "CSD U5 Pizza_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2_2020",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L12 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L12 autoSFLP_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L13 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L13 autoSFLP_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 crosstab warmup_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U5 crosstab warmup_2018_2019_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L14 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L14 autoSFLP_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5L15 autoSFLP_2020",
+        "script_level.level_keys": [
+          "CSD U5L15 autoSFLP_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd u5 recommender sample_2020",
+        "script_level.level_keys": [
+          "csd u5 recommender sample_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Recommendation",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 test_2020",
+        "script_level.level_keys": [
+          "CSD U5 test_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd5-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd5-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csd5-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd5-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 5 Deeper Learning Reflections",
+      "name": "Complete Unit 5 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "csd5dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "csd5dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      },
+      "level_keys": [
+        "csd5dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-q1",
+        "script_level.level_keys": [
+          "csd5dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-q2",
+        "script_level.level_keys": [
+          "csd5dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-q3",
+        "script_level.level_keys": [
+          "csd5dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-dlp.script_json
+++ b/dashboard/config/scripts_json/csd5-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd5-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd5-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 5 Deeper Learning Reflections",
+      "name": "Complete Unit 5 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "csd5dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "csd5dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd5dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      },
+      "level_keys": [
+        "csd5dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-lessons",
+        "script_level.level_keys": [
+          "csd5dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-tools",
+        "script_level.level_keys": [
+          "csd5dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd5dlp-assessment",
+        "script_level.level_keys": [
+          "csd5dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd5-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-draft.script_json
+++ b/dashboard/config/scripts_json/csd5-draft.script_json
@@ -1,0 +1,1646 @@
+{
+  "script": {
+    "name": "csd5-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd5-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Encryption",
+      "name": "Encryption",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Structuring Data",
+      "name": "Structuring Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "key": "Project - Solve a Data Problem",
+      "name": "Project - Solve a Data Problem",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representation Matters"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Patterns and Representation"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP ASCII and Binary Representation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Images"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 4-new"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 5-new"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 6-new"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Binary Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 binary 7-new"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Encryption",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Combining Representations"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U3 combining rep"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 student record"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Create a Representation"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving and Data"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving with Big Data"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 video2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 video2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 collection UPS2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 collection UPS2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 collection ads2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 collection ads2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Interpreting Data"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 data visualization"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 Pizza"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Making Decisions with Data"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 L13 SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 L13 SFLP Interpreting Data"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 data visualization"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 Pizza"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Automating Data Decisions"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Solve a Data Problem"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representation Matters",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Patterns and Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP ASCII and Binary Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Images",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 1",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 1",
+        "script_level.level_keys": [
+          "CSD U5 binary 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 2",
+        "script_level.level_keys": [
+          "CSD U5 binary 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 4-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 4-new"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 5-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 5-new"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 6-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 6-new"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 binary 7-new",
+        "script_level.level_keys": [
+          "CSD U5 binary 7-new"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 2",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Encryption",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Combining Representations",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep",
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record",
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Create a Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving and Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving with Big Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 video2",
+        "script_level.level_keys": [
+          "CSD U5 video2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 collection UPS2",
+        "script_level.level_keys": [
+          "CSD U5 collection UPS2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 collection ads2",
+        "script_level.level_keys": [
+          "CSD U5 collection ads2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Interpreting Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization",
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza",
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Structuring Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Making Decisions with Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 L13 SFLP Interpreting Data",
+        "script_level.level_keys": [
+          "CSD U5 L13 SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization",
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza",
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Automating Data Decisions",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Solve a Data Problem",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd5-old.script_json
+++ b/dashboard/config/scripts_json/csd5-old.script_json
@@ -1,0 +1,1310 @@
+{
+  "script": {
+    "name": "csd5-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd5-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Representing Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "csd5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Solving Data Problems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Representation Matters",
+      "name": "Representation Matters",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Patterns and Representation",
+      "name": "Patterns and Representation",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "ASCII and Binary Representation",
+      "name": "ASCII and Binary Representation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Representing Images",
+      "name": "Representing Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Representing Numbers",
+      "name": "Representing Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "8-bit Numbers",
+      "name": "8-bit Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "8-bit Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Combining Representations",
+      "name": "Combining Representations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Project - Create a Representation",
+      "name": "Project - Create a Representation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Problem Solving and Data",
+      "name": "Problem Solving and Data",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Making Decisions with Data",
+      "name": "Making Decisions with Data",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Interpreting Data",
+      "name": "Interpreting Data",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Automating Data Decisions",
+      "name": "Automating Data Decisions",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "key": "Project - Solve a Data Problem",
+      "name": "Project - Solve a Data Problem",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representation Matters"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Patterns and Representation"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP ASCII and Binary Representation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Images"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 4"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Representing Images"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 black white images pixelation 5"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "8-bit Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Representing Numbers Part 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "8-bit Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 fixed-bits"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "8-bit Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 fixed-bits"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Combining Representations"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U3 combining rep"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Combining Representations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 student record"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Create a Representation"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving and Data"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Making Decisions with Data"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Interpreting Data"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 data visualization"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 Pizza"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Visualization"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 Pizza 2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Automating Data Decisions"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Problem Solving with Big Data"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 video2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 video2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 collection UPS2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 collection UPS2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 collection ads2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD U5 collection ads2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "CSD-U5-SFLP Solve a Data Problem"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U5Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representation Matters",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representation Matters"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Representation Matters",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Patterns and Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Patterns and Representation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Patterns and Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP ASCII and Binary Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP ASCII and Binary Representation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "ASCII and Binary Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Images",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Images"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 2",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 3",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 4",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 black white images pixelation 5",
+        "script_level.level_keys": [
+          "CSD U5 black white images pixelation 5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Representing Images",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 1",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Representing Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Representing Numbers Part 2",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Representing Numbers Part 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "8-bit Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 fixed-bits",
+        "script_level.level_keys": [
+          "CSD U5 fixed-bits"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "8-bit Numbers",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Combining Representations",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Combining Representations"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 combining rep",
+        "script_level.level_keys": [
+          "CSD U3 combining rep"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 student record",
+        "script_level.level_keys": [
+          "CSD U5 student record"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Combining Representations",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Create a Representation",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Create a Representation"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Project - Create a Representation",
+        "lesson_group.key": "csd5_1",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving and Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving and Data"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving and Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Making Decisions with Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Making Decisions with Data"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Making Decisions with Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Interpreting Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Interpreting Data"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 data visualization",
+        "script_level.level_keys": [
+          "CSD U5 data visualization"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza",
+        "script_level.level_keys": [
+          "CSD U5 Pizza"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Pizza 2",
+        "script_level.level_keys": [
+          "CSD U5 Pizza 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Automating Data Decisions",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Automating Data Decisions"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Automating Data Decisions",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Problem Solving with Big Data",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Problem Solving with Big Data"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 video2",
+        "script_level.level_keys": [
+          "CSD U5 video2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 collection UPS2",
+        "script_level.level_keys": [
+          "CSD U5 collection UPS2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 collection ads2",
+        "script_level.level_keys": [
+          "CSD U5 collection ads2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U5-SFLP Solve a Data Problem",
+        "script_level.level_keys": [
+          "CSD-U5-SFLP Solve a Data Problem"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U5Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U5Ch2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Project - Solve a Data Problem",
+        "lesson_group.key": "csd5_2",
+        "script.name": "csd5-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-2017.script_json
+++ b/dashboard/config/scripts_json/csd6-2017.script_json
@@ -1,0 +1,7446 @@
+{
+  "script": {
+    "name": "csd6-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_types": [
+        "applab"
+      ],
+      "version_year": "2017",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd/unit6/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd6"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd/unit6/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd/unit6/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd/unit6/code/"
+        ]
+      ]
+    },
+    "new_name": "csd6-2017",
+    "family_name": "csd6",
+    "seeding_key": {
+      "script.name": "csd6-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "csd_survey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Post-Course Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd6-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Innovations in Computing_",
+      "name": "Innovations in Computing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Innovations in Computing_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Designing Screens with Code_",
+      "name": "Designing Screens with Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "The Circuit Playground_",
+      "name": "The Circuit Playground",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Input Unplugged_",
+      "name": "Input Unplugged",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Board Events_",
+      "name": "Board Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Getting Properties_",
+      "name": "Getting Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Analog Input_",
+      "name": "Analog Input",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "The Program Design Process_",
+      "name": "The Program Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Project: Make a Game__",
+      "name": "Project: Make a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Arrays and Color LEDs__",
+      "name": "Arrays and Color LEDs",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Making Music_",
+      "name": "Making Music",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Arrays and For Loops_",
+      "name": "Arrays and For Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Accelerometer_",
+      "name": "Accelerometer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Functions with Parameters_",
+      "name": "Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Circuits and Physical Prototypes_",
+      "name": "Circuits and Physical Prototypes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation_",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "key": "CSD Post-Course Survey",
+      "name": "CSD Post-Course Survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd6-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L01 TFMD"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 Innovation"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L02 TFMD"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Map"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty predict app"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Text"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy click"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy random"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine example"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L03 TFMD"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD LEDs Map"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 test LED"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 test LED"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 predict LED button"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 predict LED button"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 add LED button"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 add LED button"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED toggle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 LED toggle"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED all"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 LED all"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED create intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 LED create intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light show"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 light show"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Catch the Mouse"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 create LED app"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 create LED app 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L04 TFMD"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L05 TFMD"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD onBoardEvent Map"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - button LED prediction"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - LED buttonL"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - LED toggle buttonL up"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD Board Buttons Map"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - lightswitch toggleswitch"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - toggle state LED prediction"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - toggleswitch state setProp"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD Buzzer Map"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer intro"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration buttons"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L06 TFMD"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Map"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Demo"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty input"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty input"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty dropdown"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty board predict"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getProperty buzzer"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 slider intro"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 slider intro"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 frequency"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 frequency"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 interval"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 interval"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Event Types"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Event Types"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 change"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 change"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 get toggle"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 get toggle"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getters debug"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 getters debug"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 move motorcycle"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 design motorcycle"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L07 TFMD"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 sensor experiment embedded"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD Board Sensors Map"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog sound"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog sound"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog light"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog light"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog temp"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog temp"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog predict"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog predict"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD Polling Events Map"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog data"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog data"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog change"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog change"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog threshold"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog threshold"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD Set Scale Map"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog rgb 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog challenge"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 analog challenge"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L08 TFMD"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 emoji race demo"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar stop"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1.5"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar conditional"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setScreen"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setProperty"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar buzzer"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar final"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar final"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L09 TFMD"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 tugowar demo"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project stop"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project stop"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screens"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project screens"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screen links"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project screen links"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project board events"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project board events"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions define"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project functions define"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions call"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project functions call"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project finish"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 game project finish"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L10 TFMD"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays intro"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 arrays intro"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 arrays select predict"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 arrays select rainbow"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 array select days"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 array select days"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select random"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 arrays select random"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 arrays select variable"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array multi"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 array multi"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD colorLed Map"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds predict"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLED on"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 colorLED on"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LEDs color"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 LEDs color"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds debug"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds intensity"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds light pattern"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern off"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 light pattern off"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L11 TFMD"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 circuit playground piano"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency modification"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 frequency modification"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency creation"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 frequency creation"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Music"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "Making Music"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing with Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 piano with notes"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 piano with notes"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-Arrays"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD-Arrays"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array piano"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 array piano"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 random array notes"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 random array notes"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 making new arrays"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 making new arrays"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play predict code"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 play predict code"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play songs"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 play songs"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play null notes"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 play null notes"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 14,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CDU U6 Playground Sound Board"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L12 TFMD"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop click predict"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop click exit"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop map"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop map"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD: For Loop"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop button array"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop button array"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop list.length"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop images"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop images"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led on"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop led on"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led off"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop led off"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function call"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function finish"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L13 TFMD"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Accelerometer"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "The Accelerometer"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Airplane predict"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 investigate orientation"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 directional leds pitch"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 directional LEDs roll"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Accelerometer Events"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "Using Accelerometer Events"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 stillness game predict code"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Pedometer"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Pedometer"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "Revisiting the Counter Pattern"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 goalie"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 goalie"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt1"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt 2"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L14 TFMD"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params predict"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params predict"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params modify clouds"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify planes"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params modify planes"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params create colors"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params create colors"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 iter predict bubbles"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 iter modify bugs"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter create notes"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 iter create notes"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser intro"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 1"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 2"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 3"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 4"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 5"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L15 TFMD"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit logic video"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit predict"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit predict"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit LED map"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit pinMode"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit createLed"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit multi led"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinkers"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker buttons"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker build"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit button map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit button map"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike buzzer"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike light"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike final"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6L16 TFMD"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 final intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSD U6 final intro"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd6-2017"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L01 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation",
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L02 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Map",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty predict app",
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Text",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy click",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy random",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden 2",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine example",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 1",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 2",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 3",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 4",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD LEDs Map",
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 test LED",
+        "script_level.level_keys": [
+          "CSD U6 test LED"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 predict LED button",
+        "script_level.level_keys": [
+          "CSD U6 predict LED button"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 add LED button",
+        "script_level.level_keys": [
+          "CSD U6 add LED button"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED toggle",
+        "script_level.level_keys": [
+          "CSD U6 LED toggle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED all",
+        "script_level.level_keys": [
+          "CSD U6 LED all"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED create intro",
+        "script_level.level_keys": [
+          "CSD U6 LED create intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light show",
+        "script_level.level_keys": [
+          "CSD U6 light show"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Catch the Mouse",
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app",
+        "script_level.level_keys": [
+          "CSD U6 create LED app"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app 2",
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L04 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L05 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD onBoardEvent Map",
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button LED prediction",
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED buttonL",
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED toggle buttonL up",
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Buttons Map",
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lightswitch toggleswitch",
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggle state LED prediction",
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggleswitch state setProp",
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Buzzer Map",
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer intro",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration buttons",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L06 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Map",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Demo",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty input",
+        "script_level.level_keys": [
+          "CSD U6 getProperty input"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty dropdown",
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty board predict",
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty buzzer",
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 slider intro",
+        "script_level.level_keys": [
+          "CSD U6 slider intro"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 frequency",
+        "script_level.level_keys": [
+          "CSD U6 frequency"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 interval",
+        "script_level.level_keys": [
+          "CSD U6 interval"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Event Types",
+        "script_level.level_keys": [
+          "CSD U6 Event Types"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 change",
+        "script_level.level_keys": [
+          "CSD U6 change"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 get toggle",
+        "script_level.level_keys": [
+          "CSD U6 get toggle"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getters debug",
+        "script_level.level_keys": [
+          "CSD U6 getters debug"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 move motorcycle",
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 design motorcycle",
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L07 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 sensor experiment embedded",
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Sensors Map",
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog sound",
+        "script_level.level_keys": [
+          "CSD U6 analog sound"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog light",
+        "script_level.level_keys": [
+          "CSD U6 analog light"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog temp",
+        "script_level.level_keys": [
+          "CSD U6 analog temp"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog predict",
+        "script_level.level_keys": [
+          "CSD U6 analog predict"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Polling Events Map",
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog data",
+        "script_level.level_keys": [
+          "CSD U6 analog data"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog change",
+        "script_level.level_keys": [
+          "CSD U6 analog change"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog threshold",
+        "script_level.level_keys": [
+          "CSD U6 analog threshold"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Set Scale Map",
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 1",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 2",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rgb 3",
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog challenge",
+        "script_level.level_keys": [
+          "CSD U6 analog challenge"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L08 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emoji race demo",
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar stop",
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1.5",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 2",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 1",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 2",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 3",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar conditional",
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setScreen",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setProperty",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar buzzer",
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar final",
+        "script_level.level_keys": [
+          "CSD U6 tugowar final"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process_",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L09 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar demo",
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project stop",
+        "script_level.level_keys": [
+          "CSD U6 game project stop"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screens",
+        "script_level.level_keys": [
+          "CSD U6 game project screens"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screen links",
+        "script_level.level_keys": [
+          "CSD U6 game project screen links"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project board events",
+        "script_level.level_keys": [
+          "CSD U6 game project board events"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions define",
+        "script_level.level_keys": [
+          "CSD U6 game project functions define"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions call",
+        "script_level.level_keys": [
+          "CSD U6 game project functions call"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project finish",
+        "script_level.level_keys": [
+          "CSD U6 game project finish"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game__",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L10 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays intro",
+        "script_level.level_keys": [
+          "CSD U6 arrays intro"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays select predict",
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select rainbow",
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 array select days",
+        "script_level.level_keys": [
+          "CSDU6 array select days"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select random",
+        "script_level.level_keys": [
+          "CSDU6 arrays select random"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select variable",
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array multi",
+        "script_level.level_keys": [
+          "CSD U6 array multi"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD colorLed Map",
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds predict",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLED on",
+        "script_level.level_keys": [
+          "CSD U6 colorLED on"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LEDs color",
+        "script_level.level_keys": [
+          "CSD U6 LEDs color"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds debug",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds intensity",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds light pattern",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern off",
+        "script_level.level_keys": [
+          "CSD U6 light pattern off"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs__",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L11 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 circuit playground piano",
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency modification",
+        "script_level.level_keys": [
+          "CSDU6 frequency modification"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency creation",
+        "script_level.level_keys": [
+          "CSDU6 frequency creation"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Music",
+        "script_level.level_keys": [
+          "Making Music"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 piano with notes",
+        "script_level.level_keys": [
+          "CSDU6 piano with notes"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-Arrays",
+        "script_level.level_keys": [
+          "CSD-Arrays"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array piano",
+        "script_level.level_keys": [
+          "CSD U6 array piano"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 random array notes",
+        "script_level.level_keys": [
+          "CSD U6 random array notes"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 making new arrays",
+        "script_level.level_keys": [
+          "CSDU6 making new arrays"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play predict code",
+        "script_level.level_keys": [
+          "CSDU6 play predict code"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play songs",
+        "script_level.level_keys": [
+          "CSDU6 play songs"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play null notes",
+        "script_level.level_keys": [
+          "CSDU6 play null notes"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDU U6 Playground Sound Board",
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 14,
+        "lesson.key": "Making Music_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L12 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click predict",
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click exit",
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop map",
+        "script_level.level_keys": [
+          "CSD U6 for loop map"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop",
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop button array",
+        "script_level.level_keys": [
+          "CSD U6 for loop button array"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop list.length",
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop images",
+        "script_level.level_keys": [
+          "CSD U6 for loop images"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led on",
+        "script_level.level_keys": [
+          "CSD U6 for loop led on"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led off",
+        "script_level.level_keys": [
+          "CSD U6 for loop led off"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function call",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function finish",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L13 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Accelerometer",
+        "script_level.level_keys": [
+          "The Accelerometer"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Airplane predict",
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 investigate orientation",
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional leds pitch",
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional LEDs roll",
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Accelerometer Events",
+        "script_level.level_keys": [
+          "Using Accelerometer Events"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 stillness game predict code",
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Pedometer",
+        "script_level.level_keys": [
+          "CSD U6 Pedometer"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Revisiting the Counter Pattern",
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 goalie",
+        "script_level.level_keys": [
+          "CSD U6 goalie"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt1",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt 2",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L14 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params predict",
+        "script_level.level_keys": [
+          "CSD U6 params predict"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify clouds",
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify planes",
+        "script_level.level_keys": [
+          "CSD U6 params modify planes"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params create colors",
+        "script_level.level_keys": [
+          "CSD U6 params create colors"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter predict bubbles",
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter modify bugs",
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter create notes",
+        "script_level.level_keys": [
+          "CSD U6 iter create notes"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser intro",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 1",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 2",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 3",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 4",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 5",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L15 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit logic video",
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit predict",
+        "script_level.level_keys": [
+          "CSD U6 circuit predict"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit LED map",
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit pinMode",
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createLed",
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit multi led",
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinkers",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker buttons",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker build",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit button map",
+        "script_level.level_keys": [
+          "CSD U6 circuit button map"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike buzzer",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike light",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike final",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L16 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 final intro",
+        "script_level.level_keys": [
+          "CSD U6 final intro"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation_",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "CSD Post-Course Survey",
+        "lesson_group.key": "csd_survey",
+        "script.name": "csd6-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-2018.script_json
+++ b/dashboard/config/scripts_json/csd6-2018.script_json
@@ -1,0 +1,7813 @@
+{
+  "script": {
+    "name": "csd6-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "applab",
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true,
+      "announcements": [
+        {
+          "notice": "CS Discoveries Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes. Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csd-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-18/unit6/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd6"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-18/unit6/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-18/unit6/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-18/unit6/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd6",
+    "seeding_key": {
+      "script.name": "csd6-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Innovations in Computing",
+      "name": "Innovations in Computing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Designing Screens with Code",
+      "name": "Designing Screens with Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Input Unplugged",
+      "name": "Input Unplugged",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Board Events",
+      "name": "Board Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Getting Properties",
+      "name": "Getting Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "The Program Design Process",
+      "name": "The Program Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Project: Make a Game",
+      "name": "Project: Make a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Arrays and Color LEDs",
+      "name": "Arrays and Color LEDs",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Making Music",
+      "name": "Making Music",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Arrays and For Loops",
+      "name": "Arrays and For Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Accelerometer",
+      "name": "Accelerometer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Functions with Parameters",
+      "name": "Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Circuits and Physical Prototypes",
+      "name": "Circuits and Physical Prototypes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "key": "CS Discoveries Post-Course Survey",
+      "name": "CS Discoveries Post-Course Survey",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L01 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 Innovation_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L02 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Map_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty predict app_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Text_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy click_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy random_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden 2_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine example_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 1_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 2_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 3_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 4_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L03 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD LEDs Map_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD LEDs Map_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 test LED_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 test LED_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 predict LED button_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 add LED button_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 LED toggle_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED all_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 LED all_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 LED create intro_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light show_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 light show_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Catch the Mouse_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 create LED app_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 create LED app 2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L04 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L05 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD onBoardEvent Map_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - button LED prediction_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - LED buttonL_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - LED toggle buttonL up_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Buttons Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD Board Buttons Map_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - lightswitch toggleswitch_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - toggle state LED prediction_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - toggleswitch state setProp_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Buzzer Map_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD Buzzer Map_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer intro_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration buttons_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - board event challenge_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L06 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Map_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Demo_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty input_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty dropdown_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty board predict_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getProperty buzzer_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 slider intro_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 frequency_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 frequency_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 interval_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 interval_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Event Types_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Event Types_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 change_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 change_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 get toggle_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 getters debug_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 move motorcycle_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 design motorcycle_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 challenge motorcycle_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L07 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 sensor experiment embedded_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Sensors Map_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD Board Sensors Map_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog sound_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog light_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog light_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog temp_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog predict_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Polling Events Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD Polling Events Map_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog data_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog data_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog change_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog change_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog threshold_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Set Scale Map_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD Set Scale Map_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 1_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 2_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog rgb 3_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 analog challenge_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L08 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 emoji race demo_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar stop_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1.5_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 2_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 1_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 2_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 3_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar conditional_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setScreen_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setProperty_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar buzzer_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar final_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L09 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 tugowar demo_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project stop_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project screens_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project screen links_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project board events_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project functions define_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project functions call_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 game project finish_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L10 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays intro_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 arrays intro_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 arrays select predict_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 arrays select rainbow_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 array select days_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 array select days_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 arrays select random_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 arrays select variable_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 array multi_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD colorLed Map_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD colorLed Map_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds predict_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 colorLED on_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 LEDs color_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds debug_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds intensity_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds light pattern_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 light pattern off_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge Levels"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 light pattern challenge_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L11 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 circuit playground piano_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 frequency modification_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 frequency creation_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Music_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "Making Music_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing with Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 piano with notes_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-Arrays_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD-Arrays_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array piano_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 array piano_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 random array notes_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 making new arrays_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 play predict code_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play songs_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 play songs_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 play null notes_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CDU U6 Playground Sound Board_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 buzzer 2d arrays_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 buzzer.stop_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L12 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop click predict_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop click exit_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop map_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD: For Loop_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop button array_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop list.length_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop images_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led on_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led off_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function call_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function finish_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 1_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 1_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 2_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 2_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 3_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 3_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L13 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Accelerometer_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "The Accelerometer_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Airplane predict_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 investigate orientation_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 directional leds pitch_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 directional LEDs roll_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Accelerometer Events_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "Using Accelerometer Events_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 stillness game predict code_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Pedometer_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "Revisiting the Counter Pattern_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 goalie_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 goalie_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt1_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt 2_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L14 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params predict_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params predict_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params modify clouds_2018"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params modify planes_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params create colors_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 iter predict bubbles_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 iter modify bugs_2018"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 iter create notes_2018"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser intro_2018"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 1_2018"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 2_2018"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 3_2018"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 4_2018"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 5_2018"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 1_2018"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 2_2018"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L15 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit logic video_2018"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit predict_2018"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit LED map_2018"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit pinMode_2018"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit createLed_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit multi led_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinkers_2018"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker buttons_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker build_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit button map_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit button map_2018"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike buzzer_2018"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike light_2018"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike final_2018"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6L16 TFMD_2018"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSD U6 final intro_2018"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1_2018"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2_2018"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3_2018"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5_2018"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4_2018"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6_2018"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2018"
+      },
+      "level_keys": [
+        "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L01 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation_2018",
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L02 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Map_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty predict app_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Text_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy click_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy random_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine example_2018",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 3_2018",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 4_2018",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video_2018",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD LEDs Map_2018",
+        "script_level.level_keys": [
+          "CSD LEDs Map_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test_2018",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 test LED_2018",
+        "script_level.level_keys": [
+          "CSD U6 test LED_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 predict LED button_2018",
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 add LED button_2018",
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED toggle_2018",
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED all_2018",
+        "script_level.level_keys": [
+          "CSD U6 LED all_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED create intro_2018",
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light show_2018",
+        "script_level.level_keys": [
+          "CSD U6 light show_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Catch the Mouse_2018",
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app_2018",
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L04 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1_2018",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1_2018",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L05 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD onBoardEvent Map_2018",
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button LED prediction_2018",
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED buttonL_2018",
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED toggle buttonL up_2018",
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Buttons Map_2018",
+        "script_level.level_keys": [
+          "CSD Board Buttons Map_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lightswitch toggleswitch_2018",
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggle state LED prediction_2018",
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggleswitch state setProp_2018",
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Buzzer Map_2018",
+        "script_level.level_keys": [
+          "CSD Buzzer Map_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer intro_2018",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration_2018",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration buttons_2018",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - board event challenge_2018",
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L06 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Map_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Demo_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty input_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty dropdown_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty board predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty buzzer_2018",
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 slider intro_2018",
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 frequency_2018",
+        "script_level.level_keys": [
+          "CSD U6 frequency_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 interval_2018",
+        "script_level.level_keys": [
+          "CSD U6 interval_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Event Types_2018",
+        "script_level.level_keys": [
+          "CSD U6 Event Types_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 change_2018",
+        "script_level.level_keys": [
+          "CSD U6 change_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 get toggle_2018",
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getters debug_2018",
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 move motorcycle_2018",
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 design motorcycle_2018",
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 challenge motorcycle_2018",
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L07 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 sensor experiment embedded_2018",
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Sensors Map_2018",
+        "script_level.level_keys": [
+          "CSD Board Sensors Map_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog sound_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog light_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog light_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog temp_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Polling Events Map_2018",
+        "script_level.level_keys": [
+          "CSD Polling Events Map_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog data_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog data_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog change_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog change_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog threshold_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Set Scale Map_2018",
+        "script_level.level_keys": [
+          "CSD Set Scale Map_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rgb 3_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog challenge_2018",
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L08 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emoji race demo_2018",
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar stop_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1.5_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 3_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar conditional_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setScreen_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setProperty_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar buzzer_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar final_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L09 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar demo_2018",
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project stop_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screens_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screen links_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project board events_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions define_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions call_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project finish_2018",
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L10 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays intro_2018",
+        "script_level.level_keys": [
+          "CSD U6 arrays intro_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays select predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select rainbow_2018",
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 array select days_2018",
+        "script_level.level_keys": [
+          "CSDU6 array select days_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select random_2018",
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select variable_2018",
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array multi_2018",
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD colorLed Map_2018",
+        "script_level.level_keys": [
+          "CSD colorLed Map_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLED on_2018",
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LEDs color_2018",
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds debug_2018",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds intensity_2018",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds light pattern_2018",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern off_2018",
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern challenge_2018",
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L11 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 circuit playground piano_2018",
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency modification_2018",
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency creation_2018",
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Music_2018",
+        "script_level.level_keys": [
+          "Making Music_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 piano with notes_2018",
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-Arrays_2018",
+        "script_level.level_keys": [
+          "CSD-Arrays_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array piano_2018",
+        "script_level.level_keys": [
+          "CSD U6 array piano_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 random array notes_2018",
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 making new arrays_2018",
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play predict code_2018",
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play songs_2018",
+        "script_level.level_keys": [
+          "CSDU6 play songs_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play null notes_2018",
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDU U6 Playground Sound Board_2018",
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer 2d arrays_2018",
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer.stop_2018",
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L12 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click exit_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop map_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop_2018",
+        "script_level.level_keys": [
+          "CSD: For Loop_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print_2018",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop button array_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop list.length_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop images_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led on_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led off_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video_2018",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function call_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function finish_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 1_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 2_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 3_2018",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 3_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L13 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Accelerometer_2018",
+        "script_level.level_keys": [
+          "The Accelerometer_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Airplane predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 investigate orientation_2018",
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional leds pitch_2018",
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional LEDs roll_2018",
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Accelerometer Events_2018",
+        "script_level.level_keys": [
+          "Using Accelerometer Events_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 stillness game predict code_2018",
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Pedometer_2018",
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Revisiting the Counter Pattern_2018",
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 goalie_2018",
+        "script_level.level_keys": [
+          "CSD U6 goalie_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt1_2018",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L14 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 params predict_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify clouds_2018",
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify planes_2018",
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params create colors_2018",
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter predict bubbles_2018",
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter modify bugs_2018",
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2018"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter create notes_2018",
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser intro_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 3_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 4_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 5_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 1_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 2_2018",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L15 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit logic video_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit predict_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit LED map_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit pinMode_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createLed_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit multi led_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinkers_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker buttons_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker build_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit button map_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit button map_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike buzzer_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike light_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike final_2018",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L16 TFMD_2018",
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 final intro_2018",
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6_2018",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2_2018",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csd-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-2019.script_json
+++ b/dashboard/config/scripts_json/csd6-2019.script_json
@@ -1,0 +1,7781 @@
+{
+  "script": {
+    "name": "csd6-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "applab",
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/csd-19/unit6/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-19/unit6/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-19/unit6/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-19/unit6/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-19/unit6/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd6",
+    "seeding_key": {
+      "script.name": "csd6-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Innovations in Computing",
+      "name": "Innovations in Computing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Designing Screens with Code",
+      "name": "Designing Screens with Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Input Unplugged",
+      "name": "Input Unplugged",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Board Events",
+      "name": "Board Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Getting Properties",
+      "name": "Getting Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "The Program Design Process",
+      "name": "The Program Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Project: Make a Game",
+      "name": "Project: Make a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Arrays and Color LEDs",
+      "name": "Arrays and Color LEDs",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Making Music",
+      "name": "Making Music",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Arrays and For Loops",
+      "name": "Arrays and For Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Accelerometer",
+      "name": "Accelerometer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Functions with Parameters",
+      "name": "Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Circuits and Physical Prototypes",
+      "name": "Circuits and Physical Prototypes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L01 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 Innovation_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L02 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty predict app_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Text_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Map_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy click_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy random_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden 2_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine example_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 1_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 2_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 3_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 4_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L03 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD LEDs Map_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD LEDs Map_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 test LED_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 test LED_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 predict LED button_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 add LED button_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 LED toggle_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED all_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 LED all_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 LED create intro_2018_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light show_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 light show_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Catch the Mouse_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 create LED app_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 create LED app 2_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L04 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L05 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - button LED prediction_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - LED buttonL_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - LED toggle buttonL up_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD onBoardEvent Map_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - lightswitch toggleswitch_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - toggle state LED prediction_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - toggleswitch state setProp_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Buttons Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Board Buttons Map_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer intro_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration buttons_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Buzzer Map_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Buzzer Map_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - board event challenge_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L06 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Demo_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty input_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty dropdown_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty board predict_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty buzzer_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Map_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 slider intro_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 frequency_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 frequency_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 interval_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 interval_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 change_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 change_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 get toggle_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 getters debug_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Event Types_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Event Types_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 move motorcycle_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 design motorcycle_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 challenge motorcycle_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L07 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 sensor experiment embedded_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog sound_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog light_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog light_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog temp_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Sensors Map_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Board Sensors Map_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog predict_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog data_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog data_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog change_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog change_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog threshold_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Polling Events Map_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Polling Events Map_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Set Scale Map_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Set Scale Map_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 1_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 2_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog rgb 3_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 analog challenge_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L08 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 emoji race demo_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar stop_2018_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1.5_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 2_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 1_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 2_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 3_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar conditional_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setScreen_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setProperty_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar buzzer_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar final_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L09 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 tugowar demo_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project stop_2018_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project screens_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project screen links_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project board events_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project functions define_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project functions call_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 game project finish_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L10 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays video"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 arrays video"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 arrays select predict_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 arrays select rainbow_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 array select days_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 array select days_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 arrays select random_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 arrays select variable_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays intro_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 arrays intro_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 array multi_2018_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds predict_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 colorLED on_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 LEDs color_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds debug_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds intensity_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD colorLed Map_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD colorLed Map_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds light pattern_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 light pattern off_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge Levels"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 light pattern challenge_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L11 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 circuit playground piano_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 frequency modification_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 frequency creation_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 piano with notes_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Music_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "Making Music_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array piano_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 array piano_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 random array notes_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 making new arrays_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-Arrays_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD-Arrays_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 play predict code_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play songs_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 play songs_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 play null notes_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CDU U6 Playground Sound Board_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 buzzer 2d arrays_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 buzzer.stop_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L12 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop click predict_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop click exit_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD: For Loop_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop button array_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop list.length_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop images_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop map_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop led on_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop led off_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led color_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop led color_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led personalize_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 for loop led personalize_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L13 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Airplane predict_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 investigate orientation_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 directional leds pitch_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 directional LEDs roll_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Accelerometer_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "The Accelerometer_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 stillness game predict code_2019"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Pedometer_2019"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Accelerometer Events_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "Using Accelerometer Events_2019"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "Revisiting the Counter Pattern_2019"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 goalie_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 goalie_2019"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt1_2019"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt 2_2019"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L14 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params predict_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params predict_2019"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video_2019"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params modify clouds_2019"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params modify planes_2019"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params create colors_2019"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 iter predict bubbles_2019"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 iter modify bugs_2019"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 iter create notes_2019"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser intro_2019"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 1_2019"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 2_2019"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 3_2019"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 4_2019"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 5_2019"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 1_2019"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 17,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 2_2019"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L15 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit logic video_2019"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit predict_2019"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit LED map_2019"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit pinMode_2019"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit createLed_2019"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit multi led_2019"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinkers_2019"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker buttons_2019"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker build_2018_2019"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit button map_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit button map_2019"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton_2019"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike buzzer_2019"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike light_2019"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike final_2019"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6L16 TFMD_2019"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD U6 final intro_2018_2019"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1_2019"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2_2019"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3_2019"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5_2019"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4_2019"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6_2019"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Physical Computing Post-Project Test"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "CSD Physical Computing Post-Project Test"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L01 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation_2018_2019",
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L02 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty predict app_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Text_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Map_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy click_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy random_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine example_2019",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 3_2019",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 4_2019",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video_2019",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD LEDs Map_2019",
+        "script_level.level_keys": [
+          "CSD LEDs Map_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test_2019",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 test LED_2019",
+        "script_level.level_keys": [
+          "CSD U6 test LED_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 predict LED button_2019",
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 add LED button_2019",
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED toggle_2019",
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED all_2019",
+        "script_level.level_keys": [
+          "CSD U6 LED all_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED create intro_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light show_2019",
+        "script_level.level_keys": [
+          "CSD U6 light show_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Catch the Mouse_2019",
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app_2019",
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L04 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1_2019",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1_2019",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L05 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button LED prediction_2019",
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED buttonL_2019",
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED toggle buttonL up_2019",
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD onBoardEvent Map_2019",
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lightswitch toggleswitch_2019",
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggle state LED prediction_2019",
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggleswitch state setProp_2019",
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Buttons Map_2019",
+        "script_level.level_keys": [
+          "CSD Board Buttons Map_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer intro_2019",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration_2019",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration buttons_2019",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Buzzer Map_2019",
+        "script_level.level_keys": [
+          "CSD Buzzer Map_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - board event challenge_2019",
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L06 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Demo_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty input_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty dropdown_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty board predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty buzzer_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Map_2019",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 slider intro_2019",
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 frequency_2019",
+        "script_level.level_keys": [
+          "CSD U6 frequency_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 interval_2019",
+        "script_level.level_keys": [
+          "CSD U6 interval_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 change_2019",
+        "script_level.level_keys": [
+          "CSD U6 change_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 get toggle_2019",
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getters debug_2019",
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Event Types_2019",
+        "script_level.level_keys": [
+          "CSD U6 Event Types_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 move motorcycle_2019",
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 design motorcycle_2019",
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 challenge motorcycle_2019",
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L07 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 sensor experiment embedded_2019",
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog sound_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog light_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog light_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog temp_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Sensors Map_2019",
+        "script_level.level_keys": [
+          "CSD Board Sensors Map_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog data_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog data_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog change_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog change_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog threshold_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Polling Events Map_2019",
+        "script_level.level_keys": [
+          "CSD Polling Events Map_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Set Scale Map_2019",
+        "script_level.level_keys": [
+          "CSD Set Scale Map_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rgb 3_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog challenge_2019",
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L08 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emoji race demo_2019",
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar stop_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1.5_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 3_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar conditional_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setScreen_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setProperty_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar buzzer_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar final_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L09 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar demo_2019",
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project stop_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screens_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screen links_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project board events_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions define_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions call_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project finish_2019",
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L10 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays video",
+        "script_level.level_keys": [
+          "CSD U6 arrays video"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays select predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select rainbow_2019",
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 array select days_2019",
+        "script_level.level_keys": [
+          "CSDU6 array select days_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select random_2019",
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select variable_2019",
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays intro_2019",
+        "script_level.level_keys": [
+          "CSD U6 arrays intro_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array multi_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLED on_2019",
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LEDs color_2019",
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds debug_2019",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds intensity_2019",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD colorLed Map_2019",
+        "script_level.level_keys": [
+          "CSD colorLed Map_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds light pattern_2019",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern off_2019",
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern challenge_2019",
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L11 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 circuit playground piano_2019",
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency modification_2019",
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency creation_2019",
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 piano with notes_2019",
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Music_2019",
+        "script_level.level_keys": [
+          "Making Music_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array piano_2019",
+        "script_level.level_keys": [
+          "CSD U6 array piano_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 random array notes_2019",
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 making new arrays_2019",
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-Arrays_2019",
+        "script_level.level_keys": [
+          "CSD-Arrays_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play predict code_2019",
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play songs_2019",
+        "script_level.level_keys": [
+          "CSDU6 play songs_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play null notes_2019",
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDU U6 Playground Sound Board_2019",
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer 2d arrays_2019",
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer.stop_2019",
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L12 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click exit_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop_2019",
+        "script_level.level_keys": [
+          "CSD: For Loop_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print_2019",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop button array_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop list.length_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop images_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop map_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led on_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led off_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led color_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop led color_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led personalize_2019",
+        "script_level.level_keys": [
+          "CSD U6 for loop led personalize_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L13 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Airplane predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 investigate orientation_2019",
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional leds pitch_2019",
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional LEDs roll_2019",
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Accelerometer_2019",
+        "script_level.level_keys": [
+          "The Accelerometer_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 stillness game predict code_2019",
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Pedometer_2019",
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Accelerometer Events_2019",
+        "script_level.level_keys": [
+          "Using Accelerometer Events_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Revisiting the Counter Pattern_2019",
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 goalie_2019",
+        "script_level.level_keys": [
+          "CSD U6 goalie_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt1_2019",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L14 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 params predict_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video_2019",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify clouds_2019",
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify planes_2019",
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params create colors_2019",
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter predict bubbles_2019",
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter modify bugs_2019",
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter create notes_2019",
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser intro_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 3_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 4_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 5_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 1_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 2_2019",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 17,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L15 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit logic video_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit predict_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit LED map_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit pinMode_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createLed_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit multi led_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinkers_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker buttons_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker build_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit button map_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit button map_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike buzzer_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike light_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike final_2019",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L16 TFMD_2019",
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 final intro_2018_2019",
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6_2019",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Physical Computing Post-Project Test",
+        "script_level.level_keys": [
+          "CSD Physical Computing Post-Project Test"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-2020.script_json
+++ b/dashboard/config/scripts_json/csd6-2020.script_json
@@ -1,0 +1,7114 @@
+{
+  "script": {
+    "name": "csd6-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "applab",
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/csd-20/unit6/{LESSON}",
+      "version_year": "2020",
+      "curriculum_umbrella": "CSD",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/unit6/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csd"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csd-20/unit6/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csd-20/unit6/standards/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csd-20/unit6/code/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csd6",
+    "seeding_key": {
+      "script.name": "csd6-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Innovations in Computing",
+      "name": "Innovations in Computing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Designing Screens with Code",
+      "name": "Designing Screens with Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Input Unplugged",
+      "name": "Input Unplugged",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Board Events",
+      "name": "Board Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Getting Properties",
+      "name": "Getting Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "The Program Design Process",
+      "name": "The Program Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Project: Make a Game",
+      "name": "Project: Make a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Arrays and Color LEDs",
+      "name": "Arrays and Color LEDs",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Making Music",
+      "name": "Making Music",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Arrays and For Loops",
+      "name": "Arrays and For Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Accelerometer",
+      "name": "Accelerometer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Functions with Parameters",
+      "name": "Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Circuits and Physical Prototypes",
+      "name": "Circuits and Physical Prototypes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "Post-Project Test",
+      "name": "Post-Project Test",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "key": "CS Discoveries Post Course survey",
+      "name": "CS Discoveries Post Course survey",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L01 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018_2019_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 Innovation_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L02 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty predict app_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Text_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy click_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy random_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden 2_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine example_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 1_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 2_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 3_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 4_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L03 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 test LED_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 test LED_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 predict LED button_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 add LED button_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 LED toggle_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED all_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 LED all_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018_2019_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 LED create intro_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light show_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 light show_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 Catch the Mouse_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 create LED app_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 create LED app 2_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L04 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L05 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - button LED prediction_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - LED buttonL_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - LED toggle buttonL up_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - lightswitch toggleswitch_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - toggle state LED prediction_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - toggleswitch state setProp_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer intro_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration buttons_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - board event challenge_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L06 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Demo_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getProperty input_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getProperty dropdown_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getProperty board predict_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getProperty buzzer_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 slider intro_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 frequency_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 frequency_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 interval_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 interval_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 change_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 change_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 get toggle_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 getters debug_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 move motorcycle_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 design motorcycle_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 challenge motorcycle_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L07 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 sensor experiment embedded_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog sound_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog light_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog light_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog temp_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog predict_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog data_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog data_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog change_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog change_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog threshold_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 1_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 2_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog rgb 3_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 analog challenge_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L08 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 emoji race demo_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018_2019_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar stop_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1.5_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 2_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 1_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 2_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 3_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar conditional_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setScreen_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setProperty_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar buzzer_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar final_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L09 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 tugowar demo_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018_2019_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project stop_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project screens_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project screen links_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project board events_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project functions define_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project functions call_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 game project finish_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L10 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays video_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 arrays video_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 arrays select predict_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 arrays select rainbow_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 array select days_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 array select days_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 arrays select random_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 arrays select variable_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018_2019_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 array multi_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds predict_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 colorLED on_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 LEDs color_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds debug_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds intensity_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds light pattern_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 light pattern off_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge Levels"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 light pattern challenge_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L11 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 circuit playground piano_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 frequency modification_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 frequency creation_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 piano with notes_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array piano_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 array piano_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 random array notes_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 making new arrays_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 play predict code_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play songs_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 play songs_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 play null notes_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CDU U6 Playground Sound Board_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 buzzer 2d arrays_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 buzzer.stop_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L12 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop click predict_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop click exit_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD: For Loop_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop button array_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop list.length_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop images_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop map_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop led on_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop led off_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led color_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop led color_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led personalize_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 for loop led personalize_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L13 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 Airplane predict_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 investigate orientation_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 directional leds pitch_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 directional LEDs roll_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 stillness game predict code_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 Pedometer_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 goalie_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 goalie_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt1_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt 2_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L14 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params predict_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params predict_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params modify clouds_2020"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params modify planes_2020"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params create colors_2020"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 iter predict bubbles_2020"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 iter modify bugs_2020"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 iter create notes_2020"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser intro_2020"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 1_2020"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 2_2020"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 3_2020"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 4_2020"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 5_2020"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2020"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 1_2020"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2020"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 17,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 2_2020"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L15 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2020"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit logic video_2020"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit predict_2020"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit pinMode_2020"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit createLed_2020"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit multi led_2020"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinkers_2020"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2020"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker buttons_2020"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018_2019_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker build_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton_2020"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike buzzer_2020"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike light_2020"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike final_2020"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2020"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6L16 TFMD_2020"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018_2019_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD U6 final intro_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2020"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1_2020"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2_2020"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3_2020"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5_2020"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4_2020"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6_2020"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Physical Computing Post-Project Test_2020"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "CSD Physical Computing Post-Project Test_2020"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-intro-2019_2020"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      },
+      "level_keys": [
+        "csd-post-survey-levelgroup_2019_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L01 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSDU6 Innovation_2018_2019_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Innovations in Computing",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L02 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty predict app_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Text_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy click_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy random_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine example_2020",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 3_2020",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 4_2020",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video_2020",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test_2020",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 test LED_2020",
+        "script_level.level_keys": [
+          "CSD U6 test LED_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 predict LED button_2020",
+        "script_level.level_keys": [
+          "CSD U6 predict LED button_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 add LED button_2020",
+        "script_level.level_keys": [
+          "CSD U6 add LED button_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED toggle_2020",
+        "script_level.level_keys": [
+          "CSD U6 LED toggle_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED all_2020",
+        "script_level.level_keys": [
+          "CSD U6 LED all_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED create intro_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 LED create intro_2018_2019_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light show_2020",
+        "script_level.level_keys": [
+          "CSD U6 light show_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Catch the Mouse_2020",
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app_2020",
+        "script_level.level_keys": [
+          "CSD U6 create LED app_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L04 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1_2020",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1_2020",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L05 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button LED prediction_2020",
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED buttonL_2020",
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED toggle buttonL up_2020",
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lightswitch toggleswitch_2020",
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggle state LED prediction_2020",
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggleswitch state setProp_2020",
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer intro_2020",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration_2020",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration buttons_2020",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - board event challenge_2020",
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L06 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Demo_2020",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty input_2020",
+        "script_level.level_keys": [
+          "CSD U6 getProperty input_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty dropdown_2020",
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty board predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty buzzer_2020",
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 slider intro_2020",
+        "script_level.level_keys": [
+          "CSD U6 slider intro_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 frequency_2020",
+        "script_level.level_keys": [
+          "CSD U6 frequency_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 interval_2020",
+        "script_level.level_keys": [
+          "CSD U6 interval_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 change_2020",
+        "script_level.level_keys": [
+          "CSD U6 change_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 get toggle_2020",
+        "script_level.level_keys": [
+          "CSD U6 get toggle_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getters debug_2020",
+        "script_level.level_keys": [
+          "CSD U6 getters debug_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 move motorcycle_2020",
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 design motorcycle_2020",
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 challenge motorcycle_2020",
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L07 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 sensor experiment embedded_2020",
+        "script_level.level_keys": [
+          "CSD U6 sensor experiment embedded_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog sound_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog sound_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog light_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog light_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog temp_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog temp_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog predict_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog data_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog data_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog change_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog change_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog threshold_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog threshold_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rgb 3_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog challenge_2020",
+        "script_level.level_keys": [
+          "CSD U6 analog challenge_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L08 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emoji race demo_2020",
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar stop_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop_2018_2019_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1.5_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 3_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar conditional_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setScreen_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setProperty_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar buzzer_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar final_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar final_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L09 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar demo_2020",
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project stop_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project stop_2018_2019_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screens_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project screens_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screen links_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project screen links_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project board events_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project board events_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions define_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project functions define_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions call_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project functions call_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project finish_2020",
+        "script_level.level_keys": [
+          "CSD U6 game project finish_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1_2018_2019_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L10 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays video_2020",
+        "script_level.level_keys": [
+          "CSD U6 arrays video_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays select predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select rainbow_2020",
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 array select days_2020",
+        "script_level.level_keys": [
+          "CSDU6 array select days_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select random_2020",
+        "script_level.level_keys": [
+          "CSDU6 arrays select random_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select variable_2020",
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array multi_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 array multi_2018_2019_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLED on_2020",
+        "script_level.level_keys": [
+          "CSD U6 colorLED on_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LEDs color_2020",
+        "script_level.level_keys": [
+          "CSD U6 LEDs color_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds debug_2020",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds intensity_2020",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds light pattern_2020",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern off_2020",
+        "script_level.level_keys": [
+          "CSD U6 light pattern off_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern challenge_2020",
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and Color LEDs",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L11 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 circuit playground piano_2020",
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency modification_2020",
+        "script_level.level_keys": [
+          "CSDU6 frequency modification_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency creation_2020",
+        "script_level.level_keys": [
+          "CSDU6 frequency creation_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 piano with notes_2020",
+        "script_level.level_keys": [
+          "CSDU6 piano with notes_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array piano_2020",
+        "script_level.level_keys": [
+          "CSD U6 array piano_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 random array notes_2020",
+        "script_level.level_keys": [
+          "CSD U6 random array notes_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 making new arrays_2020",
+        "script_level.level_keys": [
+          "CSDU6 making new arrays_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play predict code_2020",
+        "script_level.level_keys": [
+          "CSDU6 play predict code_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play songs_2020",
+        "script_level.level_keys": [
+          "CSDU6 play songs_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play null notes_2020",
+        "script_level.level_keys": [
+          "CSDU6 play null notes_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDU U6 Playground Sound Board_2020",
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer 2d arrays_2020",
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer.stop_2020",
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L12 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click exit_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop_2020",
+        "script_level.level_keys": [
+          "CSD: For Loop_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print_2020",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop button array_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop button array_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop list.length_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop images_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop images_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop map_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop map_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led on_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop led on_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led off_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop led off_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led color_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop led color_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led personalize_2020",
+        "script_level.level_keys": [
+          "CSD U6 for loop led personalize_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L13 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Airplane predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 investigate orientation_2020",
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional leds pitch_2020",
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional LEDs roll_2020",
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 stillness game predict code_2020",
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Pedometer_2020",
+        "script_level.level_keys": [
+          "CSD U6 Pedometer_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 goalie_2020",
+        "script_level.level_keys": [
+          "CSD U6 goalie_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt1_2020",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L14 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 params predict_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video_2020",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify clouds_2020",
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify planes_2020",
+        "script_level.level_keys": [
+          "CSD U6 params modify planes_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params create colors_2020",
+        "script_level.level_keys": [
+          "CSD U6 params create colors_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter predict bubbles_2020",
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter modify bugs_2020",
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter create notes_2020",
+        "script_level.level_keys": [
+          "CSD U6 iter create notes_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser intro_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 3_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 4_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 5_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 1_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1_2020"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 2_2020",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2_2020"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 17,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L15 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit logic video_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video_2020"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit predict_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit predict_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit pinMode_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createLed_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit multi led_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinkers_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker buttons_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons_2020"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker build_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build_2018_2019_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike buzzer_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike light_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike final_2020",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L16 TFMD_2020",
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD_2020"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 final intro_2018_2019_2020",
+        "script_level.level_keys": [
+          "CSD U6 final intro_2018_2019_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1_2020"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6_2020",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019_2020",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2_2018_2019_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Physical Computing Post-Project Test_2020",
+        "script_level.level_keys": [
+          "CSD Physical Computing Post-Project Test_2020"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Post-Project Test",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-intro-2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-intro-2019_2020"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-post-survey-levelgroup_2019_2020",
+        "script_level.level_keys": [
+          "csd-post-survey-levelgroup_2019_2020"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csd6-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csd6-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csd6-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd6-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 6 Deeper Learning Reflections",
+      "name": "Complete Unit 6 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "csd6dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "csd6dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      },
+      "level_keys": [
+        "csd6dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-q1",
+        "script_level.level_keys": [
+          "csd6dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-q2",
+        "script_level.level_keys": [
+          "csd6dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-q3",
+        "script_level.level_keys": [
+          "csd6dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-dlp.script_json
+++ b/dashboard/config/scripts_json/csd6-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csd6-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd6-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 6 Deeper Learning Reflections",
+      "name": "Complete Unit 6 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "csd deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "csd6dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "csd6dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd6dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      },
+      "level_keys": [
+        "csd6dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline",
+        "script_level.level_keys": [
+          "csd deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csd",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-lessons",
+        "script_level.level_keys": [
+          "csd6dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-tools",
+        "script_level.level_keys": [
+          "csd6dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd6dlp-assessment",
+        "script_level.level_keys": [
+          "csd6dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 6 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csd6-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-draft.script_json
+++ b/dashboard/config/scripts_json/csd6-draft.script_json
@@ -1,0 +1,7749 @@
+{
+  "script": {
+    "name": "csd6-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "applab",
+        "gamelab",
+        "weblab"
+      ],
+      "lesson_extras_available": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd6-draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Computing Innovations",
+      "name": "Computing Innovations",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Designing Screens with Code",
+      "name": "Designing Screens with Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Input Unplugged",
+      "name": "Input Unplugged",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Board Events",
+      "name": "Board Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Getting Properties",
+      "name": "Getting Properties",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "The Program Design Process",
+      "name": "The Program Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Project: Make a Game",
+      "name": "Project: Make a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Arrays",
+      "name": "Arrays",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Making Music",
+      "name": "Making Music",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Arrays and For Loops",
+      "name": "Arrays and For Loops",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Accelerometer",
+      "name": "Accelerometer",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Functions with Parameters",
+      "name": "Functions with Parameters",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Circuits and Physical Prototypes",
+      "name": "Circuits and Physical Prototypes",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L01 TFMD"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 Innovation"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L02 TFMD"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Map"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty predict app"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty Text"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy click"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty xy random"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events and Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 setProperty hidden 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine example"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Building an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emotion machine 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L03 TFMD"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 hardware software video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 hardware software video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD LEDs Map"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 test LED"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 test LED"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 predict LED button"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 predict LED button"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 add LED button"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 add LED button"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED toggle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 LED toggle"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED all"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 LED all"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LED create intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 LED create intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light show"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 light show"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Catch the Mouse"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 create LED app"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "LED Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 create LED app 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L04 TFMD"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L05 TFMD"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD onBoardEvent Map"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - button LED prediction"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - LED buttonL"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - LED toggle buttonL up"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD Board Buttons Map"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - lightswitch toggleswitch"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - toggle state LED prediction"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - toggleswitch state setProp"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD Buzzer Map"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer intro"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "The Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - buzzer duration buttons"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - board event challenge"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L06 TFMD"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Map"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty Demo"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty input"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty input"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty dropdown"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty board predict"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getProperty buzzer"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 slider intro"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 slider intro"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 frequency"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 frequency"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sliders"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 interval"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 interval"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Event Types"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Event Types"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 change"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 change"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 get toggle"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 get toggle"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Change"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 getters debug"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 getters debug"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 move motorcycle"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Motorcycle"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 design motorcycle"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 challenge motorcycle"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L07 TFMD"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - sensors experiment"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD Board Sensors Map"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog sound"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog sound"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog light"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog light"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog temp"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog temp"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reading Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog predict"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog predict"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD Polling Events Map"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog data"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog data"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog change"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog change"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensor Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog threshold"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog threshold"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD Set Scale Map"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 1"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog rbg 2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Sensors to Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog rgb 3"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 analog challenge"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 analog challenge"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L08 TFMD"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 emoji race demo"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar stop"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 1.5"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar design 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar variables 3"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar conditional"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setScreen"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar setProperty"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Checking for a Winner"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar buzzer"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar final"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar final"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L09 TFMD"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 tugowar demo"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project stop"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project stop"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screens"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project screens"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project screen links"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project screen links"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project board events"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project board events"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions define"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project functions define"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project functions call"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project functions call"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 game project finish"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 game project finish"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L10 TFMD"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays intro"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 arrays intro"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 arrays select predict"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 arrays select rainbow"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 array select days"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 array select days"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select random"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 arrays select random"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 arrays select variable"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array multi"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 array multi"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD colorLed Map"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds predict"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLED on"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 colorLED on"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 LEDs color"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 LEDs color"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds debug"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds intensity"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 colorLeds light pattern"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Show"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern off"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 light pattern off"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge Levels"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 light pattern challenge"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L11 TFMD"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 circuit playground piano"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency modification"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 frequency modification"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 frequency creation"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 frequency creation"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Music"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "Making Music"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Playing with Notes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 piano with notes"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 piano with notes"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-Arrays"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD-Arrays"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 array piano"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 array piano"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 random array notes"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 random array notes"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Musical Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 making new arrays"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 making new arrays"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play predict code"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 play predict code"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play songs"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 play songs"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 play null notes"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 play null notes"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Songs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CDU U6 Playground Sound Board"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 buzzer 2d arrays"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 buzzer.stop"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L12 TFMD"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop click predict"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Programs that Repeat"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop click exit"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop map"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop map"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD: For Loop"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop button array"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop button array"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop list.length"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop images"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop images"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led on"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led on"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led off"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led off"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 functions paramters video"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function call"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led function finish"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 2"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 for loop led bonus 3"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L13 TFMD"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Accelerometer"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "The Accelerometer"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Airplane predict"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 investigate orientation"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 directional leds pitch"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Orientation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 directional LEDs roll"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Accelerometer Events"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "Using Accelerometer Events"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 stillness game predict code"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Pedometer"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Pedometer"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "Revisiting the Counter Pattern"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 goalie"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 goalie"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt1"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Accelerometer Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 Driver pt 2"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L14 TFMD"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params predict"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params predict"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params modify clouds"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params modify planes"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params modify planes"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params create colors"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params create colors"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 iter predict bubbles"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 iter modify bugs"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Iteration and Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 iter create notes"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 iter create notes"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser intro"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 1"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 2"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 3"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 4"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser 5"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 1"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Star Chaser"
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 params starchaser challenge 2"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L15 TFMD"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit logic video"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit predict"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit predict"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit LED map"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit pinMode"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit createLed"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit multi led"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinkers"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker buttons"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Smart Bike - Blinkers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike blinker build"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit button map"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit button map"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Button Circuits"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton scratch"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit createButton scratch"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike buzzer"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike light"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish the Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 16,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 circuit smart bike final"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6L16 TFMD"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 final intro"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSD U6 final intro"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "User Interface"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Input and Output"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Finishing Touches"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L01 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L01 TFMD"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation",
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L02 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L02 TFMD"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Map",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Map"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty predict app",
+        "script_level.level_keys": [
+          "CSD U6 setProperty predict app"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty Text",
+        "script_level.level_keys": [
+          "CSD U6 setProperty Text"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy click",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy click"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty xy random",
+        "script_level.level_keys": [
+          "CSD U6 setProperty xy random"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 setProperty hidden 2",
+        "script_level.level_keys": [
+          "CSD U6 setProperty hidden 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine example",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine example"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 1",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 2",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 3",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emotion machine 4",
+        "script_level.level_keys": [
+          "CSD U6 emotion machine 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Designing Screens with Code",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L03 TFMD"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 hardware software video",
+        "script_level.level_keys": [
+          "CSD U6 hardware software video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD LEDs Map",
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 test LED",
+        "script_level.level_keys": [
+          "CSD U6 test LED"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 predict LED button",
+        "script_level.level_keys": [
+          "CSD U6 predict LED button"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 add LED button",
+        "script_level.level_keys": [
+          "CSD U6 add LED button"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED toggle",
+        "script_level.level_keys": [
+          "CSD U6 LED toggle"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED all",
+        "script_level.level_keys": [
+          "CSD U6 LED all"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LED create intro",
+        "script_level.level_keys": [
+          "CSD U6 LED create intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light show",
+        "script_level.level_keys": [
+          "CSD U6 light show"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Catch the Mouse",
+        "script_level.level_keys": [
+          "CSD U6 Catch the Mouse"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app",
+        "script_level.level_keys": [
+          "CSD U6 create LED app"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 create LED app 2",
+        "script_level.level_keys": [
+          "CSD U6 create LED app 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L04 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L04 TFMD"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L05 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L05 TFMD"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD onBoardEvent Map",
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button LED prediction",
+        "script_level.level_keys": [
+          "CSDU6 - button LED prediction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED buttonL",
+        "script_level.level_keys": [
+          "CSDU6 - LED buttonL"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - LED toggle buttonL up",
+        "script_level.level_keys": [
+          "CSDU6 - LED toggle buttonL up"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Buttons Map",
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lightswitch toggleswitch",
+        "script_level.level_keys": [
+          "CSDU6 - lightswitch toggleswitch"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggle state LED prediction",
+        "script_level.level_keys": [
+          "CSDU6 - toggle state LED prediction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - toggleswitch state setProp",
+        "script_level.level_keys": [
+          "CSDU6 - toggleswitch state setProp"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Buzzer Map",
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer intro",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer intro"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 12,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - buzzer duration buttons",
+        "script_level.level_keys": [
+          "CSDU6 - buzzer duration buttons"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 13,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - board event challenge",
+        "script_level.level_keys": [
+          "CSDU6 - board event challenge"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 14,
+        "lesson.key": "Board Events",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L06 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L06 TFMD"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Map",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Map"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty Demo",
+        "script_level.level_keys": [
+          "CSD U6 getProperty Demo"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty input",
+        "script_level.level_keys": [
+          "CSD U6 getProperty input"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty dropdown",
+        "script_level.level_keys": [
+          "CSD U6 getProperty dropdown"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty board predict",
+        "script_level.level_keys": [
+          "CSD U6 getProperty board predict"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getProperty buzzer",
+        "script_level.level_keys": [
+          "CSD U6 getProperty buzzer"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 slider intro",
+        "script_level.level_keys": [
+          "CSD U6 slider intro"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 frequency",
+        "script_level.level_keys": [
+          "CSD U6 frequency"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 interval",
+        "script_level.level_keys": [
+          "CSD U6 interval"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Event Types",
+        "script_level.level_keys": [
+          "CSD U6 Event Types"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 change",
+        "script_level.level_keys": [
+          "CSD U6 change"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 get toggle",
+        "script_level.level_keys": [
+          "CSD U6 get toggle"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 getters debug",
+        "script_level.level_keys": [
+          "CSD U6 getters debug"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 move motorcycle",
+        "script_level.level_keys": [
+          "CSD U6 move motorcycle"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 design motorcycle",
+        "script_level.level_keys": [
+          "CSD U6 design motorcycle"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 challenge motorcycle",
+        "script_level.level_keys": [
+          "CSD U6 challenge motorcycle"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Getting Properties",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L07 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L07 TFMD"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors experiment",
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Sensors Map",
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog sound",
+        "script_level.level_keys": [
+          "CSD U6 analog sound"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog light",
+        "script_level.level_keys": [
+          "CSD U6 analog light"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog temp",
+        "script_level.level_keys": [
+          "CSD U6 analog temp"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog predict",
+        "script_level.level_keys": [
+          "CSD U6 analog predict"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Polling Events Map",
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog data",
+        "script_level.level_keys": [
+          "CSD U6 analog data"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog change",
+        "script_level.level_keys": [
+          "CSD U6 analog change"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog threshold",
+        "script_level.level_keys": [
+          "CSD U6 analog threshold"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Set Scale Map",
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 1",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rbg 2",
+        "script_level.level_keys": [
+          "CSD U6 analog rbg 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog rgb 3",
+        "script_level.level_keys": [
+          "CSD U6 analog rgb 3"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 analog challenge",
+        "script_level.level_keys": [
+          "CSD U6 analog challenge"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 16,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L08 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L08 TFMD"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 emoji race demo",
+        "script_level.level_keys": [
+          "CSD U6 emoji race demo"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar stop",
+        "script_level.level_keys": [
+          "CSD U6 tugowar stop"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 1.5",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 1.5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar design 2",
+        "script_level.level_keys": [
+          "CSD U6 tugowar design 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 6,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 1",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 7,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 2",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 8,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar variables 3",
+        "script_level.level_keys": [
+          "CSD U6 tugowar variables 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 9,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar conditional",
+        "script_level.level_keys": [
+          "CSD U6 tugowar conditional"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 10,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setScreen",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setScreen"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 11,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar setProperty",
+        "script_level.level_keys": [
+          "CSD U6 tugowar setProperty"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 12,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar buzzer",
+        "script_level.level_keys": [
+          "CSD U6 tugowar buzzer"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 13,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar final",
+        "script_level.level_keys": [
+          "CSD U6 tugowar final"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 14,
+        "lesson.key": "The Program Design Process",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L09 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L09 TFMD"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 tugowar demo",
+        "script_level.level_keys": [
+          "CSD U6 tugowar demo"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project stop",
+        "script_level.level_keys": [
+          "CSD U6 game project stop"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screens",
+        "script_level.level_keys": [
+          "CSD U6 game project screens"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project screen links",
+        "script_level.level_keys": [
+          "CSD U6 game project screen links"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project board events",
+        "script_level.level_keys": [
+          "CSD U6 game project board events"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions define",
+        "script_level.level_keys": [
+          "CSD U6 game project functions define"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project functions call",
+        "script_level.level_keys": [
+          "CSD U6 game project functions call"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 game project finish",
+        "script_level.level_keys": [
+          "CSD U6 game project finish"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Project: Make a Game",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L10 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L10 TFMD"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays intro",
+        "script_level.level_keys": [
+          "CSD U6 arrays intro"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 arrays select predict",
+        "script_level.level_keys": [
+          "CSD U6 arrays select predict"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select rainbow",
+        "script_level.level_keys": [
+          "CSDU6 arrays select rainbow"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 array select days",
+        "script_level.level_keys": [
+          "CSDU6 array select days"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select random",
+        "script_level.level_keys": [
+          "CSDU6 arrays select random"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 arrays select variable",
+        "script_level.level_keys": [
+          "CSDU6 arrays select variable"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array multi",
+        "script_level.level_keys": [
+          "CSD U6 array multi"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD colorLed Map",
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 9,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds predict",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds predict"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 10,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLED on",
+        "script_level.level_keys": [
+          "CSD U6 colorLED on"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 11,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 LEDs color",
+        "script_level.level_keys": [
+          "CSD U6 LEDs color"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 12,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds debug",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds debug"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 13,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds intensity",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds intensity"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 14,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 colorLeds light pattern",
+        "script_level.level_keys": [
+          "CSD U6 colorLeds light pattern"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 15,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern off",
+        "script_level.level_keys": [
+          "CSD U6 light pattern off"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 16,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 light pattern challenge",
+        "script_level.level_keys": [
+          "CSD U6 light pattern challenge"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 17,
+        "lesson.key": "Arrays",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L11 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L11 TFMD"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 circuit playground piano",
+        "script_level.level_keys": [
+          "CSDU6 circuit playground piano"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency modification",
+        "script_level.level_keys": [
+          "CSDU6 frequency modification"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 3,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 frequency creation",
+        "script_level.level_keys": [
+          "CSDU6 frequency creation"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 4,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Music",
+        "script_level.level_keys": [
+          "Making Music"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 5,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 piano with notes",
+        "script_level.level_keys": [
+          "CSDU6 piano with notes"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 6,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-Arrays",
+        "script_level.level_keys": [
+          "CSD-Arrays"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 7,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 array piano",
+        "script_level.level_keys": [
+          "CSD U6 array piano"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 8,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 random array notes",
+        "script_level.level_keys": [
+          "CSD U6 random array notes"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 9,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 making new arrays",
+        "script_level.level_keys": [
+          "CSDU6 making new arrays"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 10,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play predict code",
+        "script_level.level_keys": [
+          "CSDU6 play predict code"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 11,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play songs",
+        "script_level.level_keys": [
+          "CSDU6 play songs"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 12,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 play null notes",
+        "script_level.level_keys": [
+          "CSDU6 play null notes"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 13,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDU U6 Playground Sound Board",
+        "script_level.level_keys": [
+          "CDU U6 Playground Sound Board"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 14,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer 2d arrays",
+        "script_level.level_keys": [
+          "CSDU6 buzzer 2d arrays"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 15,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer.stop",
+        "script_level.level_keys": [
+          "CSDU6 buzzer.stop"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 16,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L12 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L12 TFMD"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click predict",
+        "script_level.level_keys": [
+          "CSD U6 for loop click predict"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop click exit",
+        "script_level.level_keys": [
+          "CSD U6 for loop click exit"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop map",
+        "script_level.level_keys": [
+          "CSD U6 for loop map"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop",
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop button array",
+        "script_level.level_keys": [
+          "CSD U6 for loop button array"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop list.length",
+        "script_level.level_keys": [
+          "CSD U6 for loop list.length"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop images",
+        "script_level.level_keys": [
+          "CSD U6 for loop images"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led on",
+        "script_level.level_keys": [
+          "CSD U6 for loop led on"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led off",
+        "script_level.level_keys": [
+          "CSD U6 for loop led off"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 functions paramters video",
+        "script_level.level_keys": [
+          "CSD U6 functions paramters video"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function call",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function call"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led function finish",
+        "script_level.level_keys": [
+          "CSD U6 for loop led function finish"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 1",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 16,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 2",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 17,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 for loop led bonus 3",
+        "script_level.level_keys": [
+          "CSD U6 for loop led bonus 3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 18,
+        "lesson.key": "Arrays and For Loops",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L13 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L13 TFMD"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Accelerometer",
+        "script_level.level_keys": [
+          "The Accelerometer"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Airplane predict",
+        "script_level.level_keys": [
+          "CSD U6 Airplane predict"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 investigate orientation",
+        "script_level.level_keys": [
+          "CSD U6 investigate orientation"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional leds pitch",
+        "script_level.level_keys": [
+          "CSD U6 directional leds pitch"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 directional LEDs roll",
+        "script_level.level_keys": [
+          "CSD U6 directional LEDs roll"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Accelerometer Events",
+        "script_level.level_keys": [
+          "Using Accelerometer Events"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 stillness game predict code",
+        "script_level.level_keys": [
+          "CSD U6 stillness game predict code"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Pedometer",
+        "script_level.level_keys": [
+          "CSD U6 Pedometer"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Revisiting the Counter Pattern",
+        "script_level.level_keys": [
+          "Revisiting the Counter Pattern"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 goalie",
+        "script_level.level_keys": [
+          "CSD U6 goalie"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt1",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt1"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 Driver pt 2",
+        "script_level.level_keys": [
+          "CSD U6 Driver pt 2"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "Accelerometer",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L14 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L14 TFMD"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params predict",
+        "script_level.level_keys": [
+          "CSD U6 params predict"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify clouds",
+        "script_level.level_keys": [
+          "CSD U6 params modify clouds"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params modify planes",
+        "script_level.level_keys": [
+          "CSD U6 params modify planes"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params create colors",
+        "script_level.level_keys": [
+          "CSD U6 params create colors"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter predict bubbles",
+        "script_level.level_keys": [
+          "CSD U6 iter predict bubbles"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter modify bugs",
+        "script_level.level_keys": [
+          "CSD U6 iter modify bugs"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 iter create notes",
+        "script_level.level_keys": [
+          "CSD U6 iter create notes"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser intro",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser intro"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 1",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 2",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 3",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 4",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 4"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser 5",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser 5"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 1",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 params starchaser challenge 2",
+        "script_level.level_keys": [
+          "CSD U6 params starchaser challenge 2"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 16,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L15 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L15 TFMD"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 1,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit logic video",
+        "script_level.level_keys": [
+          "CSD U6 circuit logic video"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 2,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit predict",
+        "script_level.level_keys": [
+          "CSD U6 circuit predict"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 3,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit LED map",
+        "script_level.level_keys": [
+          "CSD U6 circuit LED map"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 4,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit pinMode",
+        "script_level.level_keys": [
+          "CSD U6 circuit pinMode"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 5,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createLed",
+        "script_level.level_keys": [
+          "CSD U6 circuit createLed"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 6,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit multi led",
+        "script_level.level_keys": [
+          "CSD U6 circuit multi led"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 7,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinkers",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinkers"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 8,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker buttons",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker buttons"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 9,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike blinker build",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike blinker build"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 10,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit button map",
+        "script_level.level_keys": [
+          "CSD U6 circuit button map"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 11,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 12,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit createButton scratch",
+        "script_level.level_keys": [
+          "CSD U6 circuit createButton scratch"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 13,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike buzzer",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike buzzer"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 14,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike light",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike light"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 15,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 circuit smart bike final",
+        "script_level.level_keys": [
+          "CSD U6 circuit smart bike final"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 16,
+        "lesson.key": "Circuits and Physical Prototypes",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L16 TFMD",
+        "script_level.level_keys": [
+          "CSD U6L16 TFMD"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 final intro",
+        "script_level.level_keys": [
+          "CSD U6 final intro"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 8,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 9,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csd6-old.script_json
+++ b/dashboard/config/scripts_json/csd6-old.script_json
@@ -1,0 +1,5544 @@
+{
+  "script": {
+    "name": "csd6-old",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "student_detail_progress_view": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "applab"
+      ],
+      "lesson_extras_available": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csd6-old"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csd6_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming with Hardware"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "csd6_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Physical Prototypes"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Computing Innovations",
+      "name": "Computing Innovations",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Input Unplugged",
+      "name": "Input Unplugged",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Event Types",
+      "name": "Event Types",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Getters and Setters",
+      "name": "Getters and Setters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Lists",
+      "name": "Lists",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Lights",
+      "name": "Lights",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "For Loops",
+      "name": "For Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Lists and For Loops",
+      "name": "Lists and For Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Timed Loops",
+      "name": "Timed Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Project: Board Output",
+      "name": "Project: Board Output",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Physical Input",
+      "name": "Physical Input",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Sensor Applications",
+      "name": "Sensor Applications",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "key": "Project: Prototype an Innovation",
+      "name": "Project: Prototype an Innovation",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 Innovation"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 GameLab Input 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Input Examples"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 AppLab Input 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6L03 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD U6L03 Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Review: Design Mode, IDs, and Events"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Review: Design Mode, IDs, and Events"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Review Events"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Review Events"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Creating Variables In App Lab"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Creating Variables In App Lab"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - event type testing"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - event type testing"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD - Getters and Setters"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setScreen"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setScreen"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setText"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - hide show"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getText"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getText"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - dropdown setText"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - dropdown setText"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - get set with text input"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - get set with text input"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber practice"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getNumber practice"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: getText vs getNumber"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: getText vs getNumber"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - getNumber"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: setProperty"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: setProperty"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty first level"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty first level"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty Image"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty Image"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "UI Element Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setProperty"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Review Getters and Setters"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 15,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Stop: Review Getters and Setters"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Input and UI"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 16,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Challenge: Input and UI"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD LEDs Map"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.on"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 LED basics led.on"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics onEvent"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 LED basics onEvent"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.off()"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 LED basics led.off()"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED predict"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 LED predict"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED alarm silent"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 LED alarm silent"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Buzzer Map"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer freq"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 buzzer freq"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer stop"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 buzzer stop"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer alarm"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 buzzer alarm"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Buzzer and LED"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Challenge: Buzzer and LED"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to Lists - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Introduction to Lists - Part 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Lists"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Lists"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - lists - lists 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - lists - lists 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to Lists - Part 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Introduction to Lists - Part 2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Accessing List Items"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Accessing List Items"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using List Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - lists - lists 3"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using List Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - lists - lists 4"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using List Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - Arrays - indexPractice"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using List Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - Arrays - expressionsAsIndexes"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Introduction to Lists - Length"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Introduction to Lists - Length"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: List Length"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: List Length"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding List Length"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - length"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - Arrays - length"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding List Length"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - Arrays - lengthMinus1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding List Length"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - lists - lists 5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Random Button Colors"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Challenge: Random Button Colors"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD colorLed Map"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - song list"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - song list"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - set color"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - set color"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - debug"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - debug"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - toggle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - toggle"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Color LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - intensity"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - intensity"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD - Functions Review"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD - Functions Review"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds -solo light pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds -solo light pattern"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - light pattern off"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6L06 - lists and colorLeds - light pattern off"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Lights Picker"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Challenge: Lights Picker"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loops"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: For Loops"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: For Loop"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 6"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - 6"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict repeat"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict repeat"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to For Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - predict print"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Lists with For Loops"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD: Lists with For Loops"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - 5"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 10"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - 10"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - 1"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - button grid 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - button grid 1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - color buttons"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - color buttons"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - color buttons with for"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - color buttons with for"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Looping Over Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loop - why for"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loop - why for"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Check with Teacher"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "Stop: Check with Teacher"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD - for loop - on off"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD - for loop - on off"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loops and LEDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - for loops - lights picker"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - for loops - lights picker"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 - timed Loop predict for"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD U6 - timed Loop predict for"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Timed Loop Map"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Timed Loop Map"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Timed Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U6 - timed Loop predict timed"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD U6 - timed Loop predict timed"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Timed Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop smiley rand y"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop smiley rand y"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Timed Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop smiley event"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop smiley event"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Timed Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop console.log()"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop console.log()"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop stop board"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop stop board"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and the Board"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random blink"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop random blink"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and the Board"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random sound"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop random sound"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and the Board"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop predict counter"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop predict counter"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Timed For Loop Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Timed For Loop Map"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop for LEDs"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop for LEDs"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random sound exit"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop random sound exit"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Timed Loops and Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop helpers"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop helpers"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - timed loop challenge"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - timed loop challenge"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 exemplar LEDs"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 exemplar LEDs"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project design"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 project design"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project events"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 project events"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project functions"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 project functions"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project output"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 project output"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project finish"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - ch 1 project finish"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch1"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD onBoardEvent Map"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonL"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button screen buttonL"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonR"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button screen buttonR"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Board Buttons Map"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button toggle"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button toggle"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button on off"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button on off"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button up down predict"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button up down predict"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button up down"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button up down"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button check for understanding"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button check for understanding"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button switch"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button switch"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Switch"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button debug"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button debug"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war right button"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war right button"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war left button"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war left button"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War game"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war challenge"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war challenge"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors experiment"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Board Sensors Map"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors sound"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors sound"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors light"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors light"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors temp"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors predict"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors predict"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Set Scale Map"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Displaying Sensor Values"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors rgb part 1"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Displaying Sensor Values"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors rgb part 2"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSD Polling Events Map"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Displaying Sensor Values"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 3"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors rgb part 3"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Displaying Sensor Values"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp f c"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors temp f c"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors challenge"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors challenge"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensor theremin demo"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensor theremin demo"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Theremin Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors theremin 1"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Theremin Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors theremin 2"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Light Theremin Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 3"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors theremin 3"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensor vu meter demo"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensor vu meter demo"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "VU Meter Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors vu meter 1"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "VU Meter Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors vu meter 2"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "VU Meter Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 3"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors vu meter 3"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensor love tester demo"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensor love tester demo"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Love Tester Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors love tester 1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Love Tester Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors love tester 2"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Love Tester Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 3"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensors love tester 3"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensor projects challenge"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - sensor projects challenge"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 1"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 2"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 3"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 4"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 5"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "CSDU6 - final project 6"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      },
+      "level_keys": [
+        "csd-pulse-check-survey-1-levelgroup U6Ch2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Innovation",
+        "script_level.level_keys": [
+          "CSDU6 Innovation"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Computing Innovations",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 GameLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 GameLab Input 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 AppLab Input 1",
+        "script_level.level_keys": [
+          "CSDU6 AppLab Input 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Input Unplugged",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6L03 Overview",
+        "script_level.level_keys": [
+          "CSD U6L03 Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Review: Design Mode, IDs, and Events",
+        "script_level.level_keys": [
+          "CSD Review: Design Mode, IDs, and Events"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Review Events",
+        "script_level.level_keys": [
+          "CSD: Review Events"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Creating Variables In App Lab",
+        "script_level.level_keys": [
+          "CSD: Creating Variables In App Lab"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - event type testing",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - event type testing"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Event Types",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD - Getters and Setters",
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setScreen",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setScreen"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - hide show",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getText"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - dropdown setText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - dropdown setText"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - get set with text input",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - get set with text input"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getNumber practice",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber practice"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: getText vs getNumber",
+        "script_level.level_keys": [
+          "CSD: getText vs getNumber"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - getNumber",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - getNumber"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: setProperty",
+        "script_level.level_keys": [
+          "CSD: setProperty"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty first level",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty first level"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty Image",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty Image"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setProperty",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setProperty"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Review Getters and Setters",
+        "script_level.level_keys": [
+          "Stop: Review Getters and Setters"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 15,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Input and UI",
+        "script_level.level_keys": [
+          "Challenge: Input and UI"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 16,
+        "lesson.key": "Getters and Setters",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD LEDs Map",
+        "script_level.level_keys": [
+          "CSD LEDs Map"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics led.on",
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.on"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics onEvent",
+        "script_level.level_keys": [
+          "CSDU6 LED basics onEvent"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics led.off()",
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.off()"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED predict",
+        "script_level.level_keys": [
+          "CSDU6 LED predict"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED alarm silent",
+        "script_level.level_keys": [
+          "CSDU6 LED alarm silent"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Buzzer Map",
+        "script_level.level_keys": [
+          "CSD Buzzer Map"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer freq",
+        "script_level.level_keys": [
+          "CSDU6 buzzer freq"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer stop",
+        "script_level.level_keys": [
+          "CSDU6 buzzer stop"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer alarm",
+        "script_level.level_keys": [
+          "CSDU6 buzzer alarm"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Buzzer and LED",
+        "script_level.level_keys": [
+          "Challenge: Buzzer and LED"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to Lists - Part 1",
+        "script_level.level_keys": [
+          "CSD: Introduction to Lists - Part 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Lists",
+        "script_level.level_keys": [
+          "CSD: Lists"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lists - lists 1",
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lists - lists 2",
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to Lists - Part 2",
+        "script_level.level_keys": [
+          "CSD: Introduction to Lists - Part 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Accessing List Items",
+        "script_level.level_keys": [
+          "CSD: Accessing List Items"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lists - lists 3",
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lists - lists 4",
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - Arrays - indexPractice",
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - Arrays - expressionsAsIndexes",
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Introduction to Lists - Length",
+        "script_level.level_keys": [
+          "CSD Introduction to Lists - Length"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: List Length",
+        "script_level.level_keys": [
+          "CSD: List Length"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - Arrays - length",
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - length"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - Arrays - lengthMinus1",
+        "script_level.level_keys": [
+          "CSDU6 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - lists - lists 5",
+        "script_level.level_keys": [
+          "CSDU6 - lists - lists 5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Random Button Colors",
+        "script_level.level_keys": [
+          "Challenge: Random Button Colors"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Lists",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD colorLed Map",
+        "script_level.level_keys": [
+          "CSD colorLed Map"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - song list",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - song list"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - set color",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - set color"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - debug",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - debug"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - toggle",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - toggle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - intensity",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - intensity"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD - Functions Review",
+        "script_level.level_keys": [
+          "CSD - Functions Review"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds -solo light pattern",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds -solo light pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6L06 - lists and colorLeds - light pattern off",
+        "script_level.level_keys": [
+          "CSDU6L06 - lists and colorLeds - light pattern off"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Lights Picker",
+        "script_level.level_keys": [
+          "Challenge: Lights Picker"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Lights",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loops",
+        "script_level.level_keys": [
+          "CSD: For Loops"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: For Loop",
+        "script_level.level_keys": [
+          "CSD: For Loop"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - 2",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - 6",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 6"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict repeat",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict repeat"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - predict print",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - predict print"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Lists with For Loops",
+        "script_level.level_keys": [
+          "CSD: Lists with For Loops"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - 5",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 5"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - 10",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 10"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - 1",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - button grid 1",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - button grid 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - color buttons",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - color buttons"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - color buttons with for",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - color buttons with for"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loop - why for",
+        "script_level.level_keys": [
+          "CSDU6 - for loop - why for"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Check with Teacher",
+        "script_level.level_keys": [
+          "Stop: Check with Teacher"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD - for loop - on off",
+        "script_level.level_keys": [
+          "CSD - for loop - on off"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - for loops - lights picker",
+        "script_level.level_keys": [
+          "CSDU6 - for loops - lights picker"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Lists and For Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 - timed Loop predict for",
+        "script_level.level_keys": [
+          "CSD U6 - timed Loop predict for"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Timed Loop Map",
+        "script_level.level_keys": [
+          "CSD Timed Loop Map"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U6 - timed Loop predict timed",
+        "script_level.level_keys": [
+          "CSD U6 - timed Loop predict timed"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop smiley rand y",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop smiley rand y"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop smiley event",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop smiley event"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop console.log()",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop console.log()"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop stop board",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop stop board"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop random blink",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random blink"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop random sound",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random sound"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop predict counter",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop predict counter"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Timed For Loop Map",
+        "script_level.level_keys": [
+          "CSD Timed For Loop Map"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop for LEDs",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop for LEDs"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop random sound exit",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop random sound exit"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop helpers",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop helpers"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - timed loop challenge",
+        "script_level.level_keys": [
+          "CSDU6 - timed loop challenge"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Timed Loops",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 exemplar LEDs",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 exemplar LEDs"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 project design",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project design"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 project events",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project events"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 project functions",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project functions"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 project output",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project output"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - ch 1 project finish",
+        "script_level.level_keys": [
+          "CSDU6 - ch 1 project finish"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch1",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch1"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Project: Board Output",
+        "lesson_group.key": "csd6_1",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD onBoardEvent Map",
+        "script_level.level_keys": [
+          "CSD onBoardEvent Map"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button screen buttonL",
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonL"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button screen buttonR",
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonR"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Buttons Map",
+        "script_level.level_keys": [
+          "CSD Board Buttons Map"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button toggle",
+        "script_level.level_keys": [
+          "CSDU6 - button toggle"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button on off",
+        "script_level.level_keys": [
+          "CSDU6 - button on off"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button up down predict",
+        "script_level.level_keys": [
+          "CSDU6 - button up down predict"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button up down",
+        "script_level.level_keys": [
+          "CSDU6 - button up down"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button check for understanding",
+        "script_level.level_keys": [
+          "CSDU6 - button check for understanding"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button switch",
+        "script_level.level_keys": [
+          "CSDU6 - button switch"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button debug",
+        "script_level.level_keys": [
+          "CSDU6 - button debug"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war right button",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war right button"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war left button",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war left button"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war challenge",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war challenge"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors experiment",
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Board Sensors Map",
+        "script_level.level_keys": [
+          "CSD Board Sensors Map"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors sound",
+        "script_level.level_keys": [
+          "CSDU6 - sensors sound"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors light",
+        "script_level.level_keys": [
+          "CSDU6 - sensors light"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors temp",
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors predict",
+        "script_level.level_keys": [
+          "CSDU6 - sensors predict"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Set Scale Map",
+        "script_level.level_keys": [
+          "CSD Set Scale Map"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors rgb part 1",
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors rgb part 2",
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Polling Events Map",
+        "script_level.level_keys": [
+          "CSD Polling Events Map"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors rgb part 3",
+        "script_level.level_keys": [
+          "CSDU6 - sensors rgb part 3"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 11,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors temp f c",
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp f c"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 12,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors challenge",
+        "script_level.level_keys": [
+          "CSDU6 - sensors challenge"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 13,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensor theremin demo",
+        "script_level.level_keys": [
+          "CSDU6 - sensor theremin demo"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors theremin 1",
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors theremin 2",
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors theremin 3",
+        "script_level.level_keys": [
+          "CSDU6 - sensors theremin 3"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensor vu meter demo",
+        "script_level.level_keys": [
+          "CSDU6 - sensor vu meter demo"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors vu meter 1",
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 1"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors vu meter 2",
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors vu meter 3",
+        "script_level.level_keys": [
+          "CSDU6 - sensors vu meter 3"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensor love tester demo",
+        "script_level.level_keys": [
+          "CSDU6 - sensor love tester demo"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors love tester 1",
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors love tester 2",
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors love tester 3",
+        "script_level.level_keys": [
+          "CSDU6 - sensors love tester 3"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensor projects challenge",
+        "script_level.level_keys": [
+          "CSDU6 - sensor projects challenge"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Sensor Applications",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 1",
+        "script_level.level_keys": [
+          "CSDU6 - final project 1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 2",
+        "script_level.level_keys": [
+          "CSDU6 - final project 2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 3",
+        "script_level.level_keys": [
+          "CSDU6 - final project 3"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 4",
+        "script_level.level_keys": [
+          "CSDU6 - final project 4"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 5",
+        "script_level.level_keys": [
+          "CSDU6 - final project 5"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - final project 6",
+        "script_level.level_keys": [
+          "CSDU6 - final project 6"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-pulse-check-survey-1-levelgroup U6Ch2",
+        "script_level.level_keys": [
+          "csd-pulse-check-survey-1-levelgroup U6Ch2"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Project: Prototype an Innovation",
+        "lesson_group.key": "csd6_2",
+        "script.name": "csd6-old"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csdgraveyard.script_json
+++ b/dashboard/config/scripts_json/csdgraveyard.script_json
@@ -1,0 +1,1007 @@
+{
+  "script": {
+    "name": "csdgraveyard",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csdgraveyard"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Styling with CSS",
+      "name": "Introduction to Styling with CSS",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "key": "External Style Sheets",
+      "name": "External Style Sheets",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "Unit 2 Lesson 7 Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Intro to CSS"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Intro to CSS"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Selector and Property"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Selector and Property"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - p tags"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - p tags"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - head body"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - head body"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - title element in head"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - title element in head"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - body tags"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - body tags"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - text properties"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - text properties"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - font properties"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - font properties"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - image properties"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - image properties"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Stop: Intro to CSS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "Stop: Intro to CSS"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - About Me Page Styling"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - About Me Page Styling"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Brand Book Example"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "Brand Book Example"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 Pick Your Fonts"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 Pick Your Fonts"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 Pick Your Colors"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 Pick Your Colors"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - External Style Sheets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - External Style Sheets"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Link Tag"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Link Tag"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Using Your Font"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Using Your Font"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Developing Brand Style"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Developing Brand Style"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - Separate Content and Style"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - Separate Content and Style"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Divs to break up the page"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Divs to break up the page"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - External Style Sheets"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - External Style Sheets"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Consistent Personal Site Style"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Consistent Personal Site Style"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 Make Your Logo"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 Make Your Logo"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Image as A Link"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Image as A Link"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - Favicon"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - Favicon"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU2 - PW - ESS Final touches"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 15,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      },
+      "level_keys": [
+        "CSDU2 - PW - ESS Final touches"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Lesson 7 Overview",
+        "script_level.level_keys": [
+          "Unit 2 Lesson 7 Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Intro to CSS",
+        "script_level.level_keys": [
+          "CSDU2 - Intro to CSS"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Selector and Property",
+        "script_level.level_keys": [
+          "CSDU2 - Selector and Property"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - p tags",
+        "script_level.level_keys": [
+          "CSDU2 - p tags"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - head body",
+        "script_level.level_keys": [
+          "CSDU2 - head body"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - title element in head",
+        "script_level.level_keys": [
+          "CSDU2 - title element in head"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - body tags",
+        "script_level.level_keys": [
+          "CSDU2 - body tags"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - text properties",
+        "script_level.level_keys": [
+          "CSDU2 - text properties"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - font properties",
+        "script_level.level_keys": [
+          "CSDU2 - font properties"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - image properties",
+        "script_level.level_keys": [
+          "CSDU2 - image properties"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Stop: Intro to CSS",
+        "script_level.level_keys": [
+          "Stop: Intro to CSS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - About Me Page Styling",
+        "script_level.level_keys": [
+          "CSDU2 - About Me Page Styling"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Styling with CSS",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Brand Book Example",
+        "script_level.level_keys": [
+          "Brand Book Example"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 Pick Your Fonts",
+        "script_level.level_keys": [
+          "CSDU2 Pick Your Fonts"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 Pick Your Colors",
+        "script_level.level_keys": [
+          "CSDU2 Pick Your Colors"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - External Style Sheets",
+        "script_level.level_keys": [
+          "CSDU2 - External Style Sheets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Link Tag",
+        "script_level.level_keys": [
+          "CSDU2 - Link Tag"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Using Your Font",
+        "script_level.level_keys": [
+          "CSDU2 - Using Your Font"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Developing Brand Style",
+        "script_level.level_keys": [
+          "CSDU2 - Developing Brand Style"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - Separate Content and Style",
+        "script_level.level_keys": [
+          "CSDU2 - Separate Content and Style"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Divs to break up the page",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Divs to break up the page"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - External Style Sheets",
+        "script_level.level_keys": [
+          "CSDU2 - PW - External Style Sheets"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Consistent Personal Site Style",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Consistent Personal Site Style"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 Make Your Logo",
+        "script_level.level_keys": [
+          "CSDU2 Make Your Logo"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Image as A Link",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Image as A Link"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - Favicon",
+        "script_level.level_keys": [
+          "CSDU2 - PW - Favicon"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU2 - PW - ESS Final touches",
+        "script_level.level_keys": [
+          "CSDU2 - PW - ESS Final touches"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 15,
+        "lesson.key": "External Style Sheets",
+        "lesson_group.key": "",
+        "script.name": "csdgraveyard"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csdnovice.script_json
+++ b/dashboard/config/scripts_json/csdnovice.script_json
@@ -1,0 +1,638 @@
+{
+  "script": {
+    "name": "csdnovice",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "CS Discoveries TeacherCon Novice"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csdnovice"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome",
+      "name": "Welcome",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "key": "Tuesday",
+      "name": "Tuesday",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "key": "Wednesday",
+      "name": "Wednesday",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "key": "Thursday",
+      "name": "Thursday",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-csd-novice"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "welcome-csd-novice"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-unit"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-tuesday-unit"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-unit2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-tuesday-unit2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-tuesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-facilitation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-tuesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-unit"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-wednesday-unit"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-wednesday-unit2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-wednesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-facilitation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-wednesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-unit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-thursday-unit"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-unit2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-thursday-unit2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-thursday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-thursday-pedagogy2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-facilitation"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-thursday-facilitation"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-novice-congrats"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      },
+      "level_keys": [
+        "csd-novice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-csd-novice",
+        "script_level.level_keys": [
+          "welcome-csd-novice"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-unit",
+        "script_level.level_keys": [
+          "csd-tuesday-unit"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-unit2",
+        "script_level.level_keys": [
+          "csd-tuesday-unit2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-pedagogy",
+        "script_level.level_keys": [
+          "csd-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-facilitation",
+        "script_level.level_keys": [
+          "csd-tuesday-facilitation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-unit",
+        "script_level.level_keys": [
+          "csd-wednesday-unit"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-unit2",
+        "script_level.level_keys": [
+          "csd-wednesday-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-pedagogy",
+        "script_level.level_keys": [
+          "csd-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-facilitation",
+        "script_level.level_keys": [
+          "csd-wednesday-facilitation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-unit",
+        "script_level.level_keys": [
+          "csd-thursday-unit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-unit2",
+        "script_level.level_keys": [
+          "csd-thursday-unit2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-pedagogy",
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-pedagogy2",
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-facilitation",
+        "script_level.level_keys": [
+          "csd-thursday-facilitation"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-novice-congrats",
+        "script_level.level_keys": [
+          "csd-novice-congrats"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "",
+        "script.name": "csdnovice"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csf2harvey.script_json
+++ b/dashboard/config/scripts_json/csf2harvey.script_json
@@ -1,0 +1,217 @@
+{
+  "script": {
+    "name": "csf2harvey",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csf2harvey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csf2harvey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Snowflakes",
+      "name": "Snowflakes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      }
+    },
+    {
+      "key": "Binary",
+      "name": "Binary",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary",
+        "lesson_group.key": "content",
+        "script.name": "csf2harvey"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvey_snowflake_artist1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      },
+      "level_keys": [
+        "harvey_snowflake_artist1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvey_snowflake_artist2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      },
+      "level_keys": [
+        "harvey_snowflake_artist2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "expresslink"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      },
+      "level_keys": [
+        "expresslink"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvey_pixelation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "content",
+        "script.name": "csf2harvey"
+      },
+      "level_keys": [
+        "harvey_pixelation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "harvey_snowflake_artist1",
+        "script_level.level_keys": [
+          "harvey_snowflake_artist1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvey_snowflake_artist2",
+        "script_level.level_keys": [
+          "harvey_snowflake_artist2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "expresslink",
+        "script_level.level_keys": [
+          "expresslink"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Snowflakes",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "csf2harvey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvey_pixelation",
+        "script_level.level_keys": [
+          "harvey_pixelation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "content",
+        "script.name": "csf2harvey"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csl-vn.script_json
+++ b/dashboard/config/scripts_json/csl-vn.script_json
@@ -1,0 +1,2667 @@
+{
+  "script": {
+    "name": "csl-vn",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csl-vn"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sequencing with Scrat",
+      "name": "Sequencing with Scrat",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops in Ice Age",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "Ocean Scene with Loops",
+      "name": "Ocean Scene with Loops",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "key": "Tell a Story in Play Lab",
+      "name": "Tell a Story in Play Lab",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp2_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3a_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3b_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp4a_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp5a_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "bb8_skinOverview_K-1_video_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops_video_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_iceage_loops12_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_video_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops12_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_video_events_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playLab_events1_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playLab_events2_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playLab_events3_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playLab_events4_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playLab_events5_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2019",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp1_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp2_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3b_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp4a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp5a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2019",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_K-1_video_2019",
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops_video_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops1_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops2_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops3_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops4_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops6_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops7_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops8_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops9_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops10_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops11_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops12_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2019",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1_2019",
+        "script_level.level_keys": [
+          "courseA_video_loops1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2019",
+        "script_level.level_keys": [
+          "courseA_video_events_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2_2019",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "csl-vn"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-ap.script_json
+++ b/dashboard/config/scripts_json/csp-ap.script_json
@@ -1,0 +1,421 @@
+{
+  "script": {
+    "name": "csp-ap",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "This unit is being replaced....",
+          "details": "As part of improving Performance Task prep, this unit has been split into separate units \"Explore PT Prep\" and \"Create PT Prep\" which can now be found in the pull down menu where you assign units to one of your sections.  Please go there and assign your section to the appropriate unit to see improved activities and resources.  The lesson plan for the Explore PT prep will link to the new lessons. Click the Learn More button to read about the changes and updates.",
+          "link": "http://forum.code.org/t/curriculum-updates-2017-18/10762/52",
+          "type": "bullhorn"
+        }
+      ],
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-ap"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: AP Tech Setup"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_1",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "csp_ap_3",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 3: AP Create Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "csp_ap_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: AP Explore Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+      "name": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "csp_ap_1",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Create PT Prep - Reviewing the Task",
+      "name": "Create PT Prep - Reviewing the Task",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Create PT Prep - Making a Plan",
+      "name": "Create PT Prep - Making a Plan",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Explore PT Prep - Reviewing the Task",
+      "name": "Explore PT Prep - Reviewing the Task",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Explore PT - Making a Plan",
+      "name": "Explore PT - Making a Plan",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "key": "Explore PT - Complete the Task",
+      "name": "Explore PT - Complete the Task",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "AP Performance Task Tech Setup - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 AP Performance Task Tech Setup - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "csp_ap_1",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 AP Performance Task Tech Setup - Student Links"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT -  Review - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Create PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Make a Plan - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Create PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Complete the Task - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Create PT - Complete the Task - Student Links"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Review - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Explore PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Make a Plan - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Explore PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Complete the Task - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      },
+      "level_keys": [
+        "U6 Explore PT - Complete the Task - Student Links"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U6 AP Performance Task Tech Setup - Student Links",
+        "script_level.level_keys": [
+          "U6 AP Performance Task Tech Setup - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "csp_ap_1",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-ap"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-apprentice-18.script_json
+++ b/dashboard/config/scripts_json/csp-apprentice-18.script_json
@@ -1,0 +1,798 @@
+{
+  "script": {
+    "name": "csp-apprentice-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-apprentice-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Apprentice Reflection Overview",
+      "name": "Apprentice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "welcome-apprentice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-monday"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "feel-monday"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-tuesday"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "feel-tuesday"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "instructional-strategy-tuesday"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-wednesday"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "feel-wednesday"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "getting-buy-in-wednesday"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "morning-prep-thursday"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "feel-thursday"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "recruiting-thursday"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      },
+      "level_keys": [
+        "apprentice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-apprentice-18",
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-monday",
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-monday",
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-tuesday",
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-tuesday",
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "instructional-strategy-tuesday",
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-wednesday",
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-wednesday",
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "getting-buy-in-wednesday",
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit2",
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-thursday",
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-thursday",
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "recruiting-thursday",
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit2",
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit3",
+        "script_level.level_keys": [
+          "csp-pushDL-unit3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "apprentice-congrats",
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-apprentice-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-ca-a.script_json
+++ b/dashboard/config/scripts_json/csp-ca-a.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "csp-ca-a",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-ca-a"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp-ca-a"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Commutative Assessment A",
+      "name": "Commutative Assessment A",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Commutative Assessment A",
+        "lesson_group.key": "",
+        "script.name": "csp-ca-a"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Commutative Assessment A",
+        "lesson_group.key": "",
+        "script.name": "csp-ca-a"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Commutative Assessment A",
+        "lesson_group.key": "",
+        "script.name": "csp-ca-a"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-create-2017.script_json
+++ b/dashboard/config/scripts_json/csp-create-2017.script_json
@@ -1,0 +1,341 @@
+{
+  "script": {
+    "name": "csp-create-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/csp-create/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/csp-create/standards/"
+        ]
+      ]
+    },
+    "new_name": "csp-create-2017",
+    "family_name": "csp-create",
+    "seeding_key": {
+      "script.name": "csp-create-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_3",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 3: AP Create Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Create PT Prep - Reviewing the Task",
+      "name": "Create PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "key": "Create PT Prep - Making a Plan",
+      "name": "Create PT Prep - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT -  Review - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "U6 Create PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Make a Plan - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "U6 Create PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Complete the Task - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "U6 Create PT - Complete the Task - Student Links"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-create-2018.script_json
+++ b/dashboard/config/scripts_json/csp-create-2018.script_json
@@ -1,0 +1,354 @@
+{
+  "script": {
+    "name": "csp-create-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/csp-create/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/csp-create/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp-create",
+    "seeding_key": {
+      "script.name": "csp-create-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_3",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 3: AP Create Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Create PT Prep - Reviewing the Task",
+      "name": "Create PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "key": "Create PT Prep - Making a Plan",
+      "name": "Create PT Prep - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "CSP CreateL01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL02 SFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "CSP CreateL02 SFLP_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL03 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "CSP CreateL03 SFLP"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Complete the Task"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Create Performance Task_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "Practice Create Performance Task_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL01 SFLP",
+        "script_level.level_keys": [
+          "CSP CreateL01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2018",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL02 SFLP_2018",
+        "script_level.level_keys": [
+          "CSP CreateL02 SFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL03 SFLP",
+        "script_level.level_keys": [
+          "CSP CreateL03 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Create Performance Task_2018",
+        "script_level.level_keys": [
+          "Practice Create Performance Task_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-create-2019.script_json
+++ b/dashboard/config/scripts_json/csp-create-2019.script_json
@@ -1,0 +1,373 @@
+{
+  "script": {
+    "name": "csp-create-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/csp-create/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/csp-create/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/csp-create/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp-create",
+    "seeding_key": {
+      "script.name": "csp-create-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_3",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 3: AP Create Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Create PT Prep - Reviewing the Task",
+      "name": "Create PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "key": "Create PT Prep - Making a Plan",
+      "name": "Create PT Prep - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 4,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "CSP CreateL01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL02 SFLP_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "CSP CreateL02 SFLP_2018_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP CreateL03 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "CSP CreateL03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT - Complete the Task"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Create Performance Task_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "Practice Create Performance Task_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP CreateL01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2018_2019",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL02 SFLP_2018_2019",
+        "script_level.level_keys": [
+          "CSP CreateL02 SFLP_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP CreateL03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP CreateL03 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Create Performance Task_2019",
+        "script_level.level_keys": [
+          "Practice Create Performance Task_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "csp_ap_3",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-create-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-create-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp-create-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp-create-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-create-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Create Deeper Learning Reflections",
+      "name": "Complete Create Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-create-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "csp-create-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-create-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "csp-create-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-create-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      },
+      "level_keys": [
+        "csp-create-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-create-dlp-q1",
+        "script_level.level_keys": [
+          "csp-create-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-create-dlp-q2",
+        "script_level.level_keys": [
+          "csp-create-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-create-dlp-q3",
+        "script_level.level_keys": [
+          "csp-create-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Create Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-create-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-exam.script_json
+++ b/dashboard/config/scripts_json/csp-exam.script_json
@@ -1,0 +1,576 @@
+{
+  "script": {
+    "name": "csp-exam",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-exam"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 1 Assessment 1 - Binary and Ascii ",
+      "name": "Unit 1 Assessment 1 - Binary and Ascii ",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Assessment 1 - Binary and Ascii ",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc",
+      "name": "Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc",
+      "absolute_position": 2,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression",
+      "name": "Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression",
+      "absolute_position": 3,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts",
+      "name": "Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts",
+      "absolute_position": 4,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction",
+      "name": "Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption",
+      "name": "Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review",
+      "name": "Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings",
+      "name": "Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings",
+      "absolute_position": 8,
+      "lockable": true,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists",
+      "name": "Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 4 - List Algorithms, Functions with Return Values",
+      "name": "Unit 5 Assessment 4 - List Algorithms, Functions with Return Values",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 4 - List Algorithms, Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)",
+      "name": "Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Assessment 1 - Binary and Ascii ",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_exam_prep"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 1 MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_exam_prep"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 2 MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_exam_prep"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 3 MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_exam_prep"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4 - List Algorithms, Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 4 MC_exam_prep"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_exam_prep"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A_exam_prep"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_exam_prep"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Assessment 1 - Binary and Ascii ",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_exam_prep"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_exam_prep"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_exam_prep"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 1 MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_exam_prep"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 2 MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_exam_prep"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 3 MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_exam_prep"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 4 MC_exam_prep",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_exam_prep"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4 - List Algorithms, Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A_exam_prep",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_exam_prep"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)",
+        "lesson_group.key": "",
+        "script.name": "csp-exam"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-explore-2017.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2017.script_json
@@ -1,0 +1,341 @@
+{
+  "script": {
+    "name": "csp-explore-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/csp-explore/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/csp-explore/standards/"
+        ]
+      ]
+    },
+    "new_name": "csp-explore-2017",
+    "family_name": "csp-explore",
+    "seeding_key": {
+      "script.name": "csp-explore-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_2",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 2: AP Explore Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Explore PT Prep - Reviewing the Task",
+      "name": "Explore PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "key": "Explore PT - Making a Plan",
+      "name": "Explore PT - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "key": "Explore PT - Complete the Task",
+      "name": "Explore PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Review the Task"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "U6 Explore PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Make a Plan"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "U6 Explore PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore PT - Complete the Task"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "U6 Explore PT - Complete the Task - Student Links"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-explore-2018.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2018.script_json
@@ -1,0 +1,318 @@
+{
+  "script": {
+    "name": "csp-explore-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/csp-explore/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/csp-explore/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp-explore",
+    "seeding_key": {
+      "script.name": "csp-explore-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_2",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 2: AP Explore Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Explore PT Prep - Reviewing the Task",
+      "name": "Explore PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "key": "Explore PT - Making a Plan",
+      "name": "Explore PT - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "key": "Explore PT - Complete the Task",
+      "name": "Explore PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      },
+      "level_keys": [
+        "CSP ExploreL01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL02 SFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      },
+      "level_keys": [
+        "CSP ExploreL02 SFLP_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL03 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      },
+      "level_keys": [
+        "CSP ExploreL03 SFLP"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL01 SFLP",
+        "script_level.level_keys": [
+          "CSP ExploreL01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2018",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL02 SFLP_2018",
+        "script_level.level_keys": [
+          "CSP ExploreL02 SFLP_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL03 SFLP",
+        "script_level.level_keys": [
+          "CSP ExploreL03 SFLP"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-explore-2019.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2019.script_json
@@ -1,0 +1,337 @@
+{
+  "script": {
+    "name": "csp-explore-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/csp-explore/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/csp-explore/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp/ap-prep"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/csp-explore/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp-explore",
+    "seeding_key": {
+      "script.name": "csp-explore-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_ap_2",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 2: AP Explore Performance Task"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Explore PT Prep - Reviewing the Task",
+      "name": "Explore PT Prep - Reviewing the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "key": "Explore PT - Making a Plan",
+      "name": "Explore PT - Making a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "key": "Explore PT - Complete the Task",
+      "name": "Explore PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 4,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "CSP ExploreL01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminder: Tech Setup - AP Digital Portfolio, Making PDFs, and Videos"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL02 SFLP_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "CSP ExploreL02 SFLP_2018_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP ExploreL03 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "CSP ExploreL03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP ExploreL01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2018_2019",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL02 SFLP_2018_2019",
+        "script_level.level_keys": [
+          "CSP ExploreL02 SFLP_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP ExploreL03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP ExploreL03 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "csp_ap_2",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-explore-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-explore-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp-explore-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp-explore-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-explore-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Explore Deeper Learning Reflections",
+      "name": "Complete Explore Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-explore-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "csp-explore-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-explore-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "csp-explore-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-explore-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      },
+      "level_keys": [
+        "csp-explore-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-explore-dlp-q1",
+        "script_level.level_keys": [
+          "csp-explore-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-explore-dlp-q2",
+        "script_level.level_keys": [
+          "csp-explore-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-explore-dlp-q3",
+        "script_level.level_keys": [
+          "csp-explore-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Explore Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp-explore-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-facilitators.script_json
+++ b/dashboard/config/scripts_json/csp-facilitators.script_json
@@ -1,0 +1,532 @@
+{
+  "script": {
+    "name": "csp-facilitators",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-facilitators"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Text Compression",
+      "name": "Introduction to Text Compression",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Text Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "key": "Turtle Programming",
+      "name": "Turtle Programming",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "key": "Introduction to Events",
+      "name": "Introduction to Events",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "text compression intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Text Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "text compression intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Text Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U1L13 Text Compression"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "introduction to turtle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "introduction to turtle"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "introduction to events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "introduction to events"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L13 - Turtle move with button"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U313 drag Two Buttons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U313 drag Two Buttons"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 eventsDetails"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L13 eventsDetails"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U313 Two Buttons with Ids"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U313 Two Buttons with Ids"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debug Id Problem"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L13 - Debug Id Problem"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debugging 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      },
+      "level_keys": [
+        "U3L13 - Debugging 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "text compression intro",
+        "script_level.level_keys": [
+          "text compression intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Text Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Text Compression",
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Text Compression",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "introduction to turtle",
+        "script_level.level_keys": [
+          "introduction to turtle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Turtle Programming",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "introduction to events",
+        "script_level.level_keys": [
+          "introduction to events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Turtle move with button",
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U313 drag Two Buttons",
+        "script_level.level_keys": [
+          "U313 drag Two Buttons"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 eventsDetails",
+        "script_level.level_keys": [
+          "U3L13 eventsDetails"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U313 Two Buttons with Ids",
+        "script_level.level_keys": [
+          "U313 Two Buttons with Ids"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debug Id Problem",
+        "script_level.level_keys": [
+          "U3L13 - Debug Id Problem"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debugging 1",
+        "script_level.level_keys": [
+          "U3L13 - Debugging 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Events",
+        "lesson_group.key": "",
+        "script.name": "csp-facilitators"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-march-virtual.script_json
+++ b/dashboard/config/scripts_json/csp-march-virtual.script_json
@@ -1,0 +1,617 @@
+{
+  "script": {
+    "name": "csp-march-virtual",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Curriculum Training for Facilitators",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-march-virtual"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Saturday Session Resources",
+      "name": "Saturday Session Resources",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Saturday Session Resources",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "key": "Getting Familiar with Traversals EIPM",
+      "name": "Getting Familiar with Traversals EIPM",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "key": "Comparing Make Lessons",
+      "name": "Comparing Make Lessons",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Prework_0"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Saturday Session Resources",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Prework_0"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview and Setup"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview and Setup"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part1_Task7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part1_Task7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part2_1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part2_1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part2_Task1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part2_Task1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part2_Task2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part2_Task2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Tasks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part2_Task3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part2_Task3"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mar20 Part2_Task4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      },
+      "level_keys": [
+        "Mar20 Part2_Task4"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Prework_0",
+        "script_level.level_keys": [
+          "Mar20 Prework_0"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Saturday Session Resources",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_1",
+        "script_level.level_keys": [
+          "Mar20 Part1_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_2",
+        "script_level.level_keys": [
+          "Mar20 Part1_2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task1",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task2",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task3",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task4",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task5",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task6",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part1_Task7",
+        "script_level.level_keys": [
+          "Mar20 Part1_Task7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Getting Familiar with Traversals EIPM",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part2_1",
+        "script_level.level_keys": [
+          "Mar20 Part2_1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part2_Task1",
+        "script_level.level_keys": [
+          "Mar20 Part2_Task1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part2_Task2",
+        "script_level.level_keys": [
+          "Mar20 Part2_Task2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part2_Task3",
+        "script_level.level_keys": [
+          "Mar20 Part2_Task3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mar20 Part2_Task4",
+        "script_level.level_keys": [
+          "Mar20 Part2_Task4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Comparing Make Lessons",
+        "lesson_group.key": "",
+        "script.name": "csp-march-virtual"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-mid-survey.script_json
+++ b/dashboard/config/scripts_json/csp-mid-survey.script_json
@@ -1,0 +1,86 @@
+{
+  "script": {
+    "name": "csp-mid-survey",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-mid-survey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-mid-survey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP Mid-year survey",
+      "name": "CSP Mid-year survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP Mid-year survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-mid-survey"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "CS Principles Mid-year Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP Mid-year survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-mid-survey"
+      },
+      "level_keys": [
+        "csp-post-survey-2017-levelgroup_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP Mid-year survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-mid-survey"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-novice-18.script_json
+++ b/dashboard/config/scripts_json/csp-novice-18.script_json
@@ -1,0 +1,798 @@
+{
+  "script": {
+    "name": "csp-novice-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-novice-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Novice Reflection Overview",
+      "name": "Novice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "welcome-novice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-monday-1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-monday-2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-tuesday-1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "instructional-strategy-tuesday"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-tuesday-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-wednesday-1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "getting-buy-in-wednesday"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-wednesday-2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-thursday-1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "recruiting-thursday"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pushDL-unit3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "csp-pushDL-unit3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-thursday-2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      },
+      "level_keys": [
+        "novice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-novice-18",
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-1",
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-2",
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-1",
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "instructional-strategy-tuesday",
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-2",
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-1",
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "getting-buy-in-wednesday",
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit1",
+        "script_level.level_keys": [
+          "csp-pushDL-unit1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit2",
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-2",
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-1",
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "recruiting-thursday",
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit2",
+        "script_level.level_keys": [
+          "csp-pushDL-unit2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pushDL-unit3",
+        "script_level.level_keys": [
+          "csp-pushDL-unit3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-2",
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-congrats",
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "csp-novice-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-online-test.script_json
+++ b/dashboard/config/scripts_json/csp-online-test.script_json
@@ -1,0 +1,1879 @@
+{
+  "script": {
+    "name": "csp-online-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-online-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 5 Overview",
+      "name": "Unit 5 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Event Driven Programming",
+      "name": "Event Driven Programming",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Variables and Strings",
+      "name": "Variables and Strings",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Conditionals and Boolean Logic",
+      "name": "Conditionals and Boolean Logic",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "While Loops and Introduction to Arrays",
+      "name": "While Loops and Introduction to Arrays",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Processing Arrays and Functions with Return Values",
+      "name": "Processing Arrays and Functions with Return Values",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 5"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Introduction to Unit 5"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Philosophy and Commentary"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Concepts and AP Assessments"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Concepts and AP Assessments"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Performance Task in Unit 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Practice Performance Task in Unit 5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.1 - 5.3 Lesson Connections"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "5.1 - 5.3 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design Mode Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Design Mode Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Events Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Events Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Multi-Screen App"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Project Breakdown: Multi-Screen App"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "U5 L1 - 3: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.4 - 5.6 Lesson Connections"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "5.4 - 5.6 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variables Overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Variables Overview"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Clicker Game"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Project Breakdown: Clicker Game"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Strings Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Strings Overview"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "U5 L4 - 6: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.7- 5.10 Lesson Connections"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "5.7- 5.10 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Logic and Expression Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Boolean Logic and Expression Overview"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Conditionals Overview"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Color Sleuth"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Project Breakdown: Color Sleuth"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "U5 L7 - 10: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.11 - 5.14 Lesson Connections"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "5.11 - 5.14 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "While Loops Overview"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "While Loops Overview"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Arrays Overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Arrays Overview"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Image Scroller"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Project Breakdown: Image Scroller"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L11 - 14: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "U5 L11 - 14: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.15 - 5.17 Lesson Connections"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "5.15 - 5.17 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Arrays"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Processing Arrays"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Functions that Return Values"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Functions that Return Values"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Building a Canvas Painter"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Project Breakdown: Building a Canvas Painter"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L15 - 17: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "U5 L15 - 17: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 5",
+        "script_level.level_keys": [
+          "Introduction to Unit 5"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Philosophy and Commentary",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Concepts and AP Assessments",
+        "script_level.level_keys": [
+          "Unit 5 Concepts and AP Assessments"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Performance Task in Unit 5",
+        "script_level.level_keys": [
+          "Practice Performance Task in Unit 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.1 - 5.3 Lesson Connections",
+        "script_level.level_keys": [
+          "5.1 - 5.3 Lesson Connections"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design Mode Overview",
+        "script_level.level_keys": [
+          "Design Mode Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Events Overview",
+        "script_level.level_keys": [
+          "Events Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Multi-Screen App",
+        "script_level.level_keys": [
+          "Project Breakdown: Multi-Screen App"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L1 - 3: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.4 - 5.6 Lesson Connections",
+        "script_level.level_keys": [
+          "5.4 - 5.6 Lesson Connections"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variables Overview",
+        "script_level.level_keys": [
+          "Variables Overview"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Clicker Game",
+        "script_level.level_keys": [
+          "Project Breakdown: Clicker Game"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Strings Overview",
+        "script_level.level_keys": [
+          "Strings Overview"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L4 - 6: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.7- 5.10 Lesson Connections",
+        "script_level.level_keys": [
+          "5.7- 5.10 Lesson Connections"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Logic and Expression Overview",
+        "script_level.level_keys": [
+          "Boolean Logic and Expression Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals Overview",
+        "script_level.level_keys": [
+          "Conditionals Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Color Sleuth",
+        "script_level.level_keys": [
+          "Project Breakdown: Color Sleuth"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L7 - 10: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.11 - 5.14 Lesson Connections",
+        "script_level.level_keys": [
+          "5.11 - 5.14 Lesson Connections"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "While Loops Overview",
+        "script_level.level_keys": [
+          "While Loops Overview"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Arrays Overview",
+        "script_level.level_keys": [
+          "Arrays Overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Image Scroller",
+        "script_level.level_keys": [
+          "Project Breakdown: Image Scroller"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L11 - 14: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L11 - 14: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.15 - 5.17 Lesson Connections",
+        "script_level.level_keys": [
+          "5.15 - 5.17 Lesson Connections"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Arrays",
+        "script_level.level_keys": [
+          "Processing Arrays"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Functions that Return Values",
+        "script_level.level_keys": [
+          "Functions that Return Values"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Building a Canvas Painter",
+        "script_level.level_keys": [
+          "Project Breakdown: Building a Canvas Painter"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L15 - 17: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L15 - 17: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp-online-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-post-survey-2018.script_json
+++ b/dashboard/config/scripts_json/csp-post-survey-2018.script_json
@@ -1,0 +1,88 @@
+{
+  "script": {
+    "name": "csp-post-survey-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-post-survey-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP post-course survey",
+      "name": "CSP post-course survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "CS Principles Post-course Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2018",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-post-survey.script_json
+++ b/dashboard/config/scripts_json/csp-post-survey.script_json
@@ -1,0 +1,86 @@
+{
+  "script": {
+    "name": "csp-post-survey",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-post-survey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP post-course survey",
+      "name": "CSP post-course survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "CS Principles Post-course Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-levelgroup",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP post-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp-post-survey"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp-pre-survey.script_json
+++ b/dashboard/config/scripts_json/csp-pre-survey.script_json
@@ -1,0 +1,351 @@
+{
+  "script": {
+    "name": "csp-pre-survey",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp-pre-survey"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Anonymous student pre-survey",
+      "name": "Anonymous student pre-survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Anonymous student pre-survey",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 1 Assessment",
+      "name": "Unit 1 Chapter 1 Assessment",
+      "absolute_position": 2,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "key": "NEW Unit 1 Chapter 1 Assessment",
+      "name": "NEW Unit 1 Chapter 1 Assessment",
+      "absolute_position": 3,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "NEW Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 4,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "key": "Unit 4 Chapter 1 Assessment",
+      "name": "Unit 4 Chapter 1 Assessment",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "key": "Anonymous student survey: Taking the AP exam",
+      "name": "Anonymous student survey: Taking the AP exam",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Anonymous student survey: Taking the AP exam",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP pre-assessment survey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student pre-survey",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "CSP pre-assessment survey"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "variants": {
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group",
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group",
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "NEW Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch2 Cumulative Assessment MC"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "CSP Unit 4 Ch1 Cumulative Assessment MC"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_ap_questions"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey: Taking the AP exam",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      },
+      "level_keys": [
+        "csp_ap_questions"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP pre-assessment survey",
+        "script_level.level_keys": [
+          "CSP pre-assessment survey"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student pre-survey",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group",
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group",
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch2 Cumulative Assessment MC",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "NEW Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 Ch1 Cumulative Assessment MC",
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_ap_questions",
+        "script_level.level_keys": [
+          "csp_ap_questions"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Anonymous student survey: Taking the AP exam",
+        "lesson_group.key": "",
+        "script.name": "csp-pre-survey"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-2017.script_json
+++ b/dashboard/config/scripts_json/csp1-2017.script_json
@@ -1,0 +1,3390 @@
+{
+  "script": {
+    "name": "csp1-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit1/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp1"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit1/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp1-support"
+        ]
+      ]
+    },
+    "new_name": "csp1-2017",
+    "family_name": "csp1",
+    "seeding_key": {
+      "script.name": "csp1-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "csp1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: Representing and Transmitting Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "csp1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Inventing the Internet"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Personal Innovations",
+      "name": "Personal Innovations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Sending Binary Messages",
+      "name": "Sending Binary Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Sending Binary Messages with the Internet Simulator",
+      "name": "Sending Binary Messages with the Internet Simulator",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Number Systems",
+      "name": "Number Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Sending Numbers",
+      "name": "Sending Numbers",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Encoding and Sending Formatted Text",
+      "name": "Encoding and Sending Formatted Text",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 1 Assessment",
+      "name": "Unit 1 Chapter 1 Assessment",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "The Internet",
+      "name": "The Internet",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Packets and Making a Reliable Internet",
+      "name": "Packets and Making a Reliable Internet",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "The Need for DNS",
+      "name": "The Need for DNS",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "HTTP and Abstraction",
+      "name": "HTTP and Abstraction",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Practice PT - The Internet and Society",
+      "name": "Practice PT - The Internet and Society",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 2 Assessment",
+      "name": "Unit 1 Chapter 2 Assessment",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "csp-pre-survey-2017-levelgroup"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L1 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Computer Science is Changing Everything"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_socialBelonging_control": {
+            "experiments": [
+              "rene-control-control",
+              "rene-control-affirmation"
+            ]
+          },
+          "csp_socialBelonging_intervention": {
+            "active": false,
+            "experiments": [
+              "rene-belonging-control",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Reflection: starting out in computer science"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control",
+        "csp_socialBelonging_intervention"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L2 Multiple Choice Assessment Question"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L2 Free response assessment question"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free Response"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L3 Free Response"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L3 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Binary Messages"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Binary Messages"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Wires, Cables, and Wifi"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "The Internet: Wires, Cables, and Wifi"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L3 Free response reflection question"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L4 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L3 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L4 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L5 Matching Assessment"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L4 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L6 Assessment multiple choice"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L6 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L5 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Binary Odometer"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Binary Odometer"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Widget: Binary Odometer"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L7 Free Response Assessment"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L7 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Numbers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Numbers"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L8 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L8 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L8 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Text"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Text"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment Free Response"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L10 Assessment Free Response"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L11 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L11 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Reflection Free Response"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L11 Reflection Free Response"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Collaboration Reflection"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U1L11 Collaboration Reflection"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1 Internet is for Everyone Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1 Internet is for Everyone Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "What is the Internet?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the Internet?"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "What is the Internet?"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L01 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L01 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L01 Assessment 3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L01 Assessment 4"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-1-levelgroup-U1Ch2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L9 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Broadcast"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Broadcast"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L02 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L02 Assessment 3"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L02 Assessment 4"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L02 Assessment 5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L3 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Routers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Routers"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Routers"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L04 Assessment4"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L04 Assessment5"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L04 Assessment3"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Packets"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Packets"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: Packets"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Packets, Routing, and Reliability"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "The Internet: Packets, Routing, and Reliability"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Reflection 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L05 Reflection 1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L05 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L05 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L3 Assessment"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: DNS"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Internet Simulator: DNS"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L09 Assessment1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L09 Assessment2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L09 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L10 Assessment1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: HTTP and HTML"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "The Internet: HTTP and HTML"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L11 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L11 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Free Response"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "U2L11 Free Response"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U1L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "v2 U1L14 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control",
+          "csp_affirmation_intervention"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control",
+        "csp_affirmation_intervention"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch2 Cumulative Assessment MC Group"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_intervention",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control",
+          "csp_socialBelonging_intervention"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Multiple Choice Assessment Question",
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Free response assessment question",
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free Response",
+        "script_level.level_keys": [
+          "U1L3 Free Response"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L3 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Binary Messages",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Wires, Cables, and Wifi",
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free response reflection question",
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Matching Assessment",
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L4 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Assessment multiple choice",
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L5 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Binary Odometer",
+        "script_level.level_keys": [
+          "Widget: Binary Odometer"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Assessment",
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Numbers",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L8 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Text",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 1",
+        "script_level.level_keys": [
+          "U1L10 Assessment 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 2",
+        "script_level.level_keys": [
+          "U1L10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment Free Response",
+        "script_level.level_keys": [
+          "U1L10 Assessment Free Response"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 1",
+        "script_level.level_keys": [
+          "U1L11 Assessment 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 2",
+        "script_level.level_keys": [
+          "U1L11 Assessment 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Reflection Free Response",
+        "script_level.level_keys": [
+          "U1L11 Reflection Free Response"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Collaboration Reflection",
+        "script_level.level_keys": [
+          "U1L11 Collaboration Reflection"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Encoding and Sending Formatted Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1 Internet is for Everyone Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1 Internet is for Everyone Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the Internet?",
+        "script_level.level_keys": [
+          "What is the Internet?"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 1",
+        "script_level.level_keys": [
+          "U2L01 Assessment 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 2",
+        "script_level.level_keys": [
+          "U2L01 Assessment 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 3",
+        "script_level.level_keys": [
+          "U2L01 Assessment 3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 4",
+        "script_level.level_keys": [
+          "U2L01 Assessment 4"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-1-levelgroup-U1Ch2",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L9 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Broadcast",
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Free Response Reflection",
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 3",
+        "script_level.level_keys": [
+          "U2L02 Assessment 3"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 4",
+        "script_level.level_keys": [
+          "U2L02 Assessment 4"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 5",
+        "script_level.level_keys": [
+          "U2L02 Assessment 5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 2",
+        "script_level.level_keys": [
+          "U2L3 Assessment 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Routers",
+        "script_level.level_keys": [
+          "Internet Simulator: Routers"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment1",
+        "script_level.level_keys": [
+          "U2L04 Assessment1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment4",
+        "script_level.level_keys": [
+          "U2L04 Assessment4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment5",
+        "script_level.level_keys": [
+          "U2L04 Assessment5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment2",
+        "script_level.level_keys": [
+          "U2L04 Assessment2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment3",
+        "script_level.level_keys": [
+          "U2L04 Assessment3"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Packets",
+        "script_level.level_keys": [
+          "Internet Simulator: Packets"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Packets, Routing, and Reliability",
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Reflection 1",
+        "script_level.level_keys": [
+          "U2L05 Reflection 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 1",
+        "script_level.level_keys": [
+          "U2L05 Assessment 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 2",
+        "script_level.level_keys": [
+          "U2L05 Assessment 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment",
+        "script_level.level_keys": [
+          "U2L3 Assessment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: DNS",
+        "script_level.level_keys": [
+          "Internet Simulator: DNS"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment1",
+        "script_level.level_keys": [
+          "U2L09 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment2",
+        "script_level.level_keys": [
+          "U2L09 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment1",
+        "script_level.level_keys": [
+          "U2L10 Assessment1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: HTTP and HTML",
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 1",
+        "script_level.level_keys": [
+          "U2L11 Assessment 1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 2",
+        "script_level.level_keys": [
+          "U2L11 Assessment 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Free Response",
+        "script_level.level_keys": [
+          "U2L11 Free Response"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U1L14 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U1L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control",
+        "script_level.level_keys": [
+          "csp_affirmation_control",
+          "csp_affirmation_intervention"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention",
+        "script_level.level_keys": [
+          "csp_affirmation_control",
+          "csp_affirmation_intervention"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch2 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-2018.script_json
+++ b/dashboard/config/scripts_json/csp1-2018.script_json
@@ -1,0 +1,3149 @@
+{
+  "script": {
+    "name": "csp1-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "Are you signed up for the AP exam?",
+          "details": "Now's the time to register to take the AP CS Principles exam! Be sure to ask your teacher about your school's registration deadline and sign up today. Click to learn more about six great reasons why you should.",
+          "link": "https://code.org/educate/csp/ap-students",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/unit1/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp1"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-18/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/unit1/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp1-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp1",
+    "seeding_key": {
+      "script.name": "csp1-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "csp1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: Representing and Transmitting Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "csp1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Inventing the Internet"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Personal Innovations",
+      "name": "Personal Innovations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Sending Binary Messages",
+      "name": "Sending Binary Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Sending Binary Messages with the Internet Simulator",
+      "name": "Sending Binary Messages with the Internet Simulator",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Number Systems",
+      "name": "Number Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Sending Numbers",
+      "name": "Sending Numbers",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Sending Text",
+      "name": "Sending Text",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 1 Assessment",
+      "name": "Unit 1 Chapter 1 Assessment",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "The Internet",
+      "name": "The Internet",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Packets and Making a Reliable Internet",
+      "name": "Packets and Making a Reliable Internet",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "The Need for DNS",
+      "name": "The Need for DNS",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "HTTP and Abstraction",
+      "name": "HTTP and Abstraction",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Practice PT - The Internet and Society",
+      "name": "Practice PT - The Internet and Society",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 2 Assessment",
+      "name": "Unit 1 Chapter 2 Assessment",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "csp-pre-survey-2017-levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L01 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Computer Science is Changing Everything"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "variants": {
+          "csp_socialBelonging_control_2018": {
+            "active": false
+          }
+        },
+        "progression": "Reflection: starting out in computer science"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018",
+          "csp_socialBelonging_intervention_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control_2018",
+        "csp_socialBelonging_intervention_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L2 Multiple Choice Assessment Question_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L3 Free response reflection question_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L2 Free response assessment question_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free Response_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L3 Free Response_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L03 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Binary Messages"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Binary Messages_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Wires, Cables, and Wifi"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "The Internet: Wires, Cables, and Wifi_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L4 Multiple Choice_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L3 Multiple Choice_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L4 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L5 Matching Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L04 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L6 Assessment multiple choice_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L6 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L05 SFLP"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Binary Odometer"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Widget: Binary Odometer_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L7 Free Response Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L7 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L06 SFLP"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Numbers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Numbers_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L8 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L8 Multiple Choice_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L07 SFLP"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Text"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Text_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 1_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L10 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 2_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L10 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L11 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Reflection Multiple Representations_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L11 Reflection Multiple Representations_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Abstraction Reflection_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U1L11 Abstraction Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L08 SFLP"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "What is the Internet?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the Internet?_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "What is the Internet?_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L01 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L01 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 3_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L01 Assessment 3_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 4_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L01 Assessment 4_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L09 SFLP"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Broadcast"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Broadcast_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L02 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 3_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L02 Assessment 3_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 4_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L02 Assessment 4_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 5_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L02 Assessment 5_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 2_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L3 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Routers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Routers_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Routers_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L04 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L04 Assessment4_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L04 Assessment5_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment2_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L04 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment3_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L04 Assessment3_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Packets"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Packets_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: Packets_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Packets, Routing, and Reliability"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "The Internet: Packets, Routing, and Reliability_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Reflection 1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L05 Reflection 1_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 1_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L05 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 2_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L05 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L3 Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: DNS_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "Internet Simulator: DNS_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L09 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L09 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L09 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L10 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: HTTP and HTML"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "The Internet: HTTP and HTML_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L11 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 2_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L11 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Free Response_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "U2L11 Free Response_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP U1L14 SFLP"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-2017-levelgroup_2018",
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L01 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L01 SFLP"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything_2018",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_intervention_2018",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018",
+          "csp_socialBelonging_intervention_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control_2018",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018",
+          "csp_socialBelonging_intervention_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L02 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Multiple Choice Assessment Question_2018",
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free response reflection question_2018",
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Free response assessment question_2018",
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free Response_2018",
+        "script_level.level_keys": [
+          "U1L3 Free Response_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L03 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L03 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Binary Messages_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Wires, Cables, and Wifi_2018",
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Multiple Choice_2018",
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Multiple Choice_2018",
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Matching Assessment_2018",
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L04 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L04 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Assessment multiple choice_2018",
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L05 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L05 SFLP"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Binary Odometer_2018",
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Assessment_2018",
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L06 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L06 SFLP"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Numbers_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Multiple Choice_2018",
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L07 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L07 SFLP"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Text_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U1L10 Assessment 1_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U1L10 Assessment 2_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U1L11 Assessment 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Reflection Multiple Representations_2018",
+        "script_level.level_keys": [
+          "U1L11 Reflection Multiple Representations_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Abstraction Reflection_2018",
+        "script_level.level_keys": [
+          "U1L11 Abstraction Reflection_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L08 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L08 SFLP"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the Internet?_2018",
+        "script_level.level_keys": [
+          "What is the Internet?_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U2L01 Assessment 1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U2L01 Assessment 2_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 3_2018",
+        "script_level.level_keys": [
+          "U2L01 Assessment 3_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 4_2018",
+        "script_level.level_keys": [
+          "U2L01 Assessment 4_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L09 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L09 SFLP"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Broadcast_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS_2018",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 3_2018",
+        "script_level.level_keys": [
+          "U2L02 Assessment 3_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 4_2018",
+        "script_level.level_keys": [
+          "U2L02 Assessment 4_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 5_2018",
+        "script_level.level_keys": [
+          "U2L02 Assessment 5_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U2L3 Assessment 2_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Routers_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Routers_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment1_2018",
+        "script_level.level_keys": [
+          "U2L04 Assessment1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment4_2018",
+        "script_level.level_keys": [
+          "U2L04 Assessment4_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment5_2018",
+        "script_level.level_keys": [
+          "U2L04 Assessment5_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment2_2018",
+        "script_level.level_keys": [
+          "U2L04 Assessment2_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment3_2018",
+        "script_level.level_keys": [
+          "U2L04 Assessment3_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L11 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Packets_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: Packets_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Packets, Routing, and Reliability_2018",
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Reflection 1_2018",
+        "script_level.level_keys": [
+          "U2L05 Reflection 1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U2L05 Assessment 1_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U2L05 Assessment 2_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment_2018",
+        "script_level.level_keys": [
+          "U2L3 Assessment_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L12 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: DNS_2018",
+        "script_level.level_keys": [
+          "Internet Simulator: DNS_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS_2018",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment1_2018",
+        "script_level.level_keys": [
+          "U2L09 Assessment1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment2_2018",
+        "script_level.level_keys": [
+          "U2L09 Assessment2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment1_2018",
+        "script_level.level_keys": [
+          "U2L10 Assessment1_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L13 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: HTTP and HTML_2018",
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U2L11 Assessment 1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U2L11 Assessment 2_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Free Response_2018",
+        "script_level.level_keys": [
+          "U2L11 Free Response_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L14 SFLP",
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-2019.script_json
+++ b/dashboard/config/scripts_json/csp1-2019.script_json
@@ -1,0 +1,3136 @@
+{
+  "script": {
+    "name": "csp1-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/unit1/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/unit1/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp1"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-19/unit1/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/unit1/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://code.org/educate/professional-learning/middle-high"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp1",
+    "seeding_key": {
+      "script.name": "csp1-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "csp1_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 1: Representing and Transmitting Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "csp1_2",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Chapter 2: Inventing the Internet"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Personal Innovations",
+      "name": "Personal Innovations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Sending Binary Messages",
+      "name": "Sending Binary Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Sending Binary Messages with the Internet Simulator",
+      "name": "Sending Binary Messages with the Internet Simulator",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Number Systems",
+      "name": "Number Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Sending Numbers",
+      "name": "Sending Numbers",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Sending Text",
+      "name": "Sending Text",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 1 Assessment",
+      "name": "Unit 1 Chapter 1 Assessment",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "The Internet",
+      "name": "The Internet",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Packets and Making a Reliable Internet",
+      "name": "Packets and Making a Reliable Internet",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "The Need for DNS",
+      "name": "The Need for DNS",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "HTTP and Abstraction",
+      "name": "HTTP and Abstraction",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Practice PT - The Internet and Society",
+      "name": "Practice PT - The Internet and Society",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "key": "Unit 1 Chapter 2 Assessment",
+      "name": "Unit 1 Chapter 2 Assessment",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "csp-pre-survey-levelgroup_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L01 SFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Computer Science is Changing Everything"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Reflection: starting out in computer science"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2019",
+          "csp_socialBelonging_intervention_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control_2019",
+        "csp_socialBelonging_intervention_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L02 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question_2018_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L2 Multiple Choice Assessment Question_2018_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L3 Free response reflection question_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L2 Free response assessment question_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free Response_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L3 Free Response_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L03 SFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Binary Messages"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Binary Messages_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Wires, Cables, and Wifi"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "The Internet: Wires, Cables, and Wifi_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L4 Multiple Choice_2018_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L3 Multiple Choice_2018_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L4 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment_2018_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L5 Matching Assessment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L04 SFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L04 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L6 Assessment multiple choice_2018_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L6 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L05 SFLP_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L05 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Binary Odometer"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Widget: Binary Odometer_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L7 Free Response Assessment_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L7 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L06 SFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L06 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Numbers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Numbers_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L8 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L8 Multiple Choice_2018_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L07 SFLP_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L07 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Sending Text"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Text_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L10 Assessment 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L10 Assessment 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L11 Assessment 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Reflection Multiple Representations_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L11 Reflection Multiple Representations_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Abstraction Reflection_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U1L11 Abstraction Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L08 SFLP_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L08 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "What is the Internet?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the Internet?_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "What is the Internet?_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L01 Assessment 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L01 Assessment 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 3_2018_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L01 Assessment 3_2018_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 4_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L01 Assessment 4_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L09 SFLP_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L09 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Broadcast"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Broadcast_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L02 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 3_2018_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L02 Assessment 3_2018_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 4_2018_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L02 Assessment 4_2018_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 5_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L02 Assessment 5_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L3 Assessment 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L10 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Routers"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Routers_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Routers_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L04 Assessment1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment4_2018_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L04 Assessment4_2018_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment5_2018_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L04 Assessment5_2018_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L04 Assessment2_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment3_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L04 Assessment3_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L11 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Packets"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Packets_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: Packets_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: Packets, Routing, and Reliability"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "The Internet: Packets, Routing, and Reliability_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Reflection 1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L05 Reflection 1_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L05 Assessment 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L05 Assessment 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L3 Assessment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L12 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: DNS_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "Internet Simulator: DNS_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: IP Addresses & DNS"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L09 Assessment1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L09 Assessment2_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L09 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L10 Assessment1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L13 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Internet: HTTP and HTML"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "The Internet: HTTP and HTML_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L11 Assessment 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L11 Assessment 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Free Response_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "U2L11 Free Response_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP U1L14 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      },
+      "level_keys": [
+        "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L01 SFLP_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything_2019",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_intervention_2019",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2019",
+          "csp_socialBelonging_intervention_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control_2019",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2019",
+          "csp_socialBelonging_intervention_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L02 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Multiple Choice Assessment Question_2018_2019",
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question_2018_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free response reflection question_2019",
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Free response assessment question_2019",
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free Response_2019",
+        "script_level.level_keys": [
+          "U1L3 Free Response_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L03 SFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Binary Messages_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Wires, Cables, and Wifi_2019",
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Multiple Choice_2018_2019",
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Multiple Choice_2018_2019",
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Matching Assessment_2018_2019",
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment_2018_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L04 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L04 SFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Assessment multiple choice_2018_2019",
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L05 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L05 SFLP_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Binary Odometer_2019",
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Assessment_2019",
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L06 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L06 SFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Numbers_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Multiple Choice_2018_2019",
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L07 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L07 SFLP_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Text_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 1_2018_2019",
+        "script_level.level_keys": [
+          "U1L10 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 2_2018_2019",
+        "script_level.level_keys": [
+          "U1L10 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 1_2018_2019",
+        "script_level.level_keys": [
+          "U1L11 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Reflection Multiple Representations_2019",
+        "script_level.level_keys": [
+          "U1L11 Reflection Multiple Representations_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Abstraction Reflection_2019",
+        "script_level.level_keys": [
+          "U1L11 Abstraction Reflection_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Sending Text",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch1 Cumulative Assessment MC Group v2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 1 Assessment",
+        "lesson_group.key": "csp1_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L08 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L08 SFLP_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the Internet?_2019",
+        "script_level.level_keys": [
+          "What is the Internet?_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 1_2018_2019",
+        "script_level.level_keys": [
+          "U2L01 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 2_2018_2019",
+        "script_level.level_keys": [
+          "U2L01 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 3_2018_2019",
+        "script_level.level_keys": [
+          "U2L01 Assessment 3_2018_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 4_2019",
+        "script_level.level_keys": [
+          "U2L01 Assessment 4_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-1-levelgroup-U1Ch2_2018_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L09 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L09 SFLP_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Broadcast_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS_2019",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 3_2018_2019",
+        "script_level.level_keys": [
+          "U2L02 Assessment 3_2018_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 4_2018_2019",
+        "script_level.level_keys": [
+          "U2L02 Assessment 4_2018_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 5_2019",
+        "script_level.level_keys": [
+          "U2L02 Assessment 5_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 2_2018_2019",
+        "script_level.level_keys": [
+          "U2L3 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Routers_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Routers_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment1_2018_2019",
+        "script_level.level_keys": [
+          "U2L04 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment4_2018_2019",
+        "script_level.level_keys": [
+          "U2L04 Assessment4_2018_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment5_2018_2019",
+        "script_level.level_keys": [
+          "U2L04 Assessment5_2018_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment2_2019",
+        "script_level.level_keys": [
+          "U2L04 Assessment2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment3_2019",
+        "script_level.level_keys": [
+          "U2L04 Assessment3_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L11 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Packets_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: Packets_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Packets, Routing, and Reliability_2019",
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Reflection 1_2019",
+        "script_level.level_keys": [
+          "U2L05 Reflection 1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 1_2018_2019",
+        "script_level.level_keys": [
+          "U2L05 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 2_2018_2019",
+        "script_level.level_keys": [
+          "U2L05 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment_2018_2019",
+        "script_level.level_keys": [
+          "U2L3 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L12 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: DNS_2019",
+        "script_level.level_keys": [
+          "Internet Simulator: DNS_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS_2019",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment1_2018_2019",
+        "script_level.level_keys": [
+          "U2L09 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment2_2019",
+        "script_level.level_keys": [
+          "U2L09 Assessment2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment1_2018_2019",
+        "script_level.level_keys": [
+          "U2L10 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L13 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: HTTP and HTML_2019",
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 1_2018_2019",
+        "script_level.level_keys": [
+          "U2L11 Assessment 1_2018_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 2_2018_2019",
+        "script_level.level_keys": [
+          "U2L11 Assessment 2_2018_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Free Response_2019",
+        "script_level.level_keys": [
+          "U2L11 Free Response_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L14 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 1 Ch2 Cumulative Assessment MC Group_2018_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Chapter 2 Assessment",
+        "lesson_group.key": "csp1_2",
+        "script.name": "csp1-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-2020.script_json
+++ b/dashboard/config/scripts_json/csp1-2020.script_json
@@ -1,0 +1,2262 @@
+{
+  "script": {
+    "name": "csp1-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit1/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit1/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "csp_unit1_2020",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Unit 1: Digital Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Welcome to CSP",
+      "name": "Welcome to CSP",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Representing Information",
+      "name": "Representing Information",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Circle Square Patterns",
+      "name": "Circle Square Patterns",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Overflow and Rounding",
+      "name": "Overflow and Rounding",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Representing Text",
+      "name": "Representing Text",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Black and White Images",
+      "name": "Black and White Images",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Color Images",
+      "name": "Color Images",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Lossless Compression",
+      "name": "Lossless Compression",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Lossy Compression",
+      "name": "Lossy Compression",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Intellectual Property",
+      "name": "Intellectual Property",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Project - Digital Information Dilemmas Part 1",
+      "name": "Project - Digital Information Dilemmas Part 1",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Project - Digital Information Dilemmas Part 2",
+      "name": "Project - Digital Information Dilemmas Part 2",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "key": "Lesson 14: Assessment Day",
+      "name": "Lesson 14: Assessment Day",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "csp-pre-survey-levelgroup_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Computer Science is Changing Everything"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 CFU Sending Complex Messages"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L3 CFU Sending Complex Messages"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L4 CYU3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L4 CYU3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU how many bits"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L5 CFU how many bits"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU adding bits"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L5 CFU adding bits"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU bin dec similarities"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L5 CFU bin dec similarities"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Binary Odometer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "Widget: Binary Odometer_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 CFU beyond odometer"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L6 CFU beyond odometer"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 CFU representing fractions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L6 CFU representing fractions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Reflection Multiple Representations CSP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L8 Reflection Multiple Representations CSP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to Pixelation Encoding B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L9 Introduction to Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1 L9 Introduction to Pixelation"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Pixelation - Make the Letter A_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget Fix bit offset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge a"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge a"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge B"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge B"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge C"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge C"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 CFU pixel data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 CFU pixel data"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Multiple Choice Digital Analog"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 Multiple Choice Digital Analog"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 CFU Sampling"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L9 CFU Sampling"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 RGB"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 RGB"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Shades of Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 More Shades of Color"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 More Shades of Color"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sampling"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Sampling"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Sampling"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Multiple Choice analog vs digital"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L10 Multiple Choice analog vs digital"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 CFU Sampling"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L10 CFU Sampling"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Text Compression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Widget: Text Compression"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L11 Widget: Text Compression"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Text Compression Widget with Aloe Blacc"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L11 Text Compression Widget Aloe Blacc"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1 L11 Text Compression Widget Aloe Blacc"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Multiple Choice lossless compression"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L11 Multiple Choice lossless compression"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 CFU Compression for Email"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L11 CFU Compression for Email"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lossy Compression Widget"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1 Lossy Compression Widget v1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lossy Compression Widget"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1 Lossy Compression Widget v2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 CPS CFU Cell Phone"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L11 CPS CFU Cell Phone"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 CFU Creative Commons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L12 CFU Creative Commons"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 CFU Copyright"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L12 CFU Copyright"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 CFU Digital Representation"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L13 CFU Digital Representation"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP U1L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 CSP CFU digital information"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "U1L14 CSP CFU digital information"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 1 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      },
+      "level_keys": [
+        "CSP Unit 1 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything_2020",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control_2018",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 CFU Sending Complex Messages",
+        "script_level.level_keys": [
+          "U1L3 CFU Sending Complex Messages"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L4 CYU3",
+        "script_level.level_keys": [
+          "CSP U1L4 CYU3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU how many bits",
+        "script_level.level_keys": [
+          "U1L5 CFU how many bits"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU adding bits",
+        "script_level.level_keys": [
+          "U1L5 CFU adding bits"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU bin dec similarities",
+        "script_level.level_keys": [
+          "U1L5 CFU bin dec similarities"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Binary Odometer_2020",
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 CFU beyond odometer",
+        "script_level.level_keys": [
+          "U1L6 CFU beyond odometer"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 CFU representing fractions",
+        "script_level.level_keys": [
+          "U1L6 CFU representing fractions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Reflection Multiple Representations CSP",
+        "script_level.level_keys": [
+          "U1L8 Reflection Multiple Representations CSP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L9 Introduction to Pixelation",
+        "script_level.level_keys": [
+          "U1 L9 Introduction to Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation - Make the Letter A_2019",
+        "script_level.level_keys": [
+          "U1L9 Pixelation - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget Fix bit offset",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget Fix bit offset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge a",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge a"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge B",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge B"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge C",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge C"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 CFU pixel data",
+        "script_level.level_keys": [
+          "U1L9 CFU pixel data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Multiple Choice Digital Analog",
+        "script_level.level_keys": [
+          "U1L9 Multiple Choice Digital Analog"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 CFU Sampling",
+        "script_level.level_keys": [
+          "U1L9 CFU Sampling"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 RGB",
+        "script_level.level_keys": [
+          "CSP U1L10 RGB"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 1",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 More Shades of Color",
+        "script_level.level_keys": [
+          "CSP U1L10 More Shades of Color"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 2",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 3",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Sampling",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Sampling"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 4",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Multiple Choice analog vs digital",
+        "script_level.level_keys": [
+          "U1L10 Multiple Choice analog vs digital"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 CFU Sampling",
+        "script_level.level_keys": [
+          "U1L10 CFU Sampling"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Widget: Text Compression",
+        "script_level.level_keys": [
+          "U1L11 Widget: Text Compression"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L11 Text Compression Widget Aloe Blacc",
+        "script_level.level_keys": [
+          "U1 L11 Text Compression Widget Aloe Blacc"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Multiple Choice lossless compression",
+        "script_level.level_keys": [
+          "U1L11 Multiple Choice lossless compression"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 CFU Compression for Email",
+        "script_level.level_keys": [
+          "U1L11 CFU Compression for Email"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 Lossy Compression Widget v1",
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 Lossy Compression Widget v2",
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 CPS CFU Cell Phone",
+        "script_level.level_keys": [
+          "U1L11 CPS CFU Cell Phone"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 CFU Creative Commons",
+        "script_level.level_keys": [
+          "U1L12 CFU Creative Commons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 CFU Copyright",
+        "script_level.level_keys": [
+          "U1L12 CFU Copyright"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 CFU Digital Representation",
+        "script_level.level_keys": [
+          "U1L13 CFU Digital Representation"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 CSP CFU digital information",
+        "script_level.level_keys": [
+          "U1L14 CSP CFU digital information"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 1 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "csp_unit1_2020",
+        "script.name": "csp1-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp1-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp1-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 1 Deeper Learning Reflections",
+      "name": "Complete Unit 1 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "csp1-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "csp1-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      },
+      "level_keys": [
+        "csp1-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1-dlp-q1",
+        "script_level.level_keys": [
+          "csp1-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1-dlp-q2",
+        "script_level.level_keys": [
+          "csp1-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1-dlp-q3",
+        "script_level.level_keys": [
+          "csp1-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-dlp.script_json
+++ b/dashboard/config/scripts_json/csp1-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csp1-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 1 Deeper Learning Reflections",
+      "name": "Complete Unit 1 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "csp deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "csp1dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "csp1dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp1dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      },
+      "level_keys": [
+        "csp1dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp deeper learning timeline",
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1dlp-lessons",
+        "script_level.level_keys": [
+          "csp1dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1dlp-tools",
+        "script_level.level_keys": [
+          "csp1dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp1dlp-assessment",
+        "script_level.level_keys": [
+          "csp1dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 1 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp1-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp1-pilot-staging.script_json
@@ -1,0 +1,3612 @@
+{
+  "script": {
+    "name": "csp1-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp1-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-pilot.script_json
+++ b/dashboard/config/scripts_json/csp1-pilot.script_json
@@ -1,0 +1,2341 @@
+{
+  "script": {
+    "name": "csp1-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit1/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Welcome to CSP",
+      "name": "Welcome to CSP",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Representing Information",
+      "name": "Representing Information",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Circle Square Patterns",
+      "name": "Circle Square Patterns",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Overflow and Rounding",
+      "name": "Overflow and Rounding",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Representing Text",
+      "name": "Representing Text",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Black and White Images",
+      "name": "Black and White Images",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Color Images",
+      "name": "Color Images",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Lossless Compression",
+      "name": "Lossless Compression",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Lossy Compression",
+      "name": "Lossy Compression",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Intellectual Property",
+      "name": "Intellectual Property",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Project - Digital Information Dilemmas Part 1",
+      "name": "Project - Digital Information Dilemmas Part 1",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Project - Digital Information Dilemmas Part 2",
+      "name": "Project - Digital Information Dilemmas Part 2",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Lesson 14: Assessment Day",
+      "name": "Lesson 14: Assessment Day",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Unit 1 STUDENT Survey",
+      "name": "Unit 1 STUDENT Survey",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "key": "Unit 1 TEACHER Survey",
+      "name": "Unit 1 TEACHER Survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2020 pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "csp-pre-survey-2017-levelgroup_2020 pilot"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Computer Science is Changing Everything"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "csp_socialBelonging_control_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 CFU Sending Complex Messages"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L3 CFU Sending Complex Messages"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L4 CYU3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L4 CYU3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU how many bits"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L5 CFU how many bits"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU adding bits"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L5 CFU adding bits"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CFU bin dec similarities"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L5 CFU bin dec similarities"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Binary Odometer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "Widget: Binary Odometer_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 CFU beyond odometer"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L6 CFU beyond odometer"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 CFU representing fractions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L6 CFU representing fractions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Reflection Multiple Representations CSP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L8 Reflection Multiple Representations CSP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Intro to Pixelation Encoding B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L9 Introduction to Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1 L9 Introduction to Pixelation"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Pixelation - Make the Letter A_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget Fix bit offset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge a"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge a"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge B"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge B"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: B&W"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge C"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Pixelation Widget challenge C"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 CFU pixel data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 CFU pixel data"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Multiple Choice Digital Analog"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 Multiple Choice Digital Analog"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 CFU Sampling"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L9 CFU Sampling"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 RGB"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 RGB"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "More Shades of Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 More Shades of Color"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 More Shades of Color"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sampling"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Sampling"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Sampling"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 Color Pixelation Widget 4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Multiple Choice analog vs digital"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L10 Multiple Choice analog vs digital"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 CFU Sampling"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L10 CFU Sampling"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Text Compression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Widget: Text Compression"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L11 Widget: Text Compression"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Text Compression Widget with Aloe Blacc"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L11 Text Compression Widget Aloe Blacc"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1 L11 Text Compression Widget Aloe Blacc"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Multiple Choice lossless compression"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L11 Multiple Choice lossless compression"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 CFU Compression for Email"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L11 CFU Compression for Email"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lossy Compression Widget"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1 Lossy Compression Widget v1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lossy Compression Widget"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1 Lossy Compression Widget v2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 CPS CFU Cell Phone"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L11 CPS CFU Cell Phone"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 CFU Creative Commons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L12 CFU Creative Commons"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 CFU Copyright"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L12 CFU Copyright"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 CFU Digital Representation"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L13 CFU Digital Representation"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 CSP CFU digital information"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "U1L14 CSP CFU digital information"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 1 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 1 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 1 AP-Style Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 1 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 1 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U1 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      },
+      "level_keys": [
+        "CSP U1 20-21 Teacher Pilot Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-2017-levelgroup_2020 pilot",
+        "script_level.level_keys": [
+          "csp-pre-survey-2017-levelgroup_2020 pilot"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything_2020",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_socialBelonging_control_2018",
+        "script_level.level_keys": [
+          "csp_socialBelonging_control_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to CSP",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 CFU Sending Complex Messages",
+        "script_level.level_keys": [
+          "U1L3 CFU Sending Complex Messages"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Representing Information",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L4 CYU3",
+        "script_level.level_keys": [
+          "CSP U1L4 CYU3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Circle Square Patterns",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU how many bits",
+        "script_level.level_keys": [
+          "U1L5 CFU how many bits"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU adding bits",
+        "script_level.level_keys": [
+          "U1L5 CFU adding bits"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CFU bin dec similarities",
+        "script_level.level_keys": [
+          "U1L5 CFU bin dec similarities"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Binary Odometer_2020",
+        "script_level.level_keys": [
+          "Widget: Binary Odometer_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 CFU beyond odometer",
+        "script_level.level_keys": [
+          "U1L6 CFU beyond odometer"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 CFU representing fractions",
+        "script_level.level_keys": [
+          "U1L6 CFU representing fractions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Overflow and Rounding",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Reflection Multiple Representations CSP",
+        "script_level.level_keys": [
+          "U1L8 Reflection Multiple Representations CSP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Representing Text",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L9 Introduction to Pixelation",
+        "script_level.level_keys": [
+          "U1 L9 Introduction to Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation - Make the Letter A_2019",
+        "script_level.level_keys": [
+          "U1L9 Pixelation - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget Fix bit offset",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget Fix bit offset"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge a",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge a"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge B",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge B"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Pixelation Widget challenge C",
+        "script_level.level_keys": [
+          "U1L9 Pixelation Widget challenge C"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 CFU pixel data",
+        "script_level.level_keys": [
+          "U1L9 CFU pixel data"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Multiple Choice Digital Analog",
+        "script_level.level_keys": [
+          "U1L9 Multiple Choice Digital Analog"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 CFU Sampling",
+        "script_level.level_keys": [
+          "U1L9 CFU Sampling"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Black and White Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 RGB",
+        "script_level.level_keys": [
+          "CSP U1L10 RGB"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 1",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 More Shades of Color",
+        "script_level.level_keys": [
+          "CSP U1L10 More Shades of Color"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 2",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 3",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Sampling",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Sampling"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 Color Pixelation Widget 4",
+        "script_level.level_keys": [
+          "CSP U1L10 Color Pixelation Widget 4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Multiple Choice analog vs digital",
+        "script_level.level_keys": [
+          "U1L10 Multiple Choice analog vs digital"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 CFU Sampling",
+        "script_level.level_keys": [
+          "U1L10 CFU Sampling"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Color Images",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Widget: Text Compression",
+        "script_level.level_keys": [
+          "U1L11 Widget: Text Compression"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L11 Text Compression Widget Aloe Blacc",
+        "script_level.level_keys": [
+          "U1 L11 Text Compression Widget Aloe Blacc"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Multiple Choice lossless compression",
+        "script_level.level_keys": [
+          "U1L11 Multiple Choice lossless compression"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 CFU Compression for Email",
+        "script_level.level_keys": [
+          "U1L11 CFU Compression for Email"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Lossless Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 Lossy Compression Widget v1",
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 Lossy Compression Widget v2",
+        "script_level.level_keys": [
+          "U1 Lossy Compression Widget v2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 CPS CFU Cell Phone",
+        "script_level.level_keys": [
+          "U1L11 CPS CFU Cell Phone"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Lossy Compression",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 CFU Creative Commons",
+        "script_level.level_keys": [
+          "U1L12 CFU Creative Commons"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 CFU Copyright",
+        "script_level.level_keys": [
+          "U1L12 CFU Copyright"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Intellectual Property",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 CFU Digital Representation",
+        "script_level.level_keys": [
+          "U1L13 CFU Digital Representation"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 1",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U1L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 CSP CFU digital information",
+        "script_level.level_keys": [
+          "U1L14 CSP CFU digital information"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Project - Digital Information Dilemmas Part 2",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 1 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 1 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Assessment Day",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U1 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U1 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U1 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp1-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp1-support.script_json
+++ b/dashboard/config/scripts_json/csp1-support.script_json
@@ -1,0 +1,2645 @@
+{
+  "script": {
+    "name": "csp1-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CSP Support",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp1-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 1 Overview",
+      "name": "Unit 1 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "AP Preparation and Support",
+      "name": "AP Preparation and Support",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lessons 2 - 3: Binary Messages",
+      "name": "Lessons 2 - 3: Binary Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lessons 4 - 6: Encoding and Sending Numbers",
+      "name": "Lessons 4 - 6: Encoding and Sending Numbers",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lesson 7: Encoding and Sending Text",
+      "name": "Lesson 7: Encoding and Sending Text",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lesson 9: Internet Addressing",
+      "name": "Lesson 9: Internet Addressing",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+      "name": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Lessons 12 - 13: Abstraction on the Internet",
+      "name": "Lessons 12 - 13: Abstraction on the Internet",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Introduction to Unit 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Unit 1 Teaching Philosophy and Commentary"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching with the Internet Simulator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Teaching with the Internet Simulator"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Practice Performance Tasks in Unit 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Unit 1 Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 1 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Unit 1 Vocab and Concept Review Activity"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "AP Test Prep Guidance"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.2 Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.2 Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Understanding Communication Protocols"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Understanding Communication Protocols"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.3 Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.3 Overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Binary as an Encoding Scheme"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Binary as an Encoding Scheme"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Binary Messages"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Internet: Wires, Cables, and Wifi"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lessons 2 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lessons 2 - 3: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.4 Overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.4 Overview"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Why Teach Number Systems?"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Why Teach Number Systems?"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.5 Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.5 Overview"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.6 Overview"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.6 Overview"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sending Numbers: The Big Picture"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Sending Numbers: The Big Picture"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Numbers"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Reflection: Create your Own Number System"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Reflection: Create your Own Number System"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lessons 4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lessons 4 - 6: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.7 Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.7 Overview"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is ASCII?"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "What is ASCII?"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: ASCII Representation of your Name"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Task: ASCII Representation of your Name"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is HTML?"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "What is HTML?"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Sending Text"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 7: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 7: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.9 Overview"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.9 Overview"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Addressing in the Game of Battleship"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Addressing in the Game of Battleship"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: Develop a Battleship Protocol"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Task: Develop a Battleship Protocol"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Broadcast"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 9: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.10 Overview"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.10 Overview"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Routers"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Routers"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.11 Overview"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.11 Overview"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: Packets"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: Packets"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Internet: Packets, Routing, and Reliability"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lessons 10 - 11: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lessons 10 - 11: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.12 Overview"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.12 Overview"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator: DNS"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Internet Simulator: DNS"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Internet: IP Addresses & DNS"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lesson 1.13 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lesson 1.13 Overview"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Internet: HTTP and HTML"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lessons 12 - 13: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Lessons 12 - 13: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Group Work and Peer Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Balancing Teacher and Tools in Unit 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Balancing Teacher and Tools in Unit 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Discovery Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Assessing Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Assessing Student Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      },
+      "level_keys": [
+        "Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 1",
+        "script_level.level_keys": [
+          "Introduction to Unit 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Teaching Philosophy and Commentary",
+        "script_level.level_keys": [
+          "Unit 1 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching with the Internet Simulator",
+        "script_level.level_keys": [
+          "Teaching with the Internet Simulator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Performance Tasks in Unit 1",
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Self-Assessment",
+        "script_level.level_keys": [
+          "Unit 1 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 1 Vocab and Concept Review Activity",
+        "script_level.level_keys": [
+          "Unit 1 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AP Test Prep Guidance",
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.2 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.2 Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Understanding Communication Protocols",
+        "script_level.level_keys": [
+          "Understanding Communication Protocols"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.3 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.3 Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Binary as an Encoding Scheme",
+        "script_level.level_keys": [
+          "Binary as an Encoding Scheme"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Binary Messages",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Binary Messages"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Wires, Cables, and Wifi",
+        "script_level.level_keys": [
+          "The Internet: Wires, Cables, and Wifi"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lessons 2 - 3: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lessons 2 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 2 - 3: Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.4 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.4 Overview"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Why Teach Number Systems?",
+        "script_level.level_keys": [
+          "Why Teach Number Systems?"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.5 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.5 Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.6 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.6 Overview"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sending Numbers: The Big Picture",
+        "script_level.level_keys": [
+          "Sending Numbers: The Big Picture"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Numbers",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Numbers"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Reflection: Create your Own Number System",
+        "script_level.level_keys": [
+          "Reflection: Create your Own Number System"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lessons 4 - 6: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lessons 4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 4 - 6: Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.7 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.7 Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is ASCII?",
+        "script_level.level_keys": [
+          "What is ASCII?"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: ASCII Representation of your Name",
+        "script_level.level_keys": [
+          "Task: ASCII Representation of your Name"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is HTML?",
+        "script_level.level_keys": [
+          "What is HTML?"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Sending Text",
+        "script_level.level_keys": [
+          "Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 7: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lesson 7: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 7: Encoding and Sending Text",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.9 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.9 Overview"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Addressing in the Game of Battleship",
+        "script_level.level_keys": [
+          "Addressing in the Game of Battleship"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: Develop a Battleship Protocol",
+        "script_level.level_keys": [
+          "Task: Develop a Battleship Protocol"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Broadcast",
+        "script_level.level_keys": [
+          "Internet Simulator: Broadcast"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 9: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lesson 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Lesson 9: Internet Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.10 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.10 Overview"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Routers",
+        "script_level.level_keys": [
+          "Internet Simulator: Routers"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.11 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.11 Overview"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: Packets",
+        "script_level.level_keys": [
+          "Internet Simulator: Packets"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: Packets, Routing, and Reliability",
+        "script_level.level_keys": [
+          "The Internet: Packets, Routing, and Reliability"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lessons 10 - 11: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lessons 10 - 11: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 10 - 11: Routers, Redundancy, and Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.12 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.12 Overview"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator: DNS",
+        "script_level.level_keys": [
+          "Internet Simulator: DNS"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: IP Addresses & DNS",
+        "script_level.level_keys": [
+          "The Internet: IP Addresses & DNS"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lesson 1.13 Overview",
+        "script_level.level_keys": [
+          "Lesson 1.13 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Internet: HTTP and HTML",
+        "script_level.level_keys": [
+          "The Internet: HTTP and HTML"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lessons 12 - 13: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "Lessons 12 - 13: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 12 - 13: Abstraction on the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Group Work and Peer Learning in Unit 1",
+        "script_level.level_keys": [
+          "Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Balancing Teacher and Tools in Unit 1",
+        "script_level.level_keys": [
+          "Balancing Teacher and Tools in Unit 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery Learning in Unit 1",
+        "script_level.level_keys": [
+          "Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Assessing Student Learning in Unit 1",
+        "script_level.level_keys": [
+          "Assessing Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp1-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp10-2020.script_json
+++ b/dashboard/config/scripts_json/csp10-2020.script_json
@@ -1,0 +1,1230 @@
+{
+  "script": {
+    "name": "csp10-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit10/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit10/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp10-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_unit10_2020",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 10: Cybersecurity and Global Impacts"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Project - Innovation Simulation Part 1",
+      "name": "Project - Innovation Simulation Part 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project - Innovation Simulation Part 2",
+      "name": "Project - Innovation Simulation Part 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Data Policies and Privacy",
+      "name": "Data Policies and Privacy",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "The Value of Privacy",
+      "name": "The Value of Privacy",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project - Innovation Simulation Part 3",
+      "name": "Project - Innovation Simulation Part 3",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Security Risks Part 1",
+      "name": "Security Risks Part 1",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Security Risks Part 2",
+      "name": "Security Risks Part 2",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 4",
+      "name": "Project: Innovation Simulation Part 4",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Protecting Data Part 1",
+      "name": "Protecting Data Part 1",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Protecting Data Part 2",
+      "name": "Protecting Data Part 2",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 5",
+      "name": "Project: Innovation Simulation Part 5",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 6",
+      "name": "Project: Innovation Simulation Part 6",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 7",
+      "name": "Project: Innovation Simulation Part 7",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "key": "Lesson 14: Unit Assessment Day",
+      "name": "Lesson 14: Unit Assessment Day",
+      "absolute_position": 14,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L01 CFU innovations"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10 L01 CFU innovations"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L02 CFU innovations part 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10 L02 CFU innovations part 2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L3 CFU Why Collect PII"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10L3 CFU Why Collect PII"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keylogging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Keylogging"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP 20-21 Keylogging"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Phishing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Phishing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP 20-21 Phishing"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Malware"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Rogue Access Points"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP 20-21 Rogue Access Points"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L07 CFU security risks"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10 L07 CFU security risks"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L08 CFU security risks"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10 L08 CFU security risks"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption Widgets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption Widgets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "Crack Random Substitution_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L9 CFU public key"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10L9 CFU public key"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L10 CFU MFA"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "U10L10 CFU MFA"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP U10L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 10 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 10 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 10 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L01 CFU innovations",
+        "script_level.level_keys": [
+          "U10 L01 CFU innovations"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L02 CFU innovations part 2",
+        "script_level.level_keys": [
+          "U10 L02 CFU innovations part 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L3 CFU Why Collect PII",
+        "script_level.level_keys": [
+          "U10L3 CFU Why Collect PII"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Keylogging",
+        "script_level.level_keys": [
+          "CSP 20-21 Keylogging"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Phishing",
+        "script_level.level_keys": [
+          "CSP 20-21 Phishing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Rogue Access Points",
+        "script_level.level_keys": [
+          "CSP 20-21 Rogue Access Points"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L07 CFU security risks",
+        "script_level.level_keys": [
+          "U10 L07 CFU security risks"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L08 CFU security risks",
+        "script_level.level_keys": [
+          "U10 L08 CFU security risks"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher_2020",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution_2020",
+        "script_level.level_keys": [
+          "Crack Random Substitution_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L9 CFU public key",
+        "script_level.level_keys": [
+          "U10L9 CFU public key"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L10 CFU MFA",
+        "script_level.level_keys": [
+          "U10L10 CFU MFA"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 10 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 10 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "csp_unit10_2020",
+        "script.name": "csp10-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp10-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp10-pilot-staging.script_json
@@ -1,0 +1,3613 @@
+{
+  "script": {
+    "name": "csp10-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp10-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp10-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp10-pilot.script_json
+++ b/dashboard/config/scripts_json/csp10-pilot.script_json
@@ -1,0 +1,1207 @@
+{
+  "script": {
+    "name": "csp10-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp10-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Project - Innovation Simulation Part 1",
+      "name": "Project - Innovation Simulation Part 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project - Innovation Simulation Part 2",
+      "name": "Project - Innovation Simulation Part 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Data Policies and Privacy",
+      "name": "Data Policies and Privacy",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "The Value of Privacy",
+      "name": "The Value of Privacy",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project - Innovation Simulation Part 3",
+      "name": "Project - Innovation Simulation Part 3",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Security Risks Part 1",
+      "name": "Security Risks Part 1",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Security Risks Part 2",
+      "name": "Security Risks Part 2",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 4",
+      "name": "Project: Innovation Simulation Part 4",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Protecting Data Part 1",
+      "name": "Protecting Data Part 1",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Protecting Data Part 2",
+      "name": "Protecting Data Part 2",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 5",
+      "name": "Project: Innovation Simulation Part 5",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 6",
+      "name": "Project: Innovation Simulation Part 6",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Project: Innovation Simulation Part 7",
+      "name": "Project: Innovation Simulation Part 7",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "key": "Lesson 14: Unit Assessment Day",
+      "name": "Lesson 14: Unit Assessment Day",
+      "absolute_position": 14,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L01 CFU innovations"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10 L01 CFU innovations"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L02 CFU innovations part 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10 L02 CFU innovations part 2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L3 CFU Why Collect PII"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10L3 CFU Why Collect PII"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Keylogging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Keylogging"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP 20-21 Keylogging"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Phishing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Phishing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP 20-21 Phishing"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Malware"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Rogue Access Points"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP 20-21 Rogue Access Points"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L07 CFU security risks"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10 L07 CFU security risks"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10 L08 CFU security risks"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10 L08 CFU security risks"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption Widgets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption Widgets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "Crack Random Substitution_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L9 CFU public key"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10L9 CFU public key"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U10L10 CFU MFA"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "U10L10 CFU MFA"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U10L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP U10L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 10 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 10 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 10 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L01 CFU innovations",
+        "script_level.level_keys": [
+          "U10 L01 CFU innovations"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L02 CFU innovations part 2",
+        "script_level.level_keys": [
+          "U10 L02 CFU innovations part 2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Project - Innovation Simulation Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L3 CFU Why Collect PII",
+        "script_level.level_keys": [
+          "U10L3 CFU Why Collect PII"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Data Policies and Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "The Value of Privacy",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Project - Innovation Simulation Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Keylogging",
+        "script_level.level_keys": [
+          "CSP 20-21 Keylogging"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Phishing",
+        "script_level.level_keys": [
+          "CSP 20-21 Phishing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Rogue Access Points",
+        "script_level.level_keys": [
+          "CSP 20-21 Rogue Access Points"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L07 CFU security risks",
+        "script_level.level_keys": [
+          "U10 L07 CFU security risks"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Security Risks Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10 L08 CFU security risks",
+        "script_level.level_keys": [
+          "U10 L08 CFU security risks"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Security Risks Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher_2020",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution_2020",
+        "script_level.level_keys": [
+          "Crack Random Substitution_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L9 CFU public key",
+        "script_level.level_keys": [
+          "U10L9 CFU public key"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Protecting Data Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U10L10 CFU MFA",
+        "script_level.level_keys": [
+          "U10L10 CFU MFA"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Protecting Data Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 5",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 6",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project: Innovation Simulation Part 7",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U10L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U10L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 10 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 10 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 14: Unit Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp10-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-2017.script_json
+++ b/dashboard/config/scripts_json/csp2-2017.script_json
@@ -1,0 +1,2891 @@
+{
+  "script": {
+    "name": "csp2-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp2"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit2/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp2-support"
+        ]
+      ]
+    },
+    "new_name": "csp2-2017",
+    "family_name": "csp2",
+    "seeding_key": {
+      "script.name": "csp2-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp2_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Encoding and Compressing Complex Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "csp2_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Manipulating and Visualizing Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bytes and File Sizes",
+      "name": "Bytes and File Sizes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Encoding B&W Images",
+      "name": "Encoding B&W Images",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Encoding Color Images",
+      "name": "Encoding Color Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Lossy Compression and File Formats",
+      "name": "Lossy Compression and File Formats",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Practice PT - Encode an Experience",
+      "name": "Practice PT - Encode an Experience",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Encode an Experience",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Unit 2 Chapter 1 Assessment",
+      "name": "Unit 2 Chapter 1 Assessment",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Chapter 1 Assessment",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Intro to Data",
+      "name": "Intro to Data",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Finding Trends with Visualizations",
+      "name": "Finding Trends with Visualizations",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Check Your Assumptions",
+      "name": "Check Your Assumptions",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Good and Bad Data Visualizations",
+      "name": "Good and Bad Data Visualizations",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Making Data Visualizations",
+      "name": "Making Data Visualizations",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Discover a Data Story",
+      "name": "Discover a Data Story",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Cleaning Data",
+      "name": "Cleaning Data",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Creating Summary Tables",
+      "name": "Creating Summary Tables",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Practice PT - Tell a Data Story",
+      "name": "Practice PT - Tell a Data Story",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Unit 2 Chapter 2 Assessment",
+      "name": "Unit 2 Chapter 2 Assessment",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L1 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L12 Reflection Free Response"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "CSP_U2_Shakespeare_Question"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-2-levelgroup-U2Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L2 Student Lesson Summary"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L2 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Text Compression"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Text Compression"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Widget: Text Compression"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L13 - Assess Text Compression reverse process"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L13 Assess Text Compression amount"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L13 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L13 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L3 Student Lesson Summary"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L3 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Widget: Black and White Pixelation"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L14 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L14 - Assessment 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L4 Student Lesson Summary"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L4 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Images, Pixels, and RGB"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Images, Pixels, and RGB"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation Flappy"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Pixelation Bee"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Favicon Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Favicon Instructions"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Favicon Instructions"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Color Pixelation"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Color Pixelation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Widget: Color Pixelation"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L5 Color Pixel MC Question"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L5 FR brighten darken image"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L5 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L16 - Matching File Compression Types"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U1L16 - Matching File Compression Types"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Encode an Experience",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Chapter 1 Assessment",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch1 Cumulative Assessment MC"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L7 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-3-levelgroup-U2Ch2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L8 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends MC"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L8 google trends MC"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L8 google trends hypothesis"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L9 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L9 What is digital divide MC"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L9 FR digital divide issue"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection A: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Collection A: Good and Bad Visualizations"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection B: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Collection B: Good and Bad Visualizations"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L10 FR why best worst viz"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Downloading the Data Set"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Downloading the Data Set"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Downloading the Data Set"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Scatter Plot"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Scatter Plot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Making a Scatter Plot"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Line Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Line Chart"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Making a Line Chart"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Bar Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Bar Chart"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Making a Bar Chart"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Editing Chart Appearance"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Editing Chart Appearance"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Editing Chart Appearance"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Data Visualizations - Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Free Play"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L10 FR describe what you made from lesson prompt"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L12 FR reflection on collaboration"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting to Know Your Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Getting to Know Your Data"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Getting to Know Your Data"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cleaning Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cleaning Data"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Cleaning Data"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Categorizing Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Categorizing Data"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Categorizing Data"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L13 Cleaning Data MC"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L13 FR Reflection data analysis objective"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L14 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 1 - The Basics"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 1 - The Basics"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 2 - Manipulation and Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 2 - Manipulation and Visualization"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 3"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "U2L14 Summary Tables MC"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U2L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "v2 U2L15 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_2": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_2": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_2",
+          "csp_affirmation_intervention_2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control_2",
+        "csp_affirmation_intervention_2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch2 Cumulative Assessment MC"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 Reflection Free Response",
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP_U2_Shakespeare_Question",
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-2-levelgroup-U2Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L2 Student Lesson Summary",
+        "script_level.level_keys": [
+          "v2 U2L2 Student Lesson Summary"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Text Compression",
+        "script_level.level_keys": [
+          "Text Compression"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Text Compression",
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 - Assess Text Compression reverse process",
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assess Text Compression amount",
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 1",
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 2",
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L3 Student Lesson Summary",
+        "script_level.level_keys": [
+          "v2 U2L3 Student Lesson Summary"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Black and White Pixelation",
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 Assessment 1",
+        "script_level.level_keys": [
+          "U1L14 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 - Assessment 2",
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L4 Student Lesson Summary",
+        "script_level.level_keys": [
+          "v2 U2L4 Student Lesson Summary"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Images, Pixels, and RGB",
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy",
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee",
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Favicon Instructions",
+        "script_level.level_keys": [
+          "Favicon Instructions"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Color Pixelation",
+        "script_level.level_keys": [
+          "Widget: Color Pixelation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 Color Pixel MC Question",
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 FR brighten darken image",
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L5 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L16 - Matching File Compression Types",
+        "script_level.level_keys": [
+          "U1L16 - Matching File Compression Types"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Encode an Experience",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch1 Cumulative Assessment MC",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Chapter 1 Assessment",
+        "lesson_group.key": "csp2_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L7 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-3-levelgroup-U2Ch2",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L8 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends MC",
+        "script_level.level_keys": [
+          "U2L8 google trends MC"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends hypothesis",
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L9 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 What is digital divide MC",
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 FR digital divide issue",
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection A: Good and Bad Visualizations",
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection B: Good and Bad Visualizations",
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR why best worst viz",
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Downloading the Data Set",
+        "script_level.level_keys": [
+          "Downloading the Data Set"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Scatter Plot",
+        "script_level.level_keys": [
+          "Making a Scatter Plot"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Line Chart",
+        "script_level.level_keys": [
+          "Making a Line Chart"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Bar Chart",
+        "script_level.level_keys": [
+          "Making a Bar Chart"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Editing Chart Appearance",
+        "script_level.level_keys": [
+          "Editing Chart Appearance"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Free Play",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR describe what you made from lesson prompt",
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L12 FR reflection on collaboration",
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Getting to Know Your Data",
+        "script_level.level_keys": [
+          "Getting to Know Your Data"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cleaning Data",
+        "script_level.level_keys": [
+          "Cleaning Data"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Categorizing Data",
+        "script_level.level_keys": [
+          "Categorizing Data"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Cleaning Data MC",
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 FR Reflection data analysis objective",
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L14 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 1 - The Basics",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 2 - Manipulation and Visualization",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 3",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Summary Tables MC",
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U2L15 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U2L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_2",
+        "script_level.level_keys": [
+          "csp_affirmation_control_2",
+          "csp_affirmation_intervention_2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_2",
+        "script_level.level_keys": [
+          "csp_affirmation_control_2",
+          "csp_affirmation_intervention_2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch2 Cumulative Assessment MC",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Chapter 2 Assessment",
+        "lesson_group.key": "csp2_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-2018.script_json
+++ b/dashboard/config/scripts_json/csp2-2018.script_json
@@ -1,0 +1,1401 @@
+{
+  "script": {
+    "name": "csp2-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "Are you signed up for the AP exam?",
+          "details": "Now's the time to register to take the AP CS Principles exam! Be sure to ask your teacher about your school's registration deadline and sign up today. Click to learn more about six great reasons why you should.",
+          "link": "https://code.org/educate/csp/ap-students",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp2"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-18/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/unit2/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp2-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp2",
+    "seeding_key": {
+      "script.name": "csp2-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp2_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 2: Digital Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bytes and File Sizes",
+      "name": "Bytes and File Sizes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Encoding B&W Images",
+      "name": "Encoding B&W Images",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Encoding Color Images",
+      "name": "Encoding Color Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Lossy vs Lossless Compression",
+      "name": "Lossy vs Lossless Compression",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Rapid Research - Format Showdown",
+      "name": "Rapid Research - Format Showdown",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "key": "Unit 2 Assessment",
+      "name": "Unit 2 Assessment",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L12 Reflection Free Response_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP_U2_Shakespeare_Question_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Text Compression_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Text Compression_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Text Compression_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Widget: Text Compression_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L13 - Assess Text Compression reverse process_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L13 Assess Text Compression amount_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 1_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L13 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L13 Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L03 SFLP"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Widget: Black and White Pixelation_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 Assessment 1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L14 Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U1L14 - Assessment 2_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L04 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Images, Pixels, and RGB"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Images, Pixels, and RGB_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation Flappy_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Pixelation Bee_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Favicon Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Favicon Instructions_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Favicon Instructions_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Color Pixelation"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Color Pixelation_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "Widget: Color Pixelation_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U2L5 Color Pixel MC Question_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U2L5 FR brighten darken image_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L05 SFLP"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 1_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U2L05 Lossy Lossless MC 1_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 2_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U2L05 Lossy Lossless MC 2_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy vs. Lossless FR 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "U2L05 Lossy vs. Lossless FR 1_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L06 SFLP"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP U2L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2018"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch1 Cumulative Assessment MC_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L01 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 Reflection Free Response_2018",
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP_U2_Shakespeare_Question_2018",
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L02 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Text Compression_2018",
+        "script_level.level_keys": [
+          "Text Compression_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Text Compression_2018",
+        "script_level.level_keys": [
+          "Widget: Text Compression_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 - Assess Text Compression reverse process_2018",
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assess Text Compression amount_2018",
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U1L13 Assessment 1_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 2_2018",
+        "script_level.level_keys": [
+          "U1L13 Assessment 2_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L03 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L03 SFLP"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A_2018",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset_2018",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Black and White Pixelation_2018",
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 Assessment 1_2018",
+        "script_level.level_keys": [
+          "U1L14 Assessment 1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 - Assessment 2_2018",
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L04 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L04 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Images, Pixels, and RGB_2018",
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color_2018",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades_2018",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4_2018",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy_2018",
+        "script_level.level_keys": [
+          "Pixelation Flappy_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee_2018",
+        "script_level.level_keys": [
+          "Pixelation Bee_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Favicon Instructions_2018",
+        "script_level.level_keys": [
+          "Favicon Instructions_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Color Pixelation_2018",
+        "script_level.level_keys": [
+          "Widget: Color Pixelation_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 Color Pixel MC Question_2018",
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 FR brighten darken image_2018",
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L05 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L05 SFLP"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy Lossless MC 1_2018",
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 1_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy Lossless MC 2_2018",
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 2_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy vs. Lossless FR 1_2018",
+        "script_level.level_keys": [
+          "U2L05 Lossy vs. Lossless FR 1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L06 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L06 SFLP"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch1 Cumulative Assessment MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-2019.script_json
+++ b/dashboard/config/scripts_json/csp2-2019.script_json
@@ -1,0 +1,1489 @@
+{
+  "script": {
+    "name": "csp2-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/unit2/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/unit2/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp2"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-19/unit2/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/unit2/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://code.org/educate/professional-learning/middle-high"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp2",
+    "seeding_key": {
+      "script.name": "csp2-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp2_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 2: Digital Information"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bytes and File Sizes",
+      "name": "Bytes and File Sizes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Encoding B&W Images",
+      "name": "Encoding B&W Images",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Encoding Color Images",
+      "name": "Encoding Color Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Lossy vs Lossless Compression",
+      "name": "Lossy vs Lossless Compression",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Rapid Research - Format Showdown",
+      "name": "Rapid Research - Format Showdown",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "Unit 2 Assessment",
+      "name": "Unit 2 Assessment",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 8,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L12 Reflection Free Response_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP_U2_Shakespeare_Question_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L02 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Text Compression_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Text Compression_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Text Compression"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Text Compression_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Widget: Text Compression_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L13 - Assess Text Compression reverse process_2018_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L13 Assess Text Compression amount_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 1_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L13 Assessment 1_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 2_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L13 Assessment 2_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L03 SFLP_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation Widget: Black and White Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Widget: Black and White Pixelation_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 Assessment 1_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L14 Assessment 1_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U1L14 - Assessment 2_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L04 SFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L04 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Images, Pixels, and RGB"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Images, Pixels, and RGB_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation Flappy_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Pixelation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Pixelation Bee_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Favicon Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Favicon Instructions_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Favicon Instructions_2018_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Color Pixelation"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Color Pixelation_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "Widget: Color Pixelation_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U2L5 Color Pixel MC Question_2018_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U2L5 FR brighten darken image_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L05 SFLP_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L05 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 1_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U2L05 Lossy Lossless MC 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 2_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U2L05 Lossy Lossless MC 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Lossy vs. Lossless FR 1_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "U2L05 Lossy vs. Lossless FR 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L06 SFLP_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP U2L06 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 Reflection Free Response_2019",
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP_U2_Shakespeare_Question_2019",
+        "script_level.level_keys": [
+          "CSP_U2_Shakespeare_Question_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-2-levelgroup-U2Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L02 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Text Compression_2019",
+        "script_level.level_keys": [
+          "Text Compression_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Text Compression_2019",
+        "script_level.level_keys": [
+          "Widget: Text Compression_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 - Assess Text Compression reverse process_2018_2019",
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assess Text Compression amount_2019",
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 1_2019",
+        "script_level.level_keys": [
+          "U1L13 Assessment 1_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 2_2019",
+        "script_level.level_keys": [
+          "U1L13 Assessment 2_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L03 SFLP_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A_2019",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset_2019",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Black and White Pixelation_2019",
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 Assessment 1_2019",
+        "script_level.level_keys": [
+          "U1L14 Assessment 1_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 - Assessment 2_2019",
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L04 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L04 SFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Images, Pixels, and RGB_2019",
+        "script_level.level_keys": [
+          "Images, Pixels, and RGB_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color_2019",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades_2019",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4_2019",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy_2019",
+        "script_level.level_keys": [
+          "Pixelation Flappy_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee_2019",
+        "script_level.level_keys": [
+          "Pixelation Bee_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Favicon Instructions_2018_2019",
+        "script_level.level_keys": [
+          "Favicon Instructions_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Color Pixelation_2019",
+        "script_level.level_keys": [
+          "Widget: Color Pixelation_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 Color Pixel MC Question_2018_2019",
+        "script_level.level_keys": [
+          "U2L5 Color Pixel MC Question_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 FR brighten darken image_2019",
+        "script_level.level_keys": [
+          "U2L5 FR brighten darken image_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L05 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L05 SFLP_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy Lossless MC 1_2018_2019",
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 1_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy Lossless MC 2_2018_2019",
+        "script_level.level_keys": [
+          "U2L05 Lossy Lossless MC 2_2018_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Lossy vs. Lossless FR 1_2018_2019",
+        "script_level.level_keys": [
+          "U2L05 Lossy vs. Lossless FR 1_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Lossy vs Lossless Compression",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L06 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L06 SFLP_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Format Showdown",
+        "lesson_group.key": "csp2_1_2018",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch1 Cumulative Assessment MC_2018_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp2-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-2020.script_json
+++ b/dashboard/config/scripts_json/csp2-2020.script_json
@@ -1,0 +1,1052 @@
+{
+  "script": {
+    "name": "csp2-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit2/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit2/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_unit2_2020",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 2: The Internet"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome to the Internet",
+      "name": "Welcome to the Internet",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Building a Network",
+      "name": "Building a Network",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Packets",
+      "name": "Packets",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "DNS and HTTP",
+      "name": "DNS and HTTP",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Project - Internet Dilemmas Part 1",
+      "name": "Project - Internet Dilemmas Part 1",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Project - Internet Dilemmas Part 2",
+      "name": "Project - Internet Dilemmas Part 2",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "key": "Lesson 9: Assessment Day",
+      "name": "Lesson 9: Assessment Day",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Internet Simulator"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L1 Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L1 Internet Simulator: Sending Text"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L1 CFU how use internet"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L1 CFU how use internet"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L1 CFU paths"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L1 CFU paths"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Broadcast Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP Internet Simulator Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L2 CSP Internet Simulator Broadcast"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP Addresses"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L2 CSP CFU IP Addresses"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP works"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L2 CSP CFU IP works"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Routers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 CSP Internet Simulator Routers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U1L3 CSP Internet Simulator Routers"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Routers"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L3 CSP CFU Routers"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Redundancy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L3 CSP CFU Redundancy"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Packets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 CSP Internet Simulator Packets 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U1L4 CSP Internet Simulator Packets 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 Multiple Choice packets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L4 Multiple Choice packets"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 CSP CFU terms"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L4 CSP CFU terms"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: DNS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CSP Internet Simulator DNS"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U1L5 CSP Internet Simulator DNS"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 CSP CFU scale"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L4 CSP CFU scale"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "U2L5 CSP CFU subgroups"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP U2L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 2 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 MC Assessment _2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      },
+      "level_keys": [
+        "CSP Unit 2 MC Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L1 Internet Simulator: Sending Text",
+        "script_level.level_keys": [
+          "CSP U2L1 Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L1 CFU how use internet",
+        "script_level.level_keys": [
+          "U2L1 CFU how use internet"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L1 CFU paths",
+        "script_level.level_keys": [
+          "U2L1 CFU paths"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP Internet Simulator Broadcast",
+        "script_level.level_keys": [
+          "U2L2 CSP Internet Simulator Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP CFU IP Addresses",
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP Addresses"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP CFU IP works",
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP works"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 CSP Internet Simulator Routers",
+        "script_level.level_keys": [
+          "U1L3 CSP Internet Simulator Routers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 CSP CFU Routers",
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Routers"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 CSP CFU Redundancy",
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Redundancy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 CSP Internet Simulator Packets 2",
+        "script_level.level_keys": [
+          "U1L4 CSP Internet Simulator Packets 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 Multiple Choice packets",
+        "script_level.level_keys": [
+          "U2L4 Multiple Choice packets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 CSP CFU terms",
+        "script_level.level_keys": [
+          "U2L4 CSP CFU terms"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Packets",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CSP Internet Simulator DNS",
+        "script_level.level_keys": [
+          "U1L5 CSP Internet Simulator DNS"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 CSP CFU scale",
+        "script_level.level_keys": [
+          "U2L4 CSP CFU scale"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 CSP CFU subgroups",
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 MC Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 2 MC Assessment _2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit2_2020",
+        "script.name": "csp2-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp2-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp2-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 2 Deeper Learning Reflections",
+      "name": "Complete Unit 2 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "csp2-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "csp2-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      },
+      "level_keys": [
+        "csp2-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2-dlp-q1",
+        "script_level.level_keys": [
+          "csp2-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2-dlp-q2",
+        "script_level.level_keys": [
+          "csp2-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2-dlp-q3",
+        "script_level.level_keys": [
+          "csp2-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-dlp.script_json
+++ b/dashboard/config/scripts_json/csp2-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csp2-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 2 Deeper Learning Reflections",
+      "name": "Complete Unit 2 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "csp deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "csp2dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "csp2dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp2dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      },
+      "level_keys": [
+        "csp2dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp deeper learning timeline",
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2dlp-lessons",
+        "script_level.level_keys": [
+          "csp2dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2dlp-tools",
+        "script_level.level_keys": [
+          "csp2dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp2dlp-assessment",
+        "script_level.level_keys": [
+          "csp2dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 2 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp2-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp2-pilot-staging.script_json
@@ -1,0 +1,3613 @@
+{
+  "script": {
+    "name": "csp2-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp2-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-pilot.script_json
+++ b/dashboard/config/scripts_json/csp2-pilot.script_json
@@ -1,0 +1,1141 @@
+{
+  "script": {
+    "name": "csp2-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit2/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome to the Internet",
+      "name": "Welcome to the Internet",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Building a Network",
+      "name": "Building a Network",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Packets",
+      "name": "Packets",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "DNS and HTTP",
+      "name": "DNS and HTTP",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Project - Internet Dilemmas Part 1",
+      "name": "Project - Internet Dilemmas Part 1",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Project - Internet Dilemmas Part 2",
+      "name": "Project - Internet Dilemmas Part 2",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Lesson 9: Assessment Day",
+      "name": "Lesson 9: Assessment Day",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Unit 2 STUDENT Survey",
+      "name": "Unit 2 STUDENT Survey",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "key": "Unit 2 TEACHER Survey",
+      "name": "Unit 2 TEACHER Survey",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Internet Simulator"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L1 Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L1 Internet Simulator: Sending Text"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L1 CFU how use internet"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L1 CFU how use internet"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L1 CFU paths"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L1 CFU paths"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Broadcast Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP Internet Simulator Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L2 CSP Internet Simulator Broadcast"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP Addresses"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L2 CSP CFU IP Addresses"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP works"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L2 CSP CFU IP works"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Routers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 CSP Internet Simulator Routers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U1L3 CSP Internet Simulator Routers"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Routers"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L3 CSP CFU Routers"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Redundancy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L3 CSP CFU Redundancy"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: Packets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 CSP Internet Simulator Packets 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U1L4 CSP Internet Simulator Packets 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 Multiple Choice packets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L4 Multiple Choice packets"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 CSP CFU terms"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L4 CSP CFU terms"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Internet Simulator: DNS"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 CSP Internet Simulator DNS"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U1L5 CSP Internet Simulator DNS"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 CSP CFU scale"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L4 CSP CFU scale"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "U2L5 CSP CFU subgroups"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 2 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 MC Assessment _2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 2 MC Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 2 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 2 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      },
+      "level_keys": [
+        "CSP U2 20-21 Teacher Pilot Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L1 Internet Simulator: Sending Text",
+        "script_level.level_keys": [
+          "CSP U2L1 Internet Simulator: Sending Text"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L1 CFU how use internet",
+        "script_level.level_keys": [
+          "U2L1 CFU how use internet"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to the Internet",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L1 CFU paths",
+        "script_level.level_keys": [
+          "U2L1 CFU paths"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Building a Network",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP Internet Simulator Broadcast",
+        "script_level.level_keys": [
+          "U2L2 CSP Internet Simulator Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP CFU IP Addresses",
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP Addresses"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 CSP CFU IP works",
+        "script_level.level_keys": [
+          "U2L2 CSP CFU IP works"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 CSP Internet Simulator Routers",
+        "script_level.level_keys": [
+          "U1L3 CSP Internet Simulator Routers"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 CSP CFU Routers",
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Routers"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 CSP CFU Redundancy",
+        "script_level.level_keys": [
+          "U2L3 CSP CFU Redundancy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 CSP Internet Simulator Packets 2",
+        "script_level.level_keys": [
+          "U1L4 CSP Internet Simulator Packets 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 Multiple Choice packets",
+        "script_level.level_keys": [
+          "U2L4 Multiple Choice packets"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 CSP CFU terms",
+        "script_level.level_keys": [
+          "U2L4 CSP CFU terms"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Packets",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 CSP Internet Simulator DNS",
+        "script_level.level_keys": [
+          "U1L5 CSP Internet Simulator DNS"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 CSP CFU scale",
+        "script_level.level_keys": [
+          "U2L4 CSP CFU scale"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 CSP CFU subgroups",
+        "script_level.level_keys": [
+          "U2L5 CSP CFU subgroups"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "DNS and HTTP",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U2L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Internet Dilemmas Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 MC Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 2 MC Assessment _2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U2 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U2 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp2-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp2-support.script_json
+++ b/dashboard/config/scripts_json/csp2-support.script_json
@@ -1,0 +1,2351 @@
+{
+  "script": {
+    "name": "csp2-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CSP Support",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp2-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 2 Overview",
+      "name": "Unit 2 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "AP Preparation and Support",
+      "name": "AP Preparation and Support",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+      "name": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Lessons 3 - 4 : Encoding Images",
+      "name": "Lessons 3 - 4 : Encoding Images",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+      "name": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Lessons 7 - 10: Interpreting Visual Data",
+      "name": "Lessons 7 - 10: Interpreting Visual Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Lessons 11 - 15: Communicating with Visualizations",
+      "name": "Lessons 11 - 15: Communicating with Visualizations",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Introduction to Unit 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Curriculum Framework Connections in Unit 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Curriculum Framework Connections in Unit 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Tool Talk"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Tool Talk"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Practice Performance Tasks in Unit 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Vocab and Concept Review Activity"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "AP Test Prep Guidance"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2.1 and 2.2 Lesson Connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "2.1 and 2.2 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview of File Sizes and Metrics"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Overview of File Sizes and Metrics"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lossless Compression and the Text Compression Widget"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Introduction to Lossless Compression and the Text Compression Widget"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is a Heuristic?"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "What is a Heuristic?"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to: Text Compression Widget"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "How to: Text Compression Widget"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Widget: Text Compression"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: Write your own Heuristic"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Task: Write your own Heuristic"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 L1 - 2: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "U2 L1 - 2: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2.3 and 2.4 Lesson Connections"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "2.3 and 2.4 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How are Images Encoded?"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "How are Images Encoded?"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "A Note On Metadata in the Curriculum Framework"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "A Note On Metadata in the Curriculum Framework"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Widget: Black and White Pixelation"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Binary, Hex, and Images"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Binary, Hex, and Images"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Color Pixelation"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Widget: Color Pixelation"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: Make your own Favicon"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Task: Make your own Favicon"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 L3 - 4: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "U2 L3 - 4: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2.5 and 2.6 Lesson Connections"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "2.5 and 2.6 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lossy Compression"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Introduction to Lossy Compression"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Lossy vs. Lossless Compression"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Lossy vs. Lossless Compression"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: Encode an Experience"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Task: Encode an Experience"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 L5 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "U2 L5 - 6: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2.7 -  10 Lesson Connections"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "2.7 -  10 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to: Setup your Class Data Tracker"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "How to: Setup your Class Data Tracker"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Correlation vs Causation"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Correlation vs Causation"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to: Use Google Trends"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "How to: Use Google Trends"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Task: Explore Google Trends"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Task: Explore Google Trends"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What Makes an Effective Visualization?"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "What Makes an Effective Visualization?"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Data Visualizations 101"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Data Visualizations 101"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "U2 L7 - 10: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2.11 - 15 Lesson Connections"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "2.11 - 15 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to: Make Charts from your Data"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "How to: Make Charts from your Data"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Selecting an Appropriate Visualization for your Data"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Selecting an Appropriate Visualization for your Data"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cleaning Data"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Cleaning Data"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Summary Tables 101"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Summary Tables 101"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 L11 - 15: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "U2 L11 - 15: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      },
+      "level_keys": [
+        "Unit 2 Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 2",
+        "script_level.level_keys": [
+          "Introduction to Unit 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Curriculum Framework Connections in Unit 2",
+        "script_level.level_keys": [
+          "Curriculum Framework Connections in Unit 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Tool Talk",
+        "script_level.level_keys": [
+          "Unit 2 Tool Talk"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Performance Tasks in Unit 2",
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Self-Assessment",
+        "script_level.level_keys": [
+          "Unit 2 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Vocab and Concept Review Activity",
+        "script_level.level_keys": [
+          "Unit 2 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AP Test Prep Guidance",
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2.1 and 2.2 Lesson Connections",
+        "script_level.level_keys": [
+          "2.1 and 2.2 Lesson Connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview of File Sizes and Metrics",
+        "script_level.level_keys": [
+          "Overview of File Sizes and Metrics"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lossless Compression and the Text Compression Widget",
+        "script_level.level_keys": [
+          "Introduction to Lossless Compression and the Text Compression Widget"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is a Heuristic?",
+        "script_level.level_keys": [
+          "What is a Heuristic?"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to: Text Compression Widget",
+        "script_level.level_keys": [
+          "How to: Text Compression Widget"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Text Compression",
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: Write your own Heuristic",
+        "script_level.level_keys": [
+          "Task: Write your own Heuristic"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 L1 - 2: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U2 L1 - 2: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 1 - 2: Bytes, File Sizes, and Text Compression",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2.3 and 2.4 Lesson Connections",
+        "script_level.level_keys": [
+          "2.3 and 2.4 Lesson Connections"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How are Images Encoded?",
+        "script_level.level_keys": [
+          "How are Images Encoded?"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "A Note On Metadata in the Curriculum Framework",
+        "script_level.level_keys": [
+          "A Note On Metadata in the Curriculum Framework"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Black and White Pixelation",
+        "script_level.level_keys": [
+          "Widget: Black and White Pixelation"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Binary, Hex, and Images",
+        "script_level.level_keys": [
+          "Binary, Hex, and Images"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Color Pixelation",
+        "script_level.level_keys": [
+          "Widget: Color Pixelation"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: Make your own Favicon",
+        "script_level.level_keys": [
+          "Task: Make your own Favicon"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 L3 - 4: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U2 L3 - 4: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 3 - 4 : Encoding Images",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2.5 and 2.6 Lesson Connections",
+        "script_level.level_keys": [
+          "2.5 and 2.6 Lesson Connections"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lossy Compression",
+        "script_level.level_keys": [
+          "Introduction to Lossy Compression"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Lossy vs. Lossless Compression",
+        "script_level.level_keys": [
+          "Lossy vs. Lossless Compression"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: Encode an Experience",
+        "script_level.level_keys": [
+          "Task: Encode an Experience"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 L5 - 6: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U2 L5 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2.7 -  10 Lesson Connections",
+        "script_level.level_keys": [
+          "2.7 -  10 Lesson Connections"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to: Setup your Class Data Tracker",
+        "script_level.level_keys": [
+          "How to: Setup your Class Data Tracker"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Correlation vs Causation",
+        "script_level.level_keys": [
+          "Correlation vs Causation"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to: Use Google Trends",
+        "script_level.level_keys": [
+          "How to: Use Google Trends"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Task: Explore Google Trends",
+        "script_level.level_keys": [
+          "Task: Explore Google Trends"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What Makes an Effective Visualization?",
+        "script_level.level_keys": [
+          "What Makes an Effective Visualization?"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Data Visualizations 101",
+        "script_level.level_keys": [
+          "Data Visualizations 101"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 L7 - 10: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U2 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 7 - 10: Interpreting Visual Data",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2.11 - 15 Lesson Connections",
+        "script_level.level_keys": [
+          "2.11 - 15 Lesson Connections"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to: Make Charts from your Data",
+        "script_level.level_keys": [
+          "How to: Make Charts from your Data"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Selecting an Appropriate Visualization for your Data",
+        "script_level.level_keys": [
+          "Selecting an Appropriate Visualization for your Data"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cleaning Data",
+        "script_level.level_keys": [
+          "Cleaning Data"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Summary Tables 101",
+        "script_level.level_keys": [
+          "Summary Tables 101"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 L11 - 15: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U2 L11 - 15: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 11 - 15: Communicating with Visualizations",
+        "lesson_group.key": "content",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 2 Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Unit 2 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp2-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-2017.script_json
+++ b/dashboard/config/scripts_json/csp3-2017.script_json
@@ -1,0 +1,3819 @@
+{
+  "script": {
+    "name": "csp3-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit3/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp/unit3/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit3/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp3-support"
+        ]
+      ]
+    },
+    "new_name": "csp3-2017",
+    "family_name": "csp3",
+    "seeding_key": {
+      "script.name": "csp3-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming Languages and Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L01 Assessment1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L01 Assessment3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L02 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_applab_turtle"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L02 Assessment"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L05 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_applab_functions"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) Abstraction in Programming"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "CSP Abstraction in Programming 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 - draw step"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 Assessment"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L04 - snowflake"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Design Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Score a student response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Assessment2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L06 Assessment"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_applab_functions_parameters"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 whats a comment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3 whats a comment"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 how to add comments"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 how to add comments"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - fish"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - randomInput"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - freePlay"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Managing Complexity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 Assessment1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 Assessment2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_applab_loops"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - introSquare"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "subgoals_U3_turtle_prediction_FR"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - bubbles"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - fish"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - seaStar"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Identify the Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "v2 U3L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Components"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - individualCode"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_3": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_3": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control_3",
+        "csp_affirmation_intervention_3"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1",
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3",
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L02 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_turtle",
+        "script_level.level_keys": [
+          "csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment",
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L05 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions",
+        "script_level.level_keys": [
+          "csp_applab_functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Abstraction in Programming 2",
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step",
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps",
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond",
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment",
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake",
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1",
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2",
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2",
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment",
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_parameters",
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 whats a comment",
+        "script_level.level_keys": [
+          "U3 whats a comment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 how to add comments",
+        "script_level.level_keys": [
+          "U3L08 how to add comments"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish",
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput",
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay",
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1",
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2",
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops",
+        "script_level.level_keys": [
+          "csp_applab_loops"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare",
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_U3_turtle_prediction_FR",
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles",
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish",
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar",
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode",
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-2018.script_json
+++ b/dashboard/config/scripts_json/csp3-2018.script_json
@@ -1,0 +1,3772 @@
+{
+  "script": {
+    "name": "csp3-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-18/unit3/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp-18/unit3/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/unit3/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp3-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp3",
+    "seeding_key": {
+      "script.name": "csp3-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 3: Intro to Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "Mid-Year Survey",
+      "name": "Mid-Year Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mid-Year Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L01 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L01 Assessment3_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L03 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L04 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_turtle_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_applab_turtle_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L02 Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L05 SFLP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_applab_functions_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Abstraction in Programming"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP Abstraction in Programming 2_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 - draw step_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 Three Steps_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 draw diamond_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L06 SFLP"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L04 - snowflake_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Design Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L04 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L04 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L07 SFLP"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Score a student response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L06 Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L08 SFLP"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_applab_functions_parameters_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 whats a comment_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3 whats a comment_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 how to add comments_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 how to add comments_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - fish_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - randomInput_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - freePlay_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Managing Complexity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L09 SFLP"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp_applab_loops_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - introSquare_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "subgoals_U3_turtle_prediction_FR_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - bubbles_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - fish_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - seaStar_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Identify the Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP U3L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Components"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - individualCode_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Share Code with Teammates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles Mid-year survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-mid-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Mid-Year Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp-mid-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L01 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1_2018",
+        "script_level.level_keys": [
+          "U3L01 Assessment1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3_2018",
+        "script_level.level_keys": [
+          "U3L01 Assessment3_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L02 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L02 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L03 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L03 SFLP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L04 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L04 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_turtle_2018",
+        "script_level.level_keys": [
+          "csp_applab_turtle_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands_2018",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right_2018",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid_2018",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment_2018",
+        "script_level.level_keys": [
+          "U3L02 Assessment_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started_2018",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR_2018",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L05 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L05 SFLP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_2018",
+        "script_level.level_keys": [
+          "csp_applab_functions_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround_2018",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround_2018",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle_2018",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Abstraction in Programming 2_2018",
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function_2018",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step_2018",
+        "script_level.level_keys": [
+          "U3L03 - draw step_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps_2018",
+        "script_level.level_keys": [
+          "U3L03 Three Steps_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond_2018",
+        "script_level.level_keys": [
+          "U3L03 draw diamond_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions_2018",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment_2018",
+        "script_level.level_keys": [
+          "U3L03 Assessment_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR_2018",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L06 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L06 SFLP"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake_2018",
+        "script_level.level_keys": [
+          "U3L04 - snowflake_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions_2018",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process_2018",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1_2018",
+        "script_level.level_keys": [
+          "U3L04 Assessment1_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2_2018",
+        "script_level.level_keys": [
+          "U3L04 Assessment2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L07 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L07 SFLP"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams_2018",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own_2018",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response_2018",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2_2018",
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice_2018",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment_2018",
+        "script_level.level_keys": [
+          "U3L06 Assessment_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup_2018",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L08 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L08 SFLP"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_parameters_2018",
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam_2018",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam_2018",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams_2018",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle_2018",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc_2018",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 whats a comment_2018",
+        "script_level.level_keys": [
+          "U3 whats a comment_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 how to add comments_2018",
+        "script_level.level_keys": [
+          "U3L08 how to add comments_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea_2018",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish_2018",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass_2018",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish_2018",
+        "script_level.level_keys": [
+          "U3L08 - fish_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish_2018",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput_2018",
+        "script_level.level_keys": [
+          "U3L08 - randomInput_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc_2018",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay_2018",
+        "script_level.level_keys": [
+          "U3L08 - freePlay_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity_2018",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1_2018",
+        "script_level.level_keys": [
+          "U3L08 Assessment1_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2_2018",
+        "script_level.level_keys": [
+          "U3L08 Assessment2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L09 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L09 SFLP"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_2018",
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare_2018",
+        "script_level.level_keys": [
+          "U3L07 - introSquare_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare_2018",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_U3_turtle_prediction_FR_2018",
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1_2018",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom_2018",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign_2018",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles_2018",
+        "script_level.level_keys": [
+          "U3L07 - bubbles_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish_2018",
+        "script_level.level_keys": [
+          "U3L07 - fish_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar_2018",
+        "script_level.level_keys": [
+          "U3L07 - seaStar_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass_2018",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass_2018",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams_2018",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random_2018",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction_2018",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops_2018",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR_2018",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L10 SFLP",
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode_2018",
+        "script_level.level_keys": [
+          "U3L08 - individualCode_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates_2018",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene_2018",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-mid-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-mid-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Mid-Year Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-2019.script_json
+++ b/dashboard/config/scripts_json/csp3-2019.script_json
@@ -1,0 +1,3741 @@
+{
+  "script": {
+    "name": "csp3-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/unit3/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-19/unit3/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp-19/unit3/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/unit3/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://code.org/educate/professional-learning/middle-high"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp3",
+    "seeding_key": {
+      "script.name": "csp3-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 3: Intro to Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L01 Assessment1_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L01 Assessment3_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L02 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L03 SFLP_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L04 SFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L04 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_turtle_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_applab_turtle_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L02 Assessment_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L05 SFLP_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L05 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_applab_functions_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Abstraction in Programming"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP Abstraction in Programming 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 - draw step_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 Three Steps_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 draw diamond_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions_2018_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 Assessment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L06 SFLP_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L06 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L04 - snowflake_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Design Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L04 Assessment1_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L04 Assessment2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L07 SFLP_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L07 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Score a student response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Assessment2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice_2018_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L06 Assessment_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L08 SFLP_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L08 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_applab_functions_parameters_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc_2018_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to add comments to code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 whats a comment_2018_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3 whats a comment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How to add comments to code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 how to add comments_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 how to add comments_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - fish_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - randomInput_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc_2018_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc_2018_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - freePlay_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Managing Complexity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 Assessment1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 Assessment2_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L09 SFLP_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L09 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp_applab_loops_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - introSquare_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "subgoals_U3_turtle_prediction_FR_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - bubbles_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - fish_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - seaStar_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Identify the Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops_2018_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops_2018_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP U3L10 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Components"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - individualCode_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Share Code with Teammates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates_2018_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates_2018_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1_2019",
+        "script_level.level_keys": [
+          "U3L01 Assessment1_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3_2019",
+        "script_level.level_keys": [
+          "U3L01 Assessment3_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L02 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L02 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L03 SFLP_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L04 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L04 SFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_turtle_2019",
+        "script_level.level_keys": [
+          "csp_applab_turtle_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands_2019",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right_2019",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid_2019",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment_2019",
+        "script_level.level_keys": [
+          "U3L02 Assessment_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started_2019",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR_2019",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L05 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L05 SFLP_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_2019",
+        "script_level.level_keys": [
+          "csp_applab_functions_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround_2019",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround_2019",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle_2019",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Abstraction in Programming 2_2018_2019",
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function_2019",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step_2019",
+        "script_level.level_keys": [
+          "U3L03 - draw step_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps_2019",
+        "script_level.level_keys": [
+          "U3L03 Three Steps_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond_2019",
+        "script_level.level_keys": [
+          "U3L03 draw diamond_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions_2018_2019",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment_2018_2019",
+        "script_level.level_keys": [
+          "U3L03 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR_2019",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L06 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L06 SFLP_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake_2019",
+        "script_level.level_keys": [
+          "U3L04 - snowflake_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions_2019",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process_2019",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1_2019",
+        "script_level.level_keys": [
+          "U3L04 Assessment1_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2_2018_2019",
+        "script_level.level_keys": [
+          "U3L04 Assessment2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L07 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L07 SFLP_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams_2019",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own_2019",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response_2019",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2_2018_2019",
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice_2018_2019",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment_2019",
+        "script_level.level_keys": [
+          "U3L06 Assessment_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup_2018_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L08 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L08 SFLP_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_parameters_2019",
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam_2019",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam_2019",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams_2019",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle_2019",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc_2018_2019",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 whats a comment_2018_2019",
+        "script_level.level_keys": [
+          "U3 whats a comment_2018_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 how to add comments_2019",
+        "script_level.level_keys": [
+          "U3L08 how to add comments_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea_2019",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish_2019",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass_2019",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish_2019",
+        "script_level.level_keys": [
+          "U3L08 - fish_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish_2019",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput_2019",
+        "script_level.level_keys": [
+          "U3L08 - randomInput_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc_2018_2019",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc_2018_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay_2019",
+        "script_level.level_keys": [
+          "U3L08 - freePlay_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity_2019",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1_2018_2019",
+        "script_level.level_keys": [
+          "U3L08 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2_2019",
+        "script_level.level_keys": [
+          "U3L08 Assessment2_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L09 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L09 SFLP_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_2019",
+        "script_level.level_keys": [
+          "csp_applab_loops_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare_2019",
+        "script_level.level_keys": [
+          "U3L07 - introSquare_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare_2019",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_U3_turtle_prediction_FR_2019",
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1_2019",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom_2019",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign_2019",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles_2019",
+        "script_level.level_keys": [
+          "U3L07 - bubbles_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish_2019",
+        "script_level.level_keys": [
+          "U3L07 - fish_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar_2019",
+        "script_level.level_keys": [
+          "U3L07 - seaStar_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass_2019",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass_2019",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams_2019",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random_2019",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction_2019",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops_2018_2019",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops_2018_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection_2019",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR_2019",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L10 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode_2019",
+        "script_level.level_keys": [
+          "U3L08 - individualCode_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates_2018_2019",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates_2018_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene_2019",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group_2018_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-2020.script_json
+++ b/dashboard/config/scripts_json/csp3-2020.script_json
@@ -1,0 +1,2131 @@
+{
+  "script": {
+    "name": "csp3-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        },
+        {
+          "notice": "Looking for the Lesson Activities?",
+          "details": "Teachers, some lessons in this unit contain activities that are not located on Code Studio. Make sure to read the Lesson Plans and check out the unit slides. ",
+          "link": "https://curriculum.code.org/csp-20/unit3/",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit3/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit3/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_unit3_2020",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 3: Intro to App Design"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Apps",
+      "name": "Introduction to Apps",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Introduction to Design Mode",
+      "name": "Introduction to Design Mode",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 1",
+      "name": "Project - Designing an App Part 1",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 2",
+      "name": "Project - Designing an App Part 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "The Need for Programming Languages",
+      "name": "The Need for Programming Languages",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Intro to Programming",
+      "name": "Intro to Programming",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Debugging",
+      "name": "Debugging",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 3",
+      "name": "Project - Designing an App Part 3",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 4",
+      "name": "Project - Designing an App Part 4",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 5",
+      "name": "Project - Designing an App Part 5",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "key": "Lesson 11: Assessment Day",
+      "name": "Lesson 11: Assessment Day",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How Computers Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "How Computers Work part 1 CSP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App Investigate"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App Investigation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App Investigation"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App Investigation"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App Investigation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L1 Input Output Matching"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township Design Mode"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Themes"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Colors"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Images"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Icons"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode ids"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Copy an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L2 Copy an App"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 CSP CFU ID names"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3L2 CSP CFU ID names"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L3 Check Your Understanding"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz Storyboard"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L4 Design Screens"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L5 CSP CFU natural language"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3L5 CSP CFU natural language"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Sequential vs Event Driven"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3L6 CSP CFU Sequential vs Event Driven"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 2"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 8"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L7 CSP CFU What was confusing"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3L7 CSP CFU What was confusing"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Pair Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "U3 L08 Pair Programming Video"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L4 Add Code"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Add More Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L9 Add More Code"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP U3 L10 Submit App"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 3 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 MC Assessment _2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      },
+      "level_keys": [
+        "CSP Unit 3 MC Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Computers Work part 1 CSP",
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App Investigate",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L1 Input Output Matching",
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township Design Mode",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Themes",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Colors",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Images",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Icons",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode ids",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Copy an App",
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 CSP CFU ID names",
+        "script_level.level_keys": [
+          "U3L2 CSP CFU ID names"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L3 Check Your Understanding",
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz Storyboard",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Design Screens",
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L5 CSP CFU natural language",
+        "script_level.level_keys": [
+          "U3L5 CSP CFU natural language"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 3",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L6 CSP CFU Sequential vs Event Driven",
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Sequential vs Event Driven"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 1",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 2",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 3",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 4",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 5",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 6",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 8",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L7 CSP CFU What was confusing",
+        "script_level.level_keys": [
+          "U3L7 CSP CFU What was confusing"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L08 Pair Programming Video",
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Add Code",
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L9 Add More Code",
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L10 Submit App",
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 MC Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 3 MC Assessment _2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_unit3_2020",
+        "script.name": "csp3-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-a.script_json
+++ b/dashboard/config/scripts_json/csp3-a.script_json
@@ -1,0 +1,190 @@
+{
+  "script": {
+    "name": "csp3-a",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "curriculum_umbrella": "CSP"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-a"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming Languages and Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP3A: Using Simple Commands",
+      "name": "CSP3A: Using Simple Commands",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoal v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      },
+      "level_keys": [
+        "subgoal v2 U3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoal U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      },
+      "level_keys": [
+        "subgoal U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoal U3 L4 introducing subgoal labels"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      },
+      "level_keys": [
+        "subgoal U3 L4 introducing subgoal labels"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoalU3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      },
+      "level_keys": [
+        "subgoalU3L2_TurtleSquare_right"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "subgoal v2 U3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "subgoal v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoal U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "subgoal U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoal U3 L4 introducing subgoal labels",
+        "script_level.level_keys": [
+          "subgoal U3 L4 introducing subgoal labels"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoalU3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "subgoalU3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSP3A: Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-a"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp3-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp3-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 3 Deeper Learning Reflections",
+      "name": "Complete Unit 3 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "csp3-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "csp3-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      },
+      "level_keys": [
+        "csp3-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3-dlp-q1",
+        "script_level.level_keys": [
+          "csp3-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3-dlp-q2",
+        "script_level.level_keys": [
+          "csp3-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3-dlp-q3",
+        "script_level.level_keys": [
+          "csp3-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-dlp.script_json
+++ b/dashboard/config/scripts_json/csp3-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csp3-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 3 Deeper Learning Reflections",
+      "name": "Complete Unit 3 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "csp deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "csp3dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "csp3dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      },
+      "level_keys": [
+        "csp3dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp deeper learning timeline",
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3dlp-lessons",
+        "script_level.level_keys": [
+          "csp3dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3dlp-tools",
+        "script_level.level_keys": [
+          "csp3dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3dlp-assessment",
+        "script_level.level_keys": [
+          "csp3dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 3 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp3-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp3-pilot-staging.script_json
@@ -1,0 +1,1580 @@
+{
+  "script": {
+    "name": "csp3-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Apps",
+      "name": "Introduction to Apps",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Introduction to Design Mode",
+      "name": "Introduction to Design Mode",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 1",
+      "name": "Project - Designing an App Part 1",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 2",
+      "name": "Project - Designing an App Part 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "The Need for Programming Languages",
+      "name": "The Need for Programming Languages",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Programs Investigate",
+      "name": "Programs Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Programs Practice",
+      "name": "Programs Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 3",
+      "name": "Project - Designing an App Part 3",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 4",
+      "name": "Project - Designing an App Part 4",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "key": "Project: Share Your App",
+      "name": "Project: Share Your App",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Share Your App",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How Computers Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "How Computers Work part 1 CSP"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App Investigate"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App Investigation"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App Investigation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App Investigation"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App Investigation"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L1 Input Output Matching"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township Design Mode"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Themes"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Colors"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Images"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Icons"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode ids"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Copy an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L2 Copy an App"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L3 Check Your Understanding"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz Storyboard"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L4 Design Screens"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Temporary Need for Programming Languages SFLP CSP3 Pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "Temporary Need for Programming Languages SFLP CSP3 Pilot"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 3"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 5"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 6"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 8"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Pair Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "U3 L08 Pair Programming Video"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L4 Add Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Add More Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L9 Add More Code"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project: Share Your App",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U3 L10 Submit App"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Computers Work part 1 CSP",
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App Investigate",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L1 Input Output Matching",
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township Design Mode",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Themes",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Colors",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Images",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Icons",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode ids",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Copy an App",
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L3 Check Your Understanding",
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz Storyboard",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Design Screens",
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Temporary Need for Programming Languages SFLP CSP3 Pilot",
+        "script_level.level_keys": [
+          "Temporary Need for Programming Languages SFLP CSP3 Pilot"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 3",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Programs Investigate",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 1",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 2",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 3",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 4",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 5",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 6",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 8",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Programs Practice",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L08 Pair Programming Video",
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Add Code",
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L9 Add More Code",
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L10 Submit App",
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Project: Share Your App",
+        "lesson_group.key": "",
+        "script.name": "csp3-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-pilot.script_json
+++ b/dashboard/config/scripts_json/csp3-pilot.script_json
@@ -1,0 +1,2215 @@
+{
+  "script": {
+    "name": "csp3-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit3/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Apps",
+      "name": "Introduction to Apps",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Introduction to Design Mode",
+      "name": "Introduction to Design Mode",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 1",
+      "name": "Project - Designing an App Part 1",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 2",
+      "name": "Project - Designing an App Part 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "The Need for Programming Languages",
+      "name": "The Need for Programming Languages",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Intro to Programming",
+      "name": "Intro to Programming",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Debugging",
+      "name": "Debugging",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 3",
+      "name": "Project - Designing an App Part 3",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 4",
+      "name": "Project - Designing an App Part 4",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Project - Designing an App Part 5",
+      "name": "Project - Designing an App Part 5",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Lesson 11: Assessment Day",
+      "name": "Lesson 11: Assessment Day",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Unit 3 STUDENT Survey",
+      "name": "Unit 3 STUDENT Survey",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "key": "Unit 3 TEACHER Survey",
+      "name": "Unit 3 TEACHER Survey",
+      "absolute_position": 13,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "App Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How Computers Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "How Computers Work part 1 CSP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Water Conservation Sample App Investigate"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz App Investigation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township App Investigation"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Four Square App Investigation"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Monarch Butterfly App Investigation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L1 Input Output Matching"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Hamilton Township Design Mode"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Themes"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Colors"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Images"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode Icons"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode Exploration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Design Mode ids"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Copy an App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L2 Copy an App"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 CSP CFU ID names"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3L2 CSP CFU ID names"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L3 Check Your Understanding"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Prototype"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 Bird Quiz Storyboard"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L4 Design Screens"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L5 CSP CFU natural language"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3L5 CSP CFU natural language"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Investigate Sequential 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Investigate Event-Driven 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Sequential vs Event Driven"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3L6 CSP CFU Sequential vs Event Driven"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 2"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 Program Practice Pt 8"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L7 CSP CFU What was confusing"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3L7 CSP CFU What was confusing"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Pair Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "U3 L08 Pair Programming Video"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Add Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L4 Add Code"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Add More Code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L9 Add More Code"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 L10 Submit App"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 3 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 MC Assessment _2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 3 MC Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 3 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 3 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      },
+      "level_keys": [
+        "CSP U3 20-21 Teacher Pilot Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Computers Work part 1 CSP",
+        "script_level.level_keys": [
+          "How Computers Work part 1 CSP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Water Conservation Sample App Investigate",
+        "script_level.level_keys": [
+          "CSP U3 Water Conservation Sample App Investigate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz App Investigation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township App Investigation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Four Square App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Four Square App Investigation"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Monarch Butterfly App Investigation",
+        "script_level.level_keys": [
+          "CSP U3 Monarch Butterfly App Investigation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L1 Input Output Matching",
+        "script_level.level_keys": [
+          "CSP U3 L1 Input Output Matching"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Apps",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Hamilton Township Design Mode",
+        "script_level.level_keys": [
+          "CSP U3 Hamilton Township Design Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Themes",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Themes"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Colors",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Colors"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Images",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode Icons",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode Icons"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Design Mode ids",
+        "script_level.level_keys": [
+          "CSP U3 L2 Design Mode ids"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L2 Copy an App",
+        "script_level.level_keys": [
+          "CSP U3 L2 Copy an App"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 CSP CFU ID names",
+        "script_level.level_keys": [
+          "U3L2 CSP CFU ID names"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Design Mode",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L3 Check Your Understanding",
+        "script_level.level_keys": [
+          "CSP U3 L3 Check Your Understanding"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 1",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 Bird Quiz Storyboard",
+        "script_level.level_keys": [
+          "CSP U3 Bird Quiz Storyboard"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Design Screens",
+        "script_level.level_keys": [
+          "CSP U3 L4 Design Screens"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 2",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L5 CSP CFU natural language",
+        "script_level.level_keys": [
+          "U3L5 CSP CFU natural language"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Programming Languages",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Sequential 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Sequential 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 1",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 2",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Investigate Event-Driven 3",
+        "script_level.level_keys": [
+          "U3 Program Investigate Event-Driven 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L6 CSP CFU Sequential vs Event Driven",
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Sequential vs Event Driven"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Intro to Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 1",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 2",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 3",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 4",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 5",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 6",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Program Practice Pt 8",
+        "script_level.level_keys": [
+          "U3 Program Practice Pt 8"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L7 CSP CFU What was confusing",
+        "script_level.level_keys": [
+          "U3L7 CSP CFU What was confusing"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Debugging",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L08 Pair Programming Video",
+        "script_level.level_keys": [
+          "U3 L08 Pair Programming Video"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L4 Add Code",
+        "script_level.level_keys": [
+          "CSP U3 L4 Add Code"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Project - Designing an App Part 3",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L9 Add More Code",
+        "script_level.level_keys": [
+          "CSP U3 L9 Add More Code"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 4",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U3L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 L10 Submit App",
+        "script_level.level_keys": [
+          "CSP U3 L10 Submit App"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Project - Designing an App Part 5",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 MC Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 3 MC Assessment _2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U3 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U3 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp3-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-recovery.script_json
+++ b/dashboard/config/scripts_json/csp3-recovery.script_json
@@ -1,0 +1,87 @@
+{
+  "script": {
+    "name": "csp3-recovery",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-recovery"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp3-recovery"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Under the sea recovery",
+      "name": "Under the sea recovery",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Under the sea recovery",
+        "lesson_group.key": "",
+        "script.name": "csp3-recovery"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here for instructions on how to recover your Under the Sea project code."
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea - clone for recovery"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Under the sea recovery",
+        "lesson_group.key": "",
+        "script.name": "csp3-recovery"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea - clone for recovery"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea - clone for recovery",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea - clone for recovery"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Under the sea recovery",
+        "lesson_group.key": "",
+        "script.name": "csp3-recovery"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
+++ b/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
@@ -1,0 +1,3930 @@
+{
+  "script": {
+    "name": "csp3-research-mxghyt",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "Check out the CSP mid-course survey",
+          "details": "We recently added a mid-course survey to the end of Unit 3.  Please allow your students some time to complete it.",
+          "link": "",
+          "type": "success"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit3/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp3"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit3/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp/unit3/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit3/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp3-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-research-mxghyt"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming Languages and Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "key": "Please complete the CSP Mid-course survey",
+      "name": "Please complete the CSP Mid-course survey",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "v2 U3L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L01 Assessment1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L01 Assessment3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "v2 U3L02 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "v2 U3L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Turtle Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG csp_applab_turtle"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands part 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L2 Using Simple Commands part 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SGU3L2A Introducing Subgoals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SGU3L2A Introducing Subgoals"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Simple Commands and Subgoals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG Add Subgoals practice"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG Add Subgoals practice"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L02 Assessment"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L05 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_functions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG csp_applab_functions"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) Abstraction in Programming"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG CSP Abstraction in Programming 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 - draw rect function"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 - draw step"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 - draw step"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 Three Steps"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L03 draw diamond"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L03 Assessment"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 - snowflake"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L04 - snowflake"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L04 - 3 by 3 with functions"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Design Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 - moveForwardwithParams"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 1 triangle"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 More Subgoals"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 More Subgoals"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 2 purple square"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 3 fill pink"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 4 bullseye"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 6 squiggles"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 5 overlapping circles"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 7 smiley face"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L06 Challenge 8 make your own"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Score a student response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L06 Assessment2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L06 Assessment"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG csp_applab_functions_parameters"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - drawSquareWithParam"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - createTriangleParam"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - squareTwoParams"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - createTwoParamTriangle"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG csp_U3_turtle_subgoal_q3_mc"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3 whats a comment"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 how to add comments"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - introUnderTheSea"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - paramsToStarfish"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - fish"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - fish"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - multiParamFish"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - randomInput"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - randomInput"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 - freePlay"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L08 - freePlay"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Managing Complexity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L08 Assessment1"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L08 Assessment2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG csp_applab_loops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG csp_applab_loops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - introSquare"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - introSquare"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - randomSquare"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG subgoals_U3_turtle_prediction_FR"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - randomDots1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - loopsWithRandom"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - topDownDesign"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - bubbles"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - bubbles"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - fish"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - fish"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - seaStar"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - seaStar"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - allSeaGrass"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - sunBeams"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG U3L07 - Free Play Loops and Random"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Identify the Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG v2 U3L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "SG v2 U3L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Components"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L08 - individualCode"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_3": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_3": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp_affirmation_control_3",
+        "csp_affirmation_intervention_3"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      },
+      "level_keys": [
+        "csp-post-survey-2017-levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1",
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3",
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L02 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_turtle",
+        "script_level.level_keys": [
+          "SG csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2 Using Simple Commands part 1",
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands part 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SGU3L2A Introducing Subgoals",
+        "script_level.level_keys": [
+          "SGU3L2A Introducing Subgoals"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "SG U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "SG U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG Add Subgoals practice",
+        "script_level.level_keys": [
+          "SG Add Subgoals practice"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "SG U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment",
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 11,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 12,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L05 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_functions",
+        "script_level.level_keys": [
+          "SG csp_applab_functions"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "SG U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "SG U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "SG U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG CSP Abstraction in Programming 2",
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 - draw rect function",
+        "script_level.level_keys": [
+          "SG U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 - draw step",
+        "script_level.level_keys": [
+          "SG U3L03 - draw step"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 Three Steps",
+        "script_level.level_keys": [
+          "SG U3L03 Three Steps"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L03 draw diamond",
+        "script_level.level_keys": [
+          "SG U3L03 draw diamond"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment",
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 - snowflake",
+        "script_level.level_keys": [
+          "SG U3L04 - snowflake"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L04 - 3 by 3 with functions",
+        "script_level.level_keys": [
+          "SG U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1",
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2",
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 - moveForwardwithParams",
+        "script_level.level_keys": [
+          "SG U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 1 triangle",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 More Subgoals",
+        "script_level.level_keys": [
+          "SG U3L07 More Subgoals"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 2 purple square",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 3 fill pink",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 4 bullseye",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 6 squiggles",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 5 overlapping circles",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 7 smiley face",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L06 Challenge 8 make your own",
+        "script_level.level_keys": [
+          "SG U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2",
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment",
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 16,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_functions_parameters",
+        "script_level.level_keys": [
+          "SG csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - drawSquareWithParam",
+        "script_level.level_keys": [
+          "SG U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - createTriangleParam",
+        "script_level.level_keys": [
+          "SG U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - squareTwoParams",
+        "script_level.level_keys": [
+          "SG U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - createTwoParamTriangle",
+        "script_level.level_keys": [
+          "SG U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_U3_turtle_subgoal_q3_mc",
+        "script_level.level_keys": [
+          "SG csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3 whats a comment",
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 how to add comments",
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - introUnderTheSea",
+        "script_level.level_keys": [
+          "SG U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - paramsToStarfish",
+        "script_level.level_keys": [
+          "SG U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - seaGrass",
+        "script_level.level_keys": [
+          "SG U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - fish",
+        "script_level.level_keys": [
+          "SG U3L08 - fish"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - multiParamFish",
+        "script_level.level_keys": [
+          "SG U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - randomInput",
+        "script_level.level_keys": [
+          "SG U3L08 - randomInput"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 - freePlay",
+        "script_level.level_keys": [
+          "SG U3L08 - freePlay"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1",
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2",
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG csp_applab_loops",
+        "script_level.level_keys": [
+          "SG csp_applab_loops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - introSquare",
+        "script_level.level_keys": [
+          "SG U3L07 - introSquare"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - randomSquare",
+        "script_level.level_keys": [
+          "SG U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG subgoals_U3_turtle_prediction_FR",
+        "script_level.level_keys": [
+          "SG subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - randomDots1",
+        "script_level.level_keys": [
+          "SG U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - loopsWithRandom",
+        "script_level.level_keys": [
+          "SG U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - topDownDesign",
+        "script_level.level_keys": [
+          "SG U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - bubbles",
+        "script_level.level_keys": [
+          "SG U3L07 - bubbles"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - fish",
+        "script_level.level_keys": [
+          "SG U3L07 - fish"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - seaStar",
+        "script_level.level_keys": [
+          "SG U3L07 - seaStar"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - seaGrass",
+        "script_level.level_keys": [
+          "SG U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - allSeaGrass",
+        "script_level.level_keys": [
+          "SG U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - sunBeams",
+        "script_level.level_keys": [
+          "SG U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L07 - Free Play Loops and Random",
+        "script_level.level_keys": [
+          "SG U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG v2 U3L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "SG v2 U3L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode",
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2017-levelgroup",
+        "script_level.level_keys": [
+          "csp-post-survey-2017-levelgroup"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Please complete the CSP Mid-course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-staging.script_json
+++ b/dashboard/config/scripts_json/csp3-staging.script_json
@@ -1,0 +1,3691 @@
+{
+  "script": {
+    "name": "csp3-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Programming Languages and Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "The Need for Algorithms",
+      "name": "The Need for Algorithms",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Creativity in Algorithms",
+      "name": "Creativity in Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "key": "Unit 3 Chapter 1 Assessment",
+      "name": "Unit 3 Chapter 1 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L01 Assessment1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L01 Assessment3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L02 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Turtle Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_applab_turtle"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L02 Assessment"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L05 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_applab_functions"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) Abstraction in Programming"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "CSP Abstraction in Programming 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 - draw step"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 Assessment"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L04 - snowflake"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Design Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-design-process"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Score a student response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-score-abstraction-response"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Assessment2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L06 Assessment"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_applab_functions_parameters"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 whats a comment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3 whats a comment"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) How to add comments to code"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 how to add comments"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 how to add comments"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "(modification only) Intro to under the sea (instruction, and template change only)"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea with comments"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea with comments"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - fish"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - randomInput"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Using Random Numbers"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - freePlay"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Managing Complexity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3-AP-Practice-FR-manage-complexity"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 Assessment1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 Assessment2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_applab_loops"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - introSquare"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "subgoals_U3_turtle_prediction_FR"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - bubbles"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - fish"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - seaStar"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "(new)AP Practice Response - Identify the Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3-AP-Practice-Choose-The-Abstraction"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "(Modified) Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "v2 U3L10 Student Lesson Introduction - stage mods only"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "v2 U3L10 Student Lesson Introduction - stage mods only"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Your Components"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - individualCode"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "How To: Share Code with Teammates"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Design Your Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_3": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_3": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "csp_affirmation_control_3",
+        "csp_affirmation_intervention_3"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      },
+      "level_keys": [
+        "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1",
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3",
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-4-levelgroup-U3Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-4-levelgroup-U3Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L02 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creativity in Algorithms",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_turtle",
+        "script_level.level_keys": [
+          "csp_applab_turtle"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment",
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L05 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions",
+        "script_level.level_keys": [
+          "csp_applab_functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Abstraction in Programming 2",
+        "script_level.level_keys": [
+          "CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step",
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps",
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond",
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment",
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake",
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-design-process",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-design-process"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1",
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2",
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-score-abstraction-response",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-score-abstraction-response"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2",
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment",
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_parameters",
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 whats a comment",
+        "script_level.level_keys": [
+          "U3 whats a comment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 how to add comments",
+        "script_level.level_keys": [
+          "U3L08 how to add comments"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea with comments",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea with comments"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish",
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput",
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 16,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay",
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 17,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-FR-manage-complexity",
+        "script_level.level_keys": [
+          "U3-AP-Practice-FR-manage-complexity"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 18,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1",
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 19,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2",
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 20,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "v2 U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops",
+        "script_level.level_keys": [
+          "csp_applab_loops"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare",
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_U3_turtle_prediction_FR",
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles",
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish",
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar",
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-AP-Practice-Choose-The-Abstraction",
+        "script_level.level_keys": [
+          "U3-AP-Practice-Choose-The-Abstraction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 16,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 17,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 18,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 19,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "v2 U3L10 Student Lesson Introduction - stage mods only",
+        "script_level.level_keys": [
+          "v2 U3L10 Student Lesson Introduction - stage mods only"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode",
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How To: Share Code with Teammates",
+        "script_level.level_keys": [
+          "How To: Share Code with Teammates"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "csp3_1",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_3",
+        "script_level.level_keys": [
+          "csp_affirmation_control_3",
+          "csp_affirmation_intervention_3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 3 Ch1 Cumulative Assessment MC Group",
+        "script_level.level_keys": [
+          "CSP Unit 3 Ch1 Cumulative Assessment MC Group"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp3-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-support.script_json
+++ b/dashboard/config/scripts_json/csp3-support.script_json
@@ -1,0 +1,1728 @@
+{
+  "script": {
+    "name": "csp3-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CSP Support",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 3 Overview",
+      "name": "Unit 3 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "AP Preparation and Support",
+      "name": "AP Preparation and Support",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Lessons 1 - 3: Algorithms",
+      "name": "Lessons 1 - 3: Algorithms",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+      "name": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+      "name": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Introduction to Unit 3"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Tool Talk"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Tool Talk"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teaching Programming in Unit 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Teaching Programming in Unit 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Practice Performance Tasks in Unit 3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Vocab and Concept Review Activity"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "AP Test Prep Guidance"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "3.1 - 3.3 Lesson Connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "3.1 - 3.3 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Understanding the Human Machine Language"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Understanding the Human Machine Language"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "3.1 - 3.3 Lesson Connections in the Framework"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "3.1 - 3.3 Lesson Connections in the Framework"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "U3 L1 - 3: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "3.4 - 3.6 Lesson Connections"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "3.4 - 3.6 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to App Lab and Turtle Programming"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Introduction to App Lab and Turtle Programming"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Philosophy Behind the Four Primitive Programming Commands"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "The Philosophy Behind the Four Primitive Programming Commands"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Defining and Calling Functions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Defining and Calling Functions"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Common Misconceptions about Functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Common Misconceptions about Functions"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Top-Down Design"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Top-Down Design"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "U3 L4 - 6: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "3.7 - 3.9 Lesson Connections"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "3.7 - 3.9 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Documentation in App Lab"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Documentation in App Lab"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Functions with Parameters"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Introduction to Functions with Parameters"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Functions with Parameters"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Functions with Parameters"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Loops"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Introduction to Loops"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Loops"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Using Loops"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 L7 - 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "U3 L7 - 9: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      },
+      "level_keys": [
+        "Unit 3 Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 3",
+        "script_level.level_keys": [
+          "Introduction to Unit 3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Tool Talk",
+        "script_level.level_keys": [
+          "Unit 3 Tool Talk"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teaching Programming in Unit 3",
+        "script_level.level_keys": [
+          "Teaching Programming in Unit 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Performance Tasks in Unit 3",
+        "script_level.level_keys": [
+          "Practice Performance Tasks in Unit 3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Self-Assessment",
+        "script_level.level_keys": [
+          "Unit 3 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Vocab and Concept Review Activity",
+        "script_level.level_keys": [
+          "Unit 3 Vocab and Concept Review Activity"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AP Test Prep Guidance",
+        "script_level.level_keys": [
+          "AP Test Prep Guidance"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "AP Preparation and Support",
+        "lesson_group.key": "required",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "3.1 - 3.3 Lesson Connections",
+        "script_level.level_keys": [
+          "3.1 - 3.3 Lesson Connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Understanding the Human Machine Language",
+        "script_level.level_keys": [
+          "Understanding the Human Machine Language"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "3.1 - 3.3 Lesson Connections in the Framework",
+        "script_level.level_keys": [
+          "3.1 - 3.3 Lesson Connections in the Framework"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L1 - 3: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U3 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 3: Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "3.4 - 3.6 Lesson Connections",
+        "script_level.level_keys": [
+          "3.4 - 3.6 Lesson Connections"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to App Lab and Turtle Programming",
+        "script_level.level_keys": [
+          "Introduction to App Lab and Turtle Programming"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Philosophy Behind the Four Primitive Programming Commands",
+        "script_level.level_keys": [
+          "The Philosophy Behind the Four Primitive Programming Commands"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Defining and Calling Functions",
+        "script_level.level_keys": [
+          "Defining and Calling Functions"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Common Misconceptions about Functions",
+        "script_level.level_keys": [
+          "Common Misconceptions about Functions"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Top-Down Design",
+        "script_level.level_keys": [
+          "Top-Down Design"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L4 - 6: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U3 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 4 - 6 : Procedural Abstraction and Top-Down Design",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "3.7 - 3.9 Lesson Connections",
+        "script_level.level_keys": [
+          "3.7 - 3.9 Lesson Connections"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Documentation in App Lab",
+        "script_level.level_keys": [
+          "Documentation in App Lab"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Functions with Parameters",
+        "script_level.level_keys": [
+          "Introduction to Functions with Parameters"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Functions with Parameters",
+        "script_level.level_keys": [
+          "Functions with Parameters"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Loops",
+        "script_level.level_keys": [
+          "Introduction to Loops"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Loops",
+        "script_level.level_keys": [
+          "Using Loops"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 L7 - 9: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U3 L7 - 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers",
+        "lesson_group.key": "content",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 3 Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Unit 3 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp3-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp3-virtual.script_json
+++ b/dashboard/config/scripts_json/csp3-virtual.script_json
@@ -1,0 +1,2102 @@
+{
+  "script": {
+    "name": "csp3-virtual",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp3-virtual"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp3_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 3: Intro to Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "key": "Creating functions with Parameters",
+      "name": "Creating functions with Parameters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "key": "Make your own Digital Scene",
+      "name": "Make your own Digital Scene",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Make your own Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_turtle_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "csp_applab_turtle_virtual"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands_virtual"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Simple Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right_virtual"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a 3x3 Grid Using Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid_virtual"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L1 Virtual CFU"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "CSP U3L1 Virtual CFU"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Defining and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "csp_applab_functions_virtual"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround_virtual"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround_virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle_virtual"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function_virtual"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 - draw step_virtual"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions With Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 Three Steps_virtual"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Draw a Diamond Using Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L03 draw diamond_virtual"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L04 - snowflake_virtual"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Functions with Turtle Commands"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions_virtual"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L2 Virtual CFU"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "CSP U3L2 Virtual CFU"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams_virtual"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle_virtual"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square_virtual"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink_virtual"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye_virtual"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles_virtual"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face_virtual"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Make Your Own Turtle Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own_virtual"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L06 Assessment2_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "csp_applab_functions_parameters_virtual"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam_virtual"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam_virtual"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams_virtual"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Drawing Shapes With Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle_virtual"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding: Defining Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018_2019_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How to add comments to code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 how to add comments_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 how to add comments_virtual"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea_virtual"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish_virtual"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass_virtual"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - fish_virtual"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish_virtual"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Under the Sea Drawing with Parameters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - randomInput_virtual"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge: Continue Your Drawing With More Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L08 - freePlay_virtual"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U3L4 Virtual CFU"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "CSP U3L4 Virtual CFU"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "csp_applab_loops_virtual"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - introSquare_virtual"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare_virtual"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1_virtual"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom_virtual"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign_virtual"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - bubbles_virtual"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - fish_virtual"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - seaStar_virtual"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass_virtual"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass_virtual"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Loops to Add Detail to Your Drawing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams_virtual"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Under the Sea"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random_virtual"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Personal Digital Scene"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Free_play_digital_scene_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Make your own Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      },
+      "level_keys": [
+        "Free_play_digital_scene_virtual"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_turtle_virtual",
+        "script_level.level_keys": [
+          "csp_applab_turtle_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands_virtual",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right_virtual",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid_virtual",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L1 Virtual CFU",
+        "script_level.level_keys": [
+          "CSP U3L1 Virtual CFU"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_virtual",
+        "script_level.level_keys": [
+          "csp_applab_functions_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround_virtual",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround_virtual",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle_virtual",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function_virtual",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step_virtual",
+        "script_level.level_keys": [
+          "U3L03 - draw step_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps_virtual",
+        "script_level.level_keys": [
+          "U3L03 Three Steps_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond_virtual",
+        "script_level.level_keys": [
+          "U3L03 draw diamond_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake_virtual",
+        "script_level.level_keys": [
+          "U3L04 - snowflake_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions_virtual",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L2 Virtual CFU",
+        "script_level.level_keys": [
+          "CSP U3L2 Virtual CFU"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams_virtual",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own_virtual",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2_2018_2019_virtual",
+        "script_level.level_keys": [
+          "U3L06 Assessment2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_parameters_virtual",
+        "script_level.level_keys": [
+          "csp_applab_functions_parameters_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam_virtual",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam_virtual",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams_virtual",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle_virtual",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc_2018_2019_virtual",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc_2018_2019_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 how to add comments_virtual",
+        "script_level.level_keys": [
+          "U3L08 how to add comments_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea_virtual",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish_virtual",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass_virtual",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish_virtual",
+        "script_level.level_keys": [
+          "U3L08 - fish_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish_virtual",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput_virtual",
+        "script_level.level_keys": [
+          "U3L08 - randomInput_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 13,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay_virtual",
+        "script_level.level_keys": [
+          "U3L08 - freePlay_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 14,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U3L4 Virtual CFU",
+        "script_level.level_keys": [
+          "CSP U3L4 Virtual CFU"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 15,
+        "lesson.key": "Creating functions with Parameters",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_virtual",
+        "script_level.level_keys": [
+          "csp_applab_loops_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare_virtual",
+        "script_level.level_keys": [
+          "U3L07 - introSquare_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare_virtual",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1_virtual",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom_virtual",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign_virtual",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles_virtual",
+        "script_level.level_keys": [
+          "U3L07 - bubbles_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish_virtual",
+        "script_level.level_keys": [
+          "U3L07 - fish_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar_virtual",
+        "script_level.level_keys": [
+          "U3L07 - seaStar_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass_virtual",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass_virtual",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams_virtual",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random_virtual",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Free_play_digital_scene_virtual",
+        "script_level.level_keys": [
+          "Free_play_digital_scene_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Make your own Digital Scene",
+        "lesson_group.key": "csp3_1_2018",
+        "script.name": "csp3-virtual"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-2017.script_json
+++ b/dashboard/config/scripts_json/csp4-2017.script_json
@@ -1,0 +1,2324 @@
+{
+  "script": {
+    "name": "csp4-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp4"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit4/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp4-support"
+        ]
+      ]
+    },
+    "new_name": "csp4-2017",
+    "family_name": "csp4",
+    "seeding_key": {
+      "script.name": "csp4-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp4_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: The World of Big Data and Encryption"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is Big Data?",
+      "name": "What is Big Data?",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Rapid Research - Data Innovations",
+      "name": "Rapid Research - Data Innovations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Identifying People with Data",
+      "name": "Identifying People with Data",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "The Cost of Free",
+      "name": "The Cost of Free",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Simple Encryption",
+      "name": "Simple Encryption",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Encryption with Keys and Passwords",
+      "name": "Encryption with Keys and Passwords",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Public Key Crypto",
+      "name": "Public Key Crypto",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Rapid Research - Cybercrime",
+      "name": "Rapid Research - Cybercrime",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Practice PT - Big Data and Security Dilemmas",
+      "name": "Practice PT - Big Data and Security Dilemmas",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Big Data and Security Dilemmas",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Unit 4 Chapter 1 Assessment",
+      "name": "Unit 4 Chapter 1 Assessment",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 1 Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 1 Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC moores law"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L1 - MC moores law"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC big data def"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L1 - MC big data def"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-5-levelgroup-U4Ch1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 2 Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 2 Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data and Medicine"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Data and Medicine"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - Data and Medicine"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "CS is Changing Everything"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - CS is Changing Everything"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L2 - FR Practice AP response about data"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 3 Introduction"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 3 Introduction"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Choose-The-Data-Concern"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L3 - FR Identifying people"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 4 Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 4 Introduction"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Future of Big Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - The Future of Big Data"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - The Future of Big Data"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Justify-the-Score"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L4 - MC cost of free"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U4L4 - FR cost of free"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 5 Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 5 Introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack a Caesar Cipher"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Terminology Recap"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Terminology Recap"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "New Challenge Introduction"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "New Challenge Introduction"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack Random Substitution"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Crack Random Substitution"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Technique: Frequency Analysis"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L13 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L13 Assessment1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L13 Assessment3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L13 Assessment4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L13 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 6 Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 6 Introduction"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Vigenere Cipher Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "The Vigenere Cipher Widget"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Secure Is Your Password?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Secure Is Your Password?"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "How Secure Is Your Password?"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L14 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L14 Assessment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L14 Assessment2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L15 Assessment1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 7 Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 7 Introduction"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cups and Beans Activity"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cups and Beans Activity"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Cups and Beans Activity"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Modulo Clock Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Modulo Clock Instructions"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Modulo Clock Instructions"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "The Modulo Clock"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Modulo Clock"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "The Modulo Clock"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Crypto Widget Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Public Key Crypto Widget Instructions"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Cryptography Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Public Key Cryptography Widget"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L18 Free Response Assessment 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L18 Match terms to cups and beans analogy"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L19 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L19 mutlichoice 20 mod 15"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L19 multichoice 13 MOD 17"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "U2L19 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 8 Introduction"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 8 Introduction"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Cybersecurity and Crime"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Video - Cybersecurity and Crime"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Lesson 9 Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Big Data and Security Dilemmas",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Unit 4 Lesson 9 Introduction"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_4": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_4": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_4",
+          "csp_affirmation_intervention_4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control_4",
+        "csp_affirmation_intervention_4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "CSP Unit 4 Ch1 Cumulative Assessment MC"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 1 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 1 Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC moores law",
+        "script_level.level_keys": [
+          "U4L1 - MC moores law"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC big data def",
+        "script_level.level_keys": [
+          "U4L1 - MC big data def"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-5-levelgroup-U4Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 2 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 2 Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Data and Medicine",
+        "script_level.level_keys": [
+          "Video - Data and Medicine"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - CS is Changing Everything",
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L2 - FR Practice AP response about data",
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 3 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 3 Introduction"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Choose-The-Data-Concern",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 - FR Identifying people",
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 4 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 4 Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - The Future of Big Data",
+        "script_level.level_keys": [
+          "Video - The Future of Big Data"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Justify-the-Score",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - MC cost of free",
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - FR cost of free",
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 5 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 5 Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap",
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction",
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution",
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment1",
+        "script_level.level_keys": [
+          "U2L13 Assessment1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment3",
+        "script_level.level_keys": [
+          "U2L13 Assessment3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment4",
+        "script_level.level_keys": [
+          "U2L13 Assessment4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 6 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 6 Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Vigenere Cipher Widget",
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Secure Is Your Password?",
+        "script_level.level_keys": [
+          "How Secure Is Your Password?"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment",
+        "script_level.level_keys": [
+          "U2L14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment2",
+        "script_level.level_keys": [
+          "U2L14 Assessment2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment1",
+        "script_level.level_keys": [
+          "U2L15 Assessment1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 7 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 7 Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cups and Beans Activity",
+        "script_level.level_keys": [
+          "Cups and Beans Activity"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Modulo Clock Instructions",
+        "script_level.level_keys": [
+          "Modulo Clock Instructions"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Modulo Clock",
+        "script_level.level_keys": [
+          "The Modulo Clock"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Crypto Widget Instructions",
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Cryptography Widget",
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Assessment 1",
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Match terms to cups and beans analogy",
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 mutlichoice 20 mod 15",
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 multichoice 13 MOD 17",
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 8 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 8 Introduction"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Cybersecurity and Crime",
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Lesson 9 Introduction",
+        "script_level.level_keys": [
+          "Unit 4 Lesson 9 Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Big Data and Security Dilemmas",
+        "lesson_group.key": "csp4_1",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_4",
+        "script_level.level_keys": [
+          "csp_affirmation_control_4",
+          "csp_affirmation_intervention_4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_4",
+        "script_level.level_keys": [
+          "csp_affirmation_control_4",
+          "csp_affirmation_intervention_4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 Ch1 Cumulative Assessment MC",
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Chapter 1 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-2018.script_json
+++ b/dashboard/config/scripts_json/csp4-2018.script_json
@@ -1,0 +1,2492 @@
+{
+  "script": {
+    "name": "csp4-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp4"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-18/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/unit4/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp4-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp4",
+    "seeding_key": {
+      "script.name": "csp4-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp4_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 4: Big Data and Privacy"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is Big Data?",
+      "name": "What is Big Data?",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Finding Trends with Visualizations",
+      "name": "Finding Trends with Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Check Your Assumptions",
+      "name": "Check Your Assumptions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Rapid Research - Data Innovations",
+      "name": "Rapid Research - Data Innovations",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Identifying People with Data",
+      "name": "Identifying People with Data",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "The Cost of Free",
+      "name": "The Cost of Free",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Simple Encryption",
+      "name": "Simple Encryption",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Encryption with Keys and Passwords",
+      "name": "Encryption with Keys and Passwords",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Public Key Crypto",
+      "name": "Public Key Crypto",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Rapid Research - Cybercrime",
+      "name": "Rapid Research - Cybercrime",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC moores law_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L1 - MC moores law_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC big data def_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L1 - MC big data def_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L08 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U2L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends MC_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L8 google trends MC_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L8 google trends hypothesis_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 google trends MC_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP Unit 4 google trends MC_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 trends as predictors_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP Unit 4 trends as predictors_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U2L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L9 What is digital divide MC_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L9 FR digital divide issue_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 MC data bias_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP Unit 4 MC data bias_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L02 SFLP"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data and Medicine"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Data and Medicine_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Video - Data and Medicine_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "CS is Changing Everything"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Video - CS is Changing Everything_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L2 - FR Practice AP response about data_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L03 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Choose-The-Data-Concern_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L3 - FR Identifying people_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L04 SFLP"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Justify-the-Score_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L4 - MC cost of free_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U4L4 - FR cost of free_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L05 SFLP"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack a Caesar Cipher"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Terminology Recap"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Terminology Recap_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "New Challenge Introduction"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "New Challenge Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack Random Substitution"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Crack Random Substitution_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Technique: Frequency Analysis"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L13 Free Response Getting Started_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L13 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment3_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L13 Assessment3_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment4_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L13 Assessment4_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L13 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L06 SFLP"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Vigenere Cipher Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "The Vigenere Cipher Widget_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Secure Is Your Password?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Secure Is Your Password?_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "How Secure Is Your Password?_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L14 Free Response Getting Started_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L14 Assessment_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L14 Assessment2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment1_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L15 Assessment1_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L07 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cups and Beans Activity"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cups and Beans Activity_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Cups and Beans Activity_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Modulo Clock Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Modulo Clock Instructions_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Modulo Clock Instructions_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "The Modulo Clock"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Modulo Clock_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "The Modulo Clock_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Crypto Widget Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Public Key Crypto Widget Instructions_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Cryptography Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Public Key Cryptography Widget_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L18 Free Response Assessment 1_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L18 Match terms to cups and beans analogy_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L19 Free Response Getting Started_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L19 mutlichoice 20 mod 15_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L19 multichoice 13 MOD 17_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "U2L19 Free Response Wrap Up_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L08 SFLP"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP U4L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Cybersecurity and Crime"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "Video - Cybersecurity and Crime_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "CSP Unit 4 Ch1 Cumulative Assessment MC_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L01 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC moores law_2018",
+        "script_level.level_keys": [
+          "U4L1 - MC moores law_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC big data def_2018",
+        "script_level.level_keys": [
+          "U4L1 - MC big data def_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L08 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L08 SFLP"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends MC_2018",
+        "script_level.level_keys": [
+          "U2L8 google trends MC_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends hypothesis_2018",
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 google trends MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 4 google trends MC_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 trends as predictors_2018",
+        "script_level.level_keys": [
+          "CSP Unit 4 trends as predictors_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L09 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L09 SFLP"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 What is digital divide MC_2018",
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 FR digital divide issue_2018",
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 MC data bias_2018",
+        "script_level.level_keys": [
+          "CSP Unit 4 MC data bias_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L02 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L02 SFLP"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Data and Medicine_2018",
+        "script_level.level_keys": [
+          "Video - Data and Medicine_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - CS is Changing Everything_2018",
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L2 - FR Practice AP response about data_2018",
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L03 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L03 SFLP"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Choose-The-Data-Concern_2018",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 - FR Identifying people_2018",
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L04 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L04 SFLP"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Justify-the-Score_2018",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - MC cost of free_2018",
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - FR cost of free_2018",
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L05 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L05 SFLP"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher_2018",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap_2018",
+        "script_level.level_keys": [
+          "Terminology Recap_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction_2018",
+        "script_level.level_keys": [
+          "New Challenge Introduction_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution_2018",
+        "script_level.level_keys": [
+          "Crack Random Substitution_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis_2018",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Getting Started_2018",
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment1_2018",
+        "script_level.level_keys": [
+          "U2L13 Assessment1_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment3_2018",
+        "script_level.level_keys": [
+          "U2L13 Assessment3_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment4_2018",
+        "script_level.level_keys": [
+          "U2L13 Assessment4_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L06 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L06 SFLP"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Vigenere Cipher Widget_2018",
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Secure Is Your Password?_2018",
+        "script_level.level_keys": [
+          "How Secure Is Your Password?_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys_2018",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Getting Started_2018",
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment_2018",
+        "script_level.level_keys": [
+          "U2L14 Assessment_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment2_2018",
+        "script_level.level_keys": [
+          "U2L14 Assessment2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment1_2018",
+        "script_level.level_keys": [
+          "U2L15 Assessment1_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L07 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L07 SFLP"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys_2018",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cups and Beans Activity_2018",
+        "script_level.level_keys": [
+          "Cups and Beans Activity_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Modulo Clock Instructions_2018",
+        "script_level.level_keys": [
+          "Modulo Clock Instructions_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Modulo Clock_2018",
+        "script_level.level_keys": [
+          "The Modulo Clock_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Crypto Widget Instructions_2018",
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Cryptography Widget_2018",
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Assessment 1_2018",
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Match terms to cups and beans analogy_2018",
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Getting Started_2018",
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 mutlichoice 20 mod 15_2018",
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 multichoice 13 MOD 17_2018",
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Wrap Up_2018",
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L08 SFLP",
+        "script_level.level_keys": [
+          "CSP U4L08 SFLP"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Cybersecurity and Crime_2018",
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 Ch1 Cumulative Assessment MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-2019.script_json
+++ b/dashboard/config/scripts_json/csp4-2019.script_json
@@ -1,0 +1,2608 @@
+{
+  "script": {
+    "name": "csp4-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/unit4/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/unit4/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp4"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-19/unit4/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/unit4/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://code.org/educate/professional-learning/middle-high"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp4",
+    "seeding_key": {
+      "script.name": "csp4-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp4_1_2018",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 4: Big Data and Privacy"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "cspAssessment",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter Assessment"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "optional",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Optional"
+      },
+      "seeding_key": {
+        "lesson_group.key": "optional",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "What is Big Data?",
+      "name": "What is Big Data?",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Finding Trends with Visualizations",
+      "name": "Finding Trends with Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Check Your Assumptions",
+      "name": "Check Your Assumptions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Rapid Research - Data Innovations",
+      "name": "Rapid Research - Data Innovations",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Identifying People with Data",
+      "name": "Identifying People with Data",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "The Cost of Free",
+      "name": "The Cost of Free",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Simple Encryption",
+      "name": "Simple Encryption",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Encryption with Keys and Passwords",
+      "name": "Encryption with Keys and Passwords",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Public Key Crypto",
+      "name": "Public Key Crypto",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Rapid Research - Cybercrime",
+      "name": "Rapid Research - Cybercrime",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "Optional: Data Questions",
+      "name": "Optional: Data Questions",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Optional: Data Questions",
+        "lesson_group.key": "optional",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 13,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC moores law_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L1 - MC moores law_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L1 - MC big data def_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L1 - MC big data def_2018_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L08 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U2L08 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends MC_2018_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L8 google trends MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L8 google trends hypothesis_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 google trends MC_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP Unit 4 google trends MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 trends as predictors_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP Unit 4 trends as predictors_2018_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L09 SFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U2L09 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC_2018_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L9 What is digital divide MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L9 FR digital divide issue_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 MC data bias_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP Unit 4 MC data bias_2018_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L02 SFLP_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L02 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data and Medicine"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Data and Medicine_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Video - Data and Medicine_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "CS is Changing Everything"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Video - CS is Changing Everything_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L2 - FR Practice AP response about data_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L03 SFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Choose-The-Data-Concern_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L3 - FR Identifying people_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L04 SFLP_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L04 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4-AP-Practice-Justify-the-Score_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L4 - MC cost of free_2018_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U4L4 - FR cost of free_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L05 SFLP_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L05 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack a Caesar Cipher"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Terminology Recap"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Terminology Recap_2018_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "New Challenge Introduction"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction_2018_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "New Challenge Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Crack Random Substitution"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Crack Random Substitution_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Technique: Frequency Analysis"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis_2018_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L13 Free Response Getting Started_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L13 Assessment1_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment3_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L13 Assessment3_2018_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment4_2018_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L13 Assessment4_2018_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L13 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L06 SFLP_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L06 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Vigenere Cipher Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "The Vigenere Cipher Widget_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Secure Is Your Password?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Secure Is Your Password?_2018_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "How Secure Is Your Password?_2018_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L14 Free Response Getting Started_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L14 Assessment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment2_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L14 Assessment2_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L15 Assessment1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CB_Question_12_2018_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CB_Question_12_2018_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L07 SFLP_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L07 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Encryption and Public Keys"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cups and Beans Activity"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cups and Beans Activity_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Cups and Beans Activity_2018_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Modulo Clock Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Modulo Clock Instructions_2018_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Modulo Clock Instructions_2018_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "The Modulo Clock"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Modulo Clock_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "The Modulo Clock_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Crypto Widget Instructions"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions_2018_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Public Key Crypto Widget Instructions_2018_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Public Key Cryptography Widget"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Public Key Cryptography Widget_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L18 Free Response Assessment 1_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy_2018_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L18 Match terms to cups and beans analogy_2018_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L19 Free Response Getting Started_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15_2018_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L19 mutlichoice 20 mod 15_2018_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L19 multichoice 13 MOD 17_2018_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "U2L19 Free Response Wrap Up_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L08 SFLP_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP U4L08 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Cybersecurity and Crime"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "Video - Cybersecurity and Crime_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 18-19 Unit 4 Data Questions"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Optional: Data Questions",
+        "lesson_group.key": "optional",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "CSP 18-19 Unit 4 Data Questions"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC moores law_2018_2019",
+        "script_level.level_keys": [
+          "U4L1 - MC moores law_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L1 - MC big data def_2018_2019",
+        "script_level.level_keys": [
+          "U4L1 - MC big data def_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-5-levelgroup-U4Ch1_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L08 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L08 SFLP_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends MC_2018_2019",
+        "script_level.level_keys": [
+          "U2L8 google trends MC_2018_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 google trends hypothesis_2019",
+        "script_level.level_keys": [
+          "U2L8 google trends hypothesis_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 google trends MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 4 google trends MC_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 trends as predictors_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 4 trends as predictors_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L09 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L09 SFLP_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 What is digital divide MC_2018_2019",
+        "script_level.level_keys": [
+          "U2L9 What is digital divide MC_2018_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 FR digital divide issue_2019",
+        "script_level.level_keys": [
+          "U2L9 FR digital divide issue_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 MC data bias_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 4 MC data bias_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L02 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L02 SFLP_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Data and Medicine_2019",
+        "script_level.level_keys": [
+          "Video - Data and Medicine_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - CS is Changing Everything_2019",
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L2 - FR Practice AP response about data_2019",
+        "script_level.level_keys": [
+          "U4L2 - FR Practice AP response about data_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L03 SFLP_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Choose-The-Data-Concern_2019",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Choose-The-Data-Concern_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 - FR Identifying people_2019",
+        "script_level.level_keys": [
+          "U4L3 - FR Identifying people_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L04 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L04 SFLP_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4-AP-Practice-Justify-the-Score_2019",
+        "script_level.level_keys": [
+          "U4-AP-Practice-Justify-the-Score_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - MC cost of free_2018_2019",
+        "script_level.level_keys": [
+          "U4L4 - MC cost of free_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L4 - FR cost of free_2019",
+        "script_level.level_keys": [
+          "U4L4 - FR cost of free_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L05 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L05 SFLP_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher_2019",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap_2018_2019",
+        "script_level.level_keys": [
+          "Terminology Recap_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction_2018_2019",
+        "script_level.level_keys": [
+          "New Challenge Introduction_2018_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution_2019",
+        "script_level.level_keys": [
+          "Crack Random Substitution_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis_2018_2019",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis_2018_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Getting Started_2019",
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment1_2019",
+        "script_level.level_keys": [
+          "U2L13 Assessment1_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment3_2018_2019",
+        "script_level.level_keys": [
+          "U2L13 Assessment3_2018_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment4_2018_2019",
+        "script_level.level_keys": [
+          "U2L13 Assessment4_2018_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L06 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L06 SFLP_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Vigenere Cipher Widget_2019",
+        "script_level.level_keys": [
+          "The Vigenere Cipher Widget_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Secure Is Your Password?_2018_2019",
+        "script_level.level_keys": [
+          "How Secure Is Your Password?_2018_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys_2019",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Getting Started_2019",
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment_2018_2019",
+        "script_level.level_keys": [
+          "U2L14 Assessment_2018_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment2_2019",
+        "script_level.level_keys": [
+          "U2L14 Assessment2_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment1_2018_2019",
+        "script_level.level_keys": [
+          "U2L15 Assessment1_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CB_Question_12_2018_2019",
+        "script_level.level_keys": [
+          "CB_Question_12_2018_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Encryption with Keys and Passwords",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L07 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L07 SFLP_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys_2019",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cups and Beans Activity_2018_2019",
+        "script_level.level_keys": [
+          "Cups and Beans Activity_2018_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Modulo Clock Instructions_2018_2019",
+        "script_level.level_keys": [
+          "Modulo Clock Instructions_2018_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Modulo Clock_2019",
+        "script_level.level_keys": [
+          "The Modulo Clock_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Crypto Widget Instructions_2018_2019",
+        "script_level.level_keys": [
+          "Public Key Crypto Widget Instructions_2018_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Cryptography Widget_2019",
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Assessment 1_2019",
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Match terms to cups and beans analogy_2018_2019",
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy_2018_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Getting Started_2019",
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 mutlichoice 20 mod 15_2018_2019",
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15_2018_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 multichoice 13 MOD 17_2018_2019",
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Wrap Up_2019",
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L08 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U4L08 SFLP_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Cybersecurity and Crime_2019",
+        "script_level.level_keys": [
+          "Video - Cybersecurity and Crime_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Cybercrime",
+        "lesson_group.key": "csp4_1_2018",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 4 Ch1 Cumulative Assessment MC_2018_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "cspAssessment",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 18-19 Unit 4 Data Questions",
+        "script_level.level_keys": [
+          "CSP 18-19 Unit 4 Data Questions"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Optional: Data Questions",
+        "lesson_group.key": "optional",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp4-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-2020.script_json
+++ b/dashboard/config/scripts_json/csp4-2020.script_json
@@ -1,0 +1,3590 @@
+{
+  "script": {
+    "name": "csp4-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit4/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        },
+        {
+          "notice": "EIPM Lessons",
+          "details": "In this unit, we beginning following our new programming model called EIPM. Check out this helpful video series to learn all about it! ",
+          "link": "https://www.youtube.com/playlist?list=PLzdnOPI1iJNeqEl6MN7c2KyM3gdBSo8t3",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit4/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit4/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 1",
+      "name": "Project - Decision Maker App Part 1",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 2",
+      "name": "Project - Decision Maker App Part 2",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 3",
+      "name": "Project - Decision Maker App Part 3",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "key": "Lesson 15: Assessment Day",
+      "name": "Lesson 15: Assessment Day",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L3 CFU Variables Psuedocode"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Randomness Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L3 CFU Variables Randomness Psuedocode"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Submit_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v1 Code"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v2 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v3 Code"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice equivalent expressions"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice equivalent expressions"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L10 CFU Conditionals Psuedocode"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L10 CFU Conditionals Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try to the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4 L09 CFU Exit Ticket_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4L10 CFU Functions Psuedocode"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1 2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1 2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP U4L15 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 4 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 CFU Variables Psuedocode",
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 CFU Variables Randomness Psuedocode",
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Randomness Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project_2020",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Submit_2020",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v1 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v2 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v3 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice equivalent expressions",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice equivalent expressions"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Conditionals Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Conditionals Psuedocode 2",
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample_2020",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator_2020",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 L09 CFU Exit Ticket_2020",
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Functions Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1 2020",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1 2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2020",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L15 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp4-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp4-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 4 Deeper Learning Reflections",
+      "name": "Complete Unit 4 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "csp4-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "csp4-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      },
+      "level_keys": [
+        "csp4-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4-dlp-q1",
+        "script_level.level_keys": [
+          "csp4-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4-dlp-q2",
+        "script_level.level_keys": [
+          "csp4-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4-dlp-q3",
+        "script_level.level_keys": [
+          "csp4-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-dlp.script_json
+++ b/dashboard/config/scripts_json/csp4-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csp4-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 4 Deeper Learning Reflections",
+      "name": "Complete Unit 4 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "csp deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "csp4dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "csp4dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp4dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      },
+      "level_keys": [
+        "csp4dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp deeper learning timeline",
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4dlp-lessons",
+        "script_level.level_keys": [
+          "csp4dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4dlp-tools",
+        "script_level.level_keys": [
+          "csp4dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp4dlp-assessment",
+        "script_level.level_keys": [
+          "csp4dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 4 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp4-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp4-pilot-staging.script_json
@@ -1,0 +1,3505 @@
+{
+  "script": {
+    "name": "csp4-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v1 Code"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v2 Code"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v3 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v1 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v2 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v3 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-pilot.script_json
+++ b/dashboard/config/scripts_json/csp4-pilot.script_json
@@ -1,0 +1,4412 @@
+{
+  "script": {
+    "name": "csp4-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit4/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "optional_stages",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Optional Stages"
+      },
+      "seeding_key": {
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 1",
+      "name": "Project - Decision Maker App Part 1",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 2",
+      "name": "Project - Decision Maker App Part 2",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Project - Decision Maker App Part 3",
+      "name": "Project - Decision Maker App Part 3",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Lesson 15: Assessment Day",
+      "name": "Lesson 15: Assessment Day",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Unit 4 STUDENT Survey",
+      "name": "Unit 4 STUDENT Survey",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "Unit 4 TEACHER Survey",
+      "name": "Unit 4 TEACHER Survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Variables Make",
+      "name": "[OLD] Variables Make",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Conditionals Make",
+      "name": "[OLD] Conditionals Make",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Functions Make",
+      "name": "[OLD] Functions Make",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L3 CFU Variables Psuedocode"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Randomness Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L3 CFU Variables Randomness Psuedocode"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Submit_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v1 Code"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v2 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v3 Code"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice equivalent expressions"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice equivalent expressions"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L10 CFU Conditionals Psuedocode"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L10 CFU Conditionals Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try to the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4 L09 CFU Exit Ticket_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L10 CFU Functions Psuedocode"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1 2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1 2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4L15 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 4 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 4 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 4 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "CSP U4 20-21 Teacher Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 CFU Variables Psuedocode",
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 CFU Variables Randomness Psuedocode",
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Randomness Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project_2020",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Submit_2020",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v1 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v2 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v3 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice equivalent expressions",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice equivalent expressions"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Conditionals Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Conditionals Psuedocode 2",
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode 2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample_2020",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator_2020",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 L09 CFU Exit Ticket_2020",
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Functions Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1 2020",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1 2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2020",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Project - Decision Maker App Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Project - Decision Maker App Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L15 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U4 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U4 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Variables Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Conditionals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 8,
+        "lesson.key": "[OLD] Functions Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp4-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-preview.script_json
+++ b/dashboard/config/scripts_json/csp4-preview.script_json
@@ -1,0 +1,3922 @@
+{
+  "script": {
+    "name": "csp4-preview",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-preview/unit4/{LESSON}",
+      "pilot_experiment": "csp-preview",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-preview"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "key": "Lesson 15: Assessment Day",
+      "name": "Lesson 15: Assessment Day",
+      "absolute_position": 15,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L1 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L1 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L2 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L2 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L3 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L3 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L3 CFU Variables Psuedocode"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L4 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L4 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L5 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L5 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L6 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L6 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v1 Code"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v2 Code"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L06 Lemon Hunter App v3 Code"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L7 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L7 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L10 CFU Conditionals Psuedocode"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L8 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L8 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L9 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L9 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4 L09 CFU Exit Ticket_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L10 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L10 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4L10 CFU Functions Psuedocode"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L11 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L11 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L12 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L12 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L13 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L13 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L14 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L14 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4L15 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP U4L15 Preview SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 4 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L1 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L1 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L2 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L2 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L3 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L3 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L3 CFU Variables Psuedocode",
+        "script_level.level_keys": [
+          "U4L3 CFU Variables Psuedocode"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L4 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L4 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L5 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L5 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L6 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L6 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v1 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v1 Code"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v2 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v2 Code"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Lemon Hunter App v3 Code",
+        "script_level.level_keys": [
+          "U4 L06 Lemon Hunter App v3 Code"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L7 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L7 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Conditionals Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Conditionals Psuedocode"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L8 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L8 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L9 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L9 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 L09 CFU Exit Ticket_2020",
+        "script_level.level_keys": [
+          "CSP U4 L09 CFU Exit Ticket_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L10 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L10 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 CFU Functions Psuedocode",
+        "script_level.level_keys": [
+          "U4L10 CFU Functions Psuedocode"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L11 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L11 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L12 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L12 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L13 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L13 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 5,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L14 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L14 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U4L15 Preview SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U4L15 Preview SFLP 20-21"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 15: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp4-preview"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp4-support.script_json
+++ b/dashboard/config/scripts_json/csp4-support.script_json
@@ -1,0 +1,1749 @@
+{
+  "script": {
+    "name": "csp4-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CSP Support",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp4-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 4 Overview",
+      "name": "Unit 4 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Lessons 1 - 4: Data in the Real World",
+      "name": "Lessons 1 - 4: Data in the Real World",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+      "name": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Lessons 8 - 9: Practice PT",
+      "name": "Lessons 8 - 9: Practice PT",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 4"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Introduction to Unit 4"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Tool Talk"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Tool Talk"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4: Practice PT highlights"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4: Practice PT highlights"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Self-Assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4.1 - 4.4 Lesson Connections"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "4.1 - 4.4 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is \"Big\" Data?"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "What is \"Big\" Data?"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Website: Data Breaches"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Website: Data Breaches"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Raw Data Podcast: Gold or Pyrite"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Raw Data Podcast: Gold or Pyrite"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Data in the CSP Framework"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Big Data in the CSP Framework"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L1 - 4: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "U4 L1 - 4: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4.5 - 4.7 Lesson Connections"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "4.5 - 4.7 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Encryption in CS"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Encryption in CS"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Terminology Recap"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "New Challenge Introduction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Crack Random Substitution"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Modular Arithmetic"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Modular Arithmetic"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Looking at More Encryption Algorithms"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Looking at More Encryption Algorithms"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Raw Data Podcast: Data Confidential"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Raw Data Podcast: Data Confidential"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L5 - 7: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "U4 L5 - 7: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4.8 - 4.9 Lesson Connections"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "4.8 - 4.9 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "A Closer Look at the Final Practice for the Explore PT"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "A Closer Look at the Final Practice for the Explore PT"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L8 - 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "U4 L8 - 9: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Balancing Teacher and Tools in Unit 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Balancing Teacher and Tools in Unit 4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Assessing Student Learning in Unit 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Assessing Student Learning in Unit 4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      },
+      "level_keys": [
+        "Unit 4 Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 4",
+        "script_level.level_keys": [
+          "Introduction to Unit 4"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Tool Talk",
+        "script_level.level_keys": [
+          "Unit 4 Tool Talk"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4: Practice PT highlights",
+        "script_level.level_keys": [
+          "Unit 4: Practice PT highlights"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Self-Assessment",
+        "script_level.level_keys": [
+          "Unit 4 Self-Assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4.1 - 4.4 Lesson Connections",
+        "script_level.level_keys": [
+          "4.1 - 4.4 Lesson Connections"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is \"Big\" Data?",
+        "script_level.level_keys": [
+          "What is \"Big\" Data?"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Website: Data Breaches",
+        "script_level.level_keys": [
+          "Website: Data Breaches"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Raw Data Podcast: Gold or Pyrite",
+        "script_level.level_keys": [
+          "Raw Data Podcast: Gold or Pyrite"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Data in the CSP Framework",
+        "script_level.level_keys": [
+          "Big Data in the CSP Framework"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L1 - 4: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U4 L1 - 4: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 1 - 4: Data in the Real World",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4.5 - 4.7 Lesson Connections",
+        "script_level.level_keys": [
+          "4.5 - 4.7 Lesson Connections"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Encryption in CS",
+        "script_level.level_keys": [
+          "Encryption in CS"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap",
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction",
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution",
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Modular Arithmetic",
+        "script_level.level_keys": [
+          "Modular Arithmetic"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Looking at More Encryption Algorithms",
+        "script_level.level_keys": [
+          "Looking at More Encryption Algorithms"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Raw Data Podcast: Data Confidential",
+        "script_level.level_keys": [
+          "Raw Data Podcast: Data Confidential"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L5 - 7: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U4 L5 - 7: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4.8 - 4.9 Lesson Connections",
+        "script_level.level_keys": [
+          "4.8 - 4.9 Lesson Connections"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "A Closer Look at the Final Practice for the Explore PT",
+        "script_level.level_keys": [
+          "A Closer Look at the Final Practice for the Explore PT"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L8 - 9: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U4 L8 - 9: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Lessons 8 - 9: Practice PT",
+        "lesson_group.key": "content",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Balancing Teacher and Tools in Unit 4",
+        "script_level.level_keys": [
+          "Balancing Teacher and Tools in Unit 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Assessing Student Learning in Unit 4",
+        "script_level.level_keys": [
+          "Assessing Student Learning in Unit 4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 4 Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Unit 4 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp4-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-2017.script_json
+++ b/dashboard/config/scripts_json/csp5-2017.script_json
@@ -1,0 +1,11361 @@
+{
+  "script": {
+    "name": "csp5-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "version_year": "2017",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp/unit5"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp5"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp/unit5/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp/unit5/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp/unit5/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp5-support"
+        ]
+      ]
+    },
+    "new_name": "csp5-2017",
+    "family_name": "csp5",
+    "seeding_key": {
+      "script.name": "csp5-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Event-Driven Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "csp5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Programming with Data Structures"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Buttons and Events",
+      "name": "Buttons and Events",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Multi-screen Apps",
+      "name": "Multi-screen Apps",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Building an App: Multi-Screen App",
+      "name": "Building an App: Multi-Screen App",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Controlling Memory with Variables",
+      "name": "Controlling Memory with Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Building an App: Clicker Game",
+      "name": "Building an App: Clicker Game",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 1",
+      "name": "Unit 5 Assessment 1",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "User Input and Strings",
+      "name": "User Input and Strings",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "\"If\" Statements Unplugged",
+      "name": "\"If\" Statements Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Boolean Expressions and \"If\" Statements",
+      "name": "Boolean Expressions and \"If\" Statements",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "\"if-else-if\" and Conditional Logic",
+      "name": "\"if-else-if\" and Conditional Logic",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Building an App: Color Sleuth",
+      "name": "Building an App: Color Sleuth",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 2",
+      "name": "Unit 5 Assessment 2",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Building an App: Image Scroller",
+      "name": "Building an App: Image Scroller",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 3",
+      "name": "Unit 5 Assessment 3",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Building an App: Canvas Painter",
+      "name": "Building an App: Canvas Painter",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 4",
+      "name": "Unit 5 Assessment 4",
+      "absolute_position": 21,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Practice PT: Create",
+      "name": "Practice PT: Create",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "name": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 1 Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 1 Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode in App Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Design Mode"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Design Mode"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_FirstTimeDesignMode"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Design Mode 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How onEvent Works"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How onEvent Works"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_moveTurtleOnButtonClick"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_turtleDriver_add2ndButton"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Event-Driven Programming Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Event-Driven Programming Patterns"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Rules About Choosing Good IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Rules About Choosing Good IDs"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Descriptive IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_addDescriptiveIDsToTurtleDriver"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Types"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_playWithEventTypes"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Intro to Debugging and Common Problems"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_predict_applab_onEventWithWrongID"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging IDs case sensitive"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one ID"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_Debugging predict unexpected behavior - two onEvents to one ID"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging 3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How setPosition and screen dimensions work"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_setPosition to fixed location"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - setPosition to move button"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Labels"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_AddLabelToChaserGame"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "How Images Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Images Work"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How Images Work"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Chaser Game v.1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Finalize Your Chaser Game v.1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 23,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-6-levelgroup-U5Ch1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 2 Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 2 Introduction"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Layering and Deleting in Design Mode"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Add onEvent from Design Mode"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 First Time Console.log"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging with Console.log"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Debugging with Console.log"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 console.log in event v. global"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 console.log debug when mouse events happen"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Debugging Overlapping Objects and Screen Events"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Multiple Screens"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Making Multiple Screens"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Add a 2nd Screen"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Use setScreen for first time"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Making a Multi Screen Chaser Game v.2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Add welcome screen to chaser game"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Add full screen image to bg of chaser game"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Multi-Screen Chaser Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5 Add game over screen"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 3 Introduction"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 3 Introduction"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Driven Programming Recap"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event Driven Programming Recap"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Event Driven Programming Recap"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Tips For Working on Your Own"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tips For Working on Your Own"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Tips For Working on Your Own"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Your Own Multi-Screen App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Project - Your Own Multi Screen App"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Response - Describe Your Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Process"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 4 Introduction"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 4 Introduction"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Basic mechanics of variables"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Basic mechanics of variables"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - three basic ops of variables"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - fix the var name syntax error v2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - write var and string with same name v2"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Create And Assign"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Text Mode"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Controlling Memory - Other ways to assign values"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - concatenate simple"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression with Other Variables"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Assigning Random Value"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Mini Calculator embed"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - User Input Division calculator"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - test reassignment of two vars"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Mental Model for Variables"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "The Mental Model for Variables"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Variable ReAssignment pt2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge2"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge3"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge4"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge5"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge6"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - variable reassignment challenge pt2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - MC variable reassignment"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 5 Introduction"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 5 Introduction"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Clicker Game Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 full clicker demo"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - practice with setText"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - DEMO up down count practice app"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - global var example count up"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - variable scoping problem debugging"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection on Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 spot the difference variable debugging"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variable Scope: Local vs. Global"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - add code to make count down work"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug forget to set text"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug var not created globally"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug logic error wrong update"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - mini clicker update score"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 click add lives"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Simple Decisions with if-statements"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Simple If-statements in UpDown App"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Add reset button to UpDown app"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v=="
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debugging Simple If-statements =v=="
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug if never triggers in UpDown app"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Clicker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 full clicker app"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Response - Choosing an Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 AP Create Practice onEvent Doesnt Count"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_5": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_5": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control_5",
+        "csp_affirmation_intervention_5"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 1 MC"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 6 Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 6 Introduction"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Demo"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - introStrings"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - doubleQuotes"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - textInput getText write"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - intro getText"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - User Input - Save getText To Variable"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - outputWithTextArea"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - toUpper"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Student Setup"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib setText"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib getText"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib toUpper"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Clear Input"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "String and Substring Free Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 Free Response 3"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 7 Introduction"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 7 Introduction"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Big Picture: if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Picture: If-statements"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Big Picture: If-statements"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Worked Example: if-statements and Robot"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Worked Example: If-statements and Robot"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "(new) Algorithms in Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Algorithms Map"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Algorithms Map"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 8 Introduction"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 8 Introduction"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Expressions and Comparison Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Boolean Expressions and Comparison Operators"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Comparison Operators Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L18 comparison operators"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If Statements Work pt 1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How If Statements Work pt 1"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_basic if - check driving age"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_basic if - DIY secret number"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 Check Password if statement lock image"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If-Else Statements Work"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How If-Else Statements Work"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else simple movie ratings example"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_basic if-else - driving age"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if-else string"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 Check Password if-else string"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Dropdown Menus Work"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How Dropdown Menus Work"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else dropdown movie checker"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else dropdown guess dice"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else weeekend challenge"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 9 Introduction"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 9 Introduction"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else-if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How \"if-else-if\" Works"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if movie example"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else-if movie example"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 if-else-if quiz grade"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Else if"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Debug"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Compound Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How the Boolean &&, || and ! Operators Work"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple OR"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple AND"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How Compound Boolean Expressions Work"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR Simple"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 compound boolean museum example"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 compound boolean museum example"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR and NOT"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Response - Score the Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5-AP-Algorithm-Does-It-Count"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 10 Introduction"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 10 Introduction"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Planning the App"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Color Sleuth - Planning the App"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Set Property Works"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Set Property Works"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How Set Property Works"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 1"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 2 small color change"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to pick a random button"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How to pick a random button"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 3 pick random button"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to make a random color"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "How to make a random color"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 4 make random RGB string"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 5 make setBoard function"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth add global var correct plus console.log"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 color sleuth check correct"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 color sleuth check correct"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect make global var"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part1 link to event handlers"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check correct"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part2 add if statement to check correct"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Color Sleuth - How to switch player turns"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt1 add var and function and console.log"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt2 update UI to indicate turn"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Color Sleuth - Keeping score"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt1 vars function stub console"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt3 update UI for scoring"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - How Does It End?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Color Sleuth - How does it end?"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Color Sleuth"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Project: Finish Color Sleuth"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Epilogue"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Color Sleuth - Epilogue"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 25,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Abstraction Color Sleuth"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 26,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP U5 AP Practice Choose the Algorithm"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "(new) AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Algorithm Color Sleuth"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_5": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_5": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "csp_affirmation_control_5",
+        "csp_affirmation_intervention_5"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 2 MC"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 11 Introduction"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 11 Introduction"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 1"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 2"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 3"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Typing in Console"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 4"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 5"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 8"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 6"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 7"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 9"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops -  Complex Condition"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 10"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 11"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 12"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Plus Plus"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Minus Minus"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - plus and minus = operator"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - minus = operator"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 14"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 15"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-7-levelgroup-U5Ch2"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 12 Introduction"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 12 Introduction"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Hypothesis"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Make a Hypothesis"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Make a Hypothesis"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 1"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.1"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.5"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 1"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 3"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 4"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 5"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 2"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment With Simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 6"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 13 Introduction"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 13 Introduction"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 1"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - createFirstArray"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - appendItem"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - introIndex"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - indexPractice"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment2"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment3"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - stringsInArrays"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertingItems"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - remove"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertionErrors"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - length"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - lengthMinus1"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - expressionsAsIndexes"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "\"My Favorite Things\" Demo App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Demo App"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings giveIDs"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings createArray"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings firstOutput"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Counting Variable"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Next"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Prev"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 27,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings addItem"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 28,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings bounds"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 29,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings keepPlaying"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 30,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 1"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 31,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 2"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 14 Introduction"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 14 Introduction"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Demo App"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - drag out key event"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Key Up and Down"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - play sound when up key"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Multiple Keys"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Buttons and Keys"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Functions"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Using URLs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Add Image URLs"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Image Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Final Image Scroller"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Project - Final Image Scroller"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Reflection Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3- Keys - Code Refactoring Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 3 MC"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 15 Introduction"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 15 Introduction"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Processing Lists with Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Processing Lists with Loops"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to for Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Intro For Loop"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Printing an Array"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Print Array"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Add 5"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Divid by 2"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Loop Array If"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Linear Search"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Counting Times"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Printing Single True"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Search with Boolean Var"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function - add list parameter"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - General Search Param"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Find Min"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 16 Introduction"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 16 Introduction"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Return Command"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Using Output from Functions: The return Command"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using minVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - useMinVal"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - writeMaxVal"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingMaxVal"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingConstrain"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - constrainTurtle"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - wrapTurtle"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 17 Introduction"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 17 Introduction"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - introCanvas"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - 200dots"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - transparentDots"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - clickToAdd"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - usingOffsetXY"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - draw at click point"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - changeToMouseMove"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - shiftKey"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Storing Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - appendToArray"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - delete"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom2"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawOriginal"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction fix Orig"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - One Dot sprayPaint"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sprayPaint"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Stored Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sketch"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Canvas Painter"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - freePlay"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 4 MC"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Vocabulary & Resources"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Lesson 18 Introduction"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Unit 5 Lesson 18 Introduction"
+      ]
+    },
+    {
+      "chapter": 299,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice Performance Task: Create"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Create Performance Task"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Practice Create Performance Task"
+      ]
+    },
+    {
+      "chapter": 300,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A"
+      ]
+    },
+    {
+      "chapter": 301,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 302,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 1 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 1 Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Design Mode",
+        "script_level.level_keys": [
+          "Introduction to Design Mode"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_FirstTimeDesignMode",
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Design Mode 1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How onEvent Works",
+        "script_level.level_keys": [
+          "How onEvent Works"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_moveTurtleOnButtonClick",
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_turtleDriver_add2ndButton",
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event-Driven Programming Patterns",
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rules About Choosing Good IDs",
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_addDescriptiveIDsToTurtleDriver",
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_playWithEventTypes",
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Debugging and Common Problems",
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_predict_applab_onEventWithWrongID",
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging IDs case sensitive",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_Debugging predict unexpected behavior - two onEvents to one ID",
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one ID"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging 3",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How setPosition and screen dimensions work",
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_setPosition to fixed location",
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - setPosition to move button",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_AddLabelToChaserGame",
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Images Work",
+        "script_level.level_keys": [
+          "How Images Work"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Finalize Your Chaser Game v.1",
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-6-levelgroup-U5Ch1",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 2 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 2 Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Layering and Deleting in Design Mode",
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add onEvent from Design Mode",
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 First Time Console.log",
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging with Console.log",
+        "script_level.level_keys": [
+          "Debugging with Console.log"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log in event v. global",
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log debug when mouse events happen",
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Debugging Overlapping Objects and Screen Events",
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Multiple Screens",
+        "script_level.level_keys": [
+          "Making Multiple Screens"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add a 2nd Screen",
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Use setScreen for first time",
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Multi Screen Chaser Game v.2",
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add welcome screen to chaser game",
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add full screen image to bg of chaser game",
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add game over screen",
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 3 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 3 Introduction"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event Driven Programming Recap",
+        "script_level.level_keys": [
+          "Event Driven Programming Recap"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tips For Working on Your Own",
+        "script_level.level_keys": [
+          "Tips For Working on Your Own"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Your Own Multi Screen App",
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Process",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 4 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 4 Introduction"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Basic mechanics of variables",
+        "script_level.level_keys": [
+          "Basic mechanics of variables"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - three basic ops of variables",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - fix the var name syntax error v2",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - write var and string with same name v2",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Create And Assign",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Text Mode",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Controlling Memory - Other ways to assign values",
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - concatenate simple",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression with Other Variables",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Assigning Random Value",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Mini Calculator embed",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - User Input Division calculator",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - test reassignment of two vars",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 2",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Mental Model for Variables",
+        "script_level.level_keys": [
+          "The Mental Model for Variables"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Variable ReAssignment pt2",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge1",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge2",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge3",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge4",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge5",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge6",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - variable reassignment challenge pt2",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - MC variable reassignment",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 5 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 5 Introduction"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 full clicker demo",
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - practice with setText",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - DEMO up down count practice app",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - global var example count up",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - variable scoping problem debugging",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 spot the difference variable debugging",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - add code to make count down work",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug forget to set text",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug var not created globally",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug logic error wrong update",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - mini clicker update score",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 click add lives",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Simple Decisions with if-statements",
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Simple If-statements in UpDown App",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Add reset button to UpDown app",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debugging Simple If-statements =v==",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v=="
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug if never triggers in UpDown app",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 full clicker app",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Create Practice onEvent Doesnt Count",
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_5",
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_5",
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 1 MC",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 6 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 6 Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Demo",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - introStrings",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - doubleQuotes",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - textInput getText write",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - intro getText",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - User Input - Save getText To Variable",
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - outputWithTextArea",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - toUpper",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Student Setup",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib setText",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib getText",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib toUpper",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Clear Input",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 Free Response 3",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 7 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 7 Introduction"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Picture: If-statements",
+        "script_level.level_keys": [
+          "Big Picture: If-statements"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Worked Example: If-statements and Robot",
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Algorithms Map",
+        "script_level.level_keys": [
+          "CSP Algorithms Map"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 8 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 8 Introduction"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Expressions and Comparison Operators",
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L18 comparison operators",
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If Statements Work pt 1",
+        "script_level.level_keys": [
+          "How If Statements Work pt 1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - check driving age",
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - DIY secret number",
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if statement lock image",
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If-Else Statements Work",
+        "script_level.level_keys": [
+          "How If-Else Statements Work"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else simple movie ratings example",
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if-else - driving age",
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if-else string",
+        "script_level.level_keys": [
+          "U5 Check Password if-else string"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Dropdown Menus Work",
+        "script_level.level_keys": [
+          "How Dropdown Menus Work"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown movie checker",
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown guess dice",
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else weeekend challenge",
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 9 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 9 Introduction"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How \"if-else-if\" Works",
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if movie example",
+        "script_level.level_keys": [
+          "U5 if-else-if movie example"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if quiz grade",
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Else if",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Debug",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How the Boolean &&, || and ! Operators Work",
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple OR",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple AND",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Compound Boolean Expressions Work",
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR Simple",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 compound boolean museum example",
+        "script_level.level_keys": [
+          "U5 compound boolean museum example"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR and NOT",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5-AP-Algorithm-Does-It-Count",
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 10 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 10 Introduction"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Planning the App",
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Set Property Works",
+        "script_level.level_keys": [
+          "How Set Property Works"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 1",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 2 small color change",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to pick a random button",
+        "script_level.level_keys": [
+          "How to pick a random button"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 3 pick random button",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to make a random color",
+        "script_level.level_keys": [
+          "How to make a random color"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 4 make random RGB string",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 5 make setBoard function",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth add global var correct plus console.log",
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 color sleuth check correct",
+        "script_level.level_keys": [
+          "U5 color sleuth check correct"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect make global var",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part1 link to event handlers",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part2 add if statement to check correct",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check correct"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How to switch player turns",
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt1 add var and function and console.log",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt2 update UI to indicate turn",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Keeping score",
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt1 vars function stub console",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt3 update UI for scoring",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How does it end?",
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project: Finish Color Sleuth",
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Epilogue",
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Abstraction Color Sleuth",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5 AP Practice Choose the Algorithm",
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Algorithm Color Sleuth",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_5",
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_5",
+        "script_level.level_keys": [
+          "csp_affirmation_control_5",
+          "csp_affirmation_intervention_5"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 2 MC",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 11 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 11 Introduction"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 3",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Typing in Console",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 4",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 5",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 8",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 6",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 7",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 9",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops -  Complex Condition",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 10",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 11",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 12",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Plus Plus",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Minus Minus",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - plus and minus = operator",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - minus = operator",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 14",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 15",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-7-levelgroup-U5Ch2",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 12 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 12 Introduction"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Make a Hypothesis",
+        "script_level.level_keys": [
+          "Make a Hypothesis"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.5",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 1",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 3",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 4",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 5",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 2",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 6",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 13 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 13 Introduction"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 1",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - createFirstArray",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - appendItem",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - introIndex",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - indexPractice",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment3",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - stringsInArrays",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertingItems",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - remove",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertionErrors",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - length",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - lengthMinus1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - expressionsAsIndexes",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Demo App",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings giveIDs",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings createArray",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings firstOutput",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Counting Variable",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Next",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Prev",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings addItem",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings bounds",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings keepPlaying",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 1",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 14 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 14 Introduction"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Demo App",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - drag out key event",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Key Up and Down",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - play sound when up key",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Multiple Keys",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Buttons and Keys",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Functions",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Add Image URLs",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Final Image Scroller",
+        "script_level.level_keys": [
+          "Project - Final Image Scroller"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Keys - Code Refactoring Exit Ticket",
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 3 MC",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 15 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 15 Introduction"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops",
+        "script_level.level_keys": [
+          "Processing Lists with Loops"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Intro For Loop",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Print Array",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Add 5",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Divid by 2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Loop Array If",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Linear Search",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Counting Times",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Printing Single True",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Search with Boolean Var",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function - add list parameter",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - General Search Param",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Find Min",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 16 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 16 Introduction"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Output from Functions: The return Command",
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - useMinVal",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - writeMaxVal",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingMaxVal",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingConstrain",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - constrainTurtle",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - wrapTurtle",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 17 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 17 Introduction"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - introCanvas",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - 200dots",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - transparentDots",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - clickToAdd",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - usingOffsetXY",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - draw at click point",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - changeToMouseMove",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - shiftKey",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - appendToArray",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - delete",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom2",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawOriginal",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction fix Orig",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - One Dot sprayPaint",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sprayPaint",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sketch",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - freePlay",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 4 MC",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Lesson 18 Introduction",
+        "script_level.level_keys": [
+          "Unit 5 Lesson 18 Introduction"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Create Performance Task",
+        "script_level.level_keys": [
+          "Practice Create Performance Task"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-2018.script_json
+++ b/dashboard/config/scripts_json/csp5-2018.script_json
@@ -1,0 +1,11102 @@
+{
+  "script": {
+    "name": "csp5-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "announcements": [
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-18/unit5"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp5"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-18/unit5/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp-18/unit5/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-18/unit5/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/s/csp5-support"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp5",
+    "seeding_key": {
+      "script.name": "csp5-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Event-Driven Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "csp5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Programming with Data Structures"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Buttons and Events",
+      "name": "Buttons and Events",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Multi-screen Apps",
+      "name": "Multi-screen Apps",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Building an App: Multi-Screen App",
+      "name": "Building an App: Multi-Screen App",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Controlling Memory with Variables",
+      "name": "Controlling Memory with Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Building an App: Clicker Game",
+      "name": "Building an App: Clicker Game",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 1",
+      "name": "Unit 5 Assessment 1",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "User Input and Strings",
+      "name": "User Input and Strings",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "\"If\" Statements Unplugged",
+      "name": "\"If\" Statements Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Boolean Expressions and \"If\" Statements",
+      "name": "Boolean Expressions and \"If\" Statements",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "\"if-else-if\" and Conditional Logic",
+      "name": "\"if-else-if\" and Conditional Logic",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Building an App: Color Sleuth",
+      "name": "Building an App: Color Sleuth",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 2",
+      "name": "Unit 5 Assessment 2",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Building an App: Image Scroller",
+      "name": "Building an App: Image Scroller",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 3",
+      "name": "Unit 5 Assessment 3",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Building an App: Canvas Painter",
+      "name": "Building an App: Canvas Painter",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 4",
+      "name": "Unit 5 Assessment 4",
+      "absolute_position": 21,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "name": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "absolute_position": 22,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L01 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode in App Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Design Mode_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Design Mode_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_FirstTimeDesignMode_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Design Mode 1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How onEvent Works_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How onEvent Works_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_moveTurtleOnButtonClick_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_turtleDriver_add2ndButton_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Event-Driven Programming Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Event-Driven Programming Patterns_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Rules About Choosing Good IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Rules About Choosing Good IDs_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Descriptive IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_addDescriptiveIDsToTurtleDriver_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Types"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_playWithEventTypes_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Intro to Debugging and Common Problems_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_predict_applab_onEventWithWrongID_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging IDs case sensitive_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging 3_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How setPosition and screen dimensions work_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_setPosition to fixed location_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - setPosition to move button_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Labels"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_AddLabelToChaserGame_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "How Images Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Images Work_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How Images Work_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Chaser Game v.1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Finalize Your Chaser Game v.1_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 23,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L02 SFLP"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L02 SFLP"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Layering and Deleting in Design Mode_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Add onEvent from Design Mode_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 First Time Console.log_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Debugging with Console.log_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 console.log in event v. global_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 console.log debug when mouse events happen_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Debugging Overlapping Objects and Screen Events_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Multiple Screens_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Making Multiple Screens_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Add a 2nd Screen_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Use setScreen for first time_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Making a Multi Screen Chaser Game v.2_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Add welcome screen to chaser game_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Add full screen image to bg of chaser game_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Multi-Screen Chaser Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5 Add game over screen_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L03 SFLP"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L03 SFLP"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Driven Programming Recap"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event Driven Programming Recap_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Event Driven Programming Recap_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Tips For Working on Your Own"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Tips For Working on Your Own_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Your Own Multi-Screen App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Project - Your Own Multi Screen App_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Describe Your Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Process_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L04 SFLP"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L04 SFLP"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Basic mechanics of variables_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Basic mechanics of variables_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - three basic ops of variables_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - fix the var name syntax error v2_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - write var and string with same name v2_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Create And Assign_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Text Mode_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Controlling Memory - Other ways to assign values_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - concatenate simple_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression with Other Variables_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Assigning Random Value_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Mini Calculator embed_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - User Input Division calculator_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - test reassignment of two vars_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "The Mental Model for Variables_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Variable ReAssignment pt2_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge3_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge4_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge5_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge6_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - variable reassignment challenge pt2_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - MC variable reassignment_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L05 SFLP"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L05 SFLP"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Clicker Game Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 full clicker demo_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - practice with setText_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - DEMO up down count practice app_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - global var example count up_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - variable scoping problem debugging_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection on Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 spot the difference variable debugging_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variable Scope: Local vs. Global"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Variable Scope: Local vs. Global_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - add code to make count down work_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug forget to set text_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug var not created globally_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug logic error wrong update_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - mini clicker update score_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 click add lives_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Simple Decisions with if-statements_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Simple If-statements in UpDown App_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Add reset button to UpDown app_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debugging Simple If-statements =v==_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug if never triggers in UpDown app_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Clicker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 full clicker app_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Choosing an Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 AP Create Practice onEvent Doesnt Count_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 1 MC_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L06 SFLP"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L06 SFLP"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Demo_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - introStrings_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - doubleQuotes_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - textInput getText write_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - intro getText_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - User Input - Save getText To Variable_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - outputWithTextArea_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - toUpper_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Student Setup_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib setText_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib getText_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib toUpper_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Clear Input_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "String and Substring Free Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 Free Response 3_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L07 SFLP"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Big Picture: if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Picture: If-statements_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Big Picture: If-statements_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Worked Example: if-statements and Robot"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Worked Example: If-statements and Robot_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Algorithms in Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Algorithms Map_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Algorithms Map_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L08 SFLP"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L08 SFLP"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Boolean Expressions_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Expressions and Comparison Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Boolean Expressions and Comparison Operators_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Comparison Operators Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L18 comparison operators_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if Statements_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How If Statements Work pt 1_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_basic if - check driving age_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_basic if - DIY secret number_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 Check Password if statement lock image_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else Statements_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How If-Else Statements Work_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else simple movie ratings example_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_basic if-else - driving age_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 Check Password if-else string_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How Dropdown Menus Work_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else dropdown movie checker_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else dropdown guess dice_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else weeekend challenge_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L09 SFLP"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L09 SFLP"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else-if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else-if Statements_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How \"if-else-if\" Works_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else-if movie example_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 if-else-if quiz grade_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Else if_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Debug_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Compound Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Compound Boolean Expressions_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How the Boolean &&, || and ! Operators Work_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple OR_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple AND_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How Compound Boolean Expressions Work_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR Simple_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 compound boolean museum example_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Score the Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5-AP-Algorithm-Does-It-Count_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Planning the App"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Color Sleuth - Planning the App_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Set Property Works"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Set Property Works_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How Set Property Works_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 1_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 2 small color change_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to pick a random button_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How to pick a random button_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 3 pick random button_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to make a random color_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "How to make a random color_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 4 make random RGB string_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 5 make setBoard function_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth add global var correct plus console.log_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 color sleuth check correct_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 color sleuth check correct_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect make global var_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part1 link to event handlers_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2018"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Color Sleuth - How to switch player turns_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Color Sleuth - Keeping score_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt1 vars function stub console_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt3 update UI for scoring_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - How Does It End?"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Color Sleuth - How does it end?_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Color Sleuth"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Project: Finish Color Sleuth_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Epilogue"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Color Sleuth - Epilogue_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 25,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Abstraction Color Sleuth_2018"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 26,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5 AP Practice Choose the Algorithm_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Algorithm Color Sleuth_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 2 MC_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 1_2018"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 2_2018"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 3_2018"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Typing in Console_2018"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 4_2018"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 5_2018"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 8_2018"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 6_2018"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 7_2018"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 9_2018"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops -  Complex Condition_2018"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 10_2018"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 11_2018"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 12_2018"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Plus Plus_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Minus Minus_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - plus and minus = operator_2018"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - minus = operator_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 14_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 15_2018"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Hypothesis"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Make a Hypothesis_2018"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 1_2018"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2_2018"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.1_2018"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.5_2018"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 1_2018"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 3_2018"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 4_2018"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 5_2018"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment With Simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 6_2018"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 1_2018"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - createFirstArray_2018"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - appendItem_2018"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - introIndex_2018"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - indexPractice_2018"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_2018"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment_2018"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment2_2018"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment3_2018"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - stringsInArrays_2018"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertingItems_2018"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - remove_2018"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertionErrors_2018"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_2018"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - length_2018"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - lengthMinus1_2018"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - expressionsAsIndexes_2018"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "\"My Favorite Things\" Demo App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Demo App_2018"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings giveIDs_2018"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings createArray_2018"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings firstOutput_2018"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Counting Variable_2018"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Next_2018"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Prev_2018"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 27,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings addItem_2018"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 28,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings bounds_2018"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 29,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings keepPlaying_2018"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 30,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 1_2018"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 31,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 2_2018"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L14 SFLP"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Demo App_2018"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - drag out key event_2018"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Key Up and Down_2018"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - play sound when up key_2018"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_2018"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Multiple Keys_2018"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Buttons and Keys_2018"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Functions_2018"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Using URLs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Add Image URLs_2018"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Image Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Project - Final Image Scroller_2018"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Reflection Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2018"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 3 MC_2018"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L15 SFLP"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Processing Lists with Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_2018"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to for Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Intro For Loop_2018"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Printing an Array"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Print Array_2018"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Add 5_2018"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Divid by 2_2018"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Loop Array If_2018"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Linear Search_2018"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Counting Times_2018"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Printing Single True_2018"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2018"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function_2018"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2018"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - General Search Param_2018"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Find Min_2018"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L16 SFLP"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Return Command"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "Using Output from Functions: The return Command_2018"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using minVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - useMinVal_2018"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - writeMaxVal_2018"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingMaxVal_2018"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingConstrain_2018"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_2018"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - constrainTurtle_2018"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_2018"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - wrapTurtle_2018"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP U5L17 SFLP"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_2018"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - introCanvas_2018"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_2018"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - 200dots_2018"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_2018"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - transparentDots_2018"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_2018"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - clickToAdd_2018"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_2018"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - usingOffsetXY_2018"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_2018"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - draw at click point_2018"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_2018"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - changeToMouseMove_2018"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_2018"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - shiftKey_2018"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Storing Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_2018"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - appendToArray_2018"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_2018"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - delete_2018"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_2018"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom_2018"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_2018"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom2_2018"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_2018"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawOriginal_2018"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_2018"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction_2018"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_2018"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction fix Orig_2018"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_2018"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - One Dot sprayPaint_2018"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_2018"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sprayPaint_2018"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Stored Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_2018"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sketch_2018"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Canvas Painter"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_2018"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - freePlay_2018"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 4 MC_2018"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A_2018"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L01 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Design Mode_2018",
+        "script_level.level_keys": [
+          "Introduction to Design Mode_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_FirstTimeDesignMode_2018",
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Design Mode 1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How onEvent Works_2018",
+        "script_level.level_keys": [
+          "How onEvent Works_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_moveTurtleOnButtonClick_2018",
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_turtleDriver_add2ndButton_2018",
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event-Driven Programming Patterns_2018",
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rules About Choosing Good IDs_2018",
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_addDescriptiveIDsToTurtleDriver_2018",
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_playWithEventTypes_2018",
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Debugging and Common Problems_2018",
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_predict_applab_onEventWithWrongID_2018",
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging IDs case sensitive_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2018",
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging 3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How setPosition and screen dimensions work_2018",
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_setPosition to fixed location_2018",
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - setPosition to move button_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_AddLabelToChaserGame_2018",
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Images Work_2018",
+        "script_level.level_keys": [
+          "How Images Work_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Finalize Your Chaser Game v.1_2018",
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L02 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L02 SFLP"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Layering and Deleting in Design Mode_2018",
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add onEvent from Design Mode_2018",
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 First Time Console.log_2018",
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging with Console.log_2018",
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log in event v. global_2018",
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log debug when mouse events happen_2018",
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Debugging Overlapping Objects and Screen Events_2018",
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Multiple Screens_2018",
+        "script_level.level_keys": [
+          "Making Multiple Screens_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add a 2nd Screen_2018",
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Use setScreen for first time_2018",
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Multi Screen Chaser Game v.2_2018",
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add welcome screen to chaser game_2018",
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add full screen image to bg of chaser game_2018",
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add game over screen_2018",
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L03 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L03 SFLP"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event Driven Programming Recap_2018",
+        "script_level.level_keys": [
+          "Event Driven Programming Recap_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tips For Working on Your Own_2018",
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Your Own Multi Screen App_2018",
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Process_2018",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L04 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L04 SFLP"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Basic mechanics of variables_2018",
+        "script_level.level_keys": [
+          "Basic mechanics of variables_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2018",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - three basic ops of variables_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - fix the var name syntax error v2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - write var and string with same name v2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Create And Assign_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Text Mode_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Controlling Memory - Other ways to assign values_2018",
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - concatenate simple_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression with Other Variables_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Assigning Random Value_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Mini Calculator embed_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - User Input Division calculator_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - test reassignment of two vars_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 2_2018",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Mental Model for Variables_2018",
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Variable ReAssignment pt2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge4_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge5_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge6_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - variable reassignment challenge pt2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - MC variable reassignment_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L05 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L05 SFLP"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 full clicker demo_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - practice with setText_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - DEMO up down count practice app_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - global var example count up_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - variable scoping problem debugging_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 spot the difference variable debugging_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variable Scope: Local vs. Global_2018",
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - add code to make count down work_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug forget to set text_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug var not created globally_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug logic error wrong update_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - mini clicker update score_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 click add lives_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Simple Decisions with if-statements_2018",
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Simple If-statements in UpDown App_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Add reset button to UpDown app_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debugging Simple If-statements =v==_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug if never triggers in UpDown app_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 full clicker app_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Create Practice onEvent Doesnt Count_2018",
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 1 MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L06 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L06 SFLP"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Demo_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - introStrings_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - doubleQuotes_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - textInput getText write_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - intro getText_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - User Input - Save getText To Variable_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - outputWithTextArea_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - toUpper_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Student Setup_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib setText_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib getText_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib toUpper_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Clear Input_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 Free Response 3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L07 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L07 SFLP"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Picture: If-statements_2018",
+        "script_level.level_keys": [
+          "Big Picture: If-statements_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Worked Example: If-statements and Robot_2018",
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Algorithms Map_2018",
+        "script_level.level_keys": [
+          "CSP Algorithms Map_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L08 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L08 SFLP"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Boolean Expressions_2018",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Expressions and Comparison Operators_2018",
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L18 comparison operators_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if Statements_2018",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If Statements Work pt 1_2018",
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - check driving age_2018",
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - DIY secret number_2018",
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if statement lock image_2018",
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else Statements_2018",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If-Else Statements Work_2018",
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else simple movie ratings example_2018",
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if-else - driving age_2018",
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if-else string_2018",
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Dropdown Menus Work_2018",
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown movie checker_2018",
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown guess dice_2018",
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else weeekend challenge_2018",
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L09 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L09 SFLP"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else-if Statements_2018",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How \"if-else-if\" Works_2018",
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if movie example_2018",
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if quiz grade_2018",
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Else if_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Debug_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Compound Boolean Expressions_2018",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How the Boolean &&, || and ! Operators Work_2018",
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple OR_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple AND_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Compound Boolean Expressions Work_2018",
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR Simple_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 compound boolean museum example_2018",
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5-AP-Algorithm-Does-It-Count_2018",
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Planning the App_2018",
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Set Property Works_2018",
+        "script_level.level_keys": [
+          "How Set Property Works_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 1_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 2 small color change_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to pick a random button_2018",
+        "script_level.level_keys": [
+          "How to pick a random button_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 3 pick random button_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to make a random color_2018",
+        "script_level.level_keys": [
+          "How to make a random color_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 4 make random RGB string_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 5 make setBoard function_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth add global var correct plus console.log_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 color sleuth check correct_2018",
+        "script_level.level_keys": [
+          "U5 color sleuth check correct_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect make global var_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part1 link to event handlers_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2018"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How to switch player turns_2018",
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Keeping score_2018",
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt1 vars function stub console_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt3 update UI for scoring_2018",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How does it end?_2018",
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project: Finish Color Sleuth_2018",
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Epilogue_2018",
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Abstraction Color Sleuth_2018",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5 AP Practice Choose the Algorithm_2018",
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Algorithm Color Sleuth_2018",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 2 MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L11 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_2018"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_2018"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_2018"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Typing in Console_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_2018"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 4_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_2018"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 5_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_2018"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 8_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_2018"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 6_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_2018"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 7_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_2018"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 9_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_2018"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops -  Complex Condition_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_2018"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 10_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_2018"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 11_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 12_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Plus Plus_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Minus Minus_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - plus and minus = operator_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - minus = operator_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 14_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 15_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L12 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Make a Hypothesis_2018",
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.5_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 1_2018",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 4_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 5_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 2_2018",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 6_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L13 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 1_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - createFirstArray_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - appendItem_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - introIndex_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - indexPractice_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment3_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - stringsInArrays_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertingItems_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - remove_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertionErrors_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - length_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - lengthMinus1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - expressionsAsIndexes_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Demo App_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings giveIDs_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings createArray_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings firstOutput_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Counting Variable_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Next_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Prev_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings addItem_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings bounds_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings keepPlaying_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 1_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L14 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Demo App_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - drag out key event_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Key Up and Down_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - play sound when up key_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Multiple Keys_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_2018"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Buttons and Keys_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Functions_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Add Image URLs_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Final Image Scroller_2018",
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 3 MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L15 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_2018",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Intro For Loop_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Print Array_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Add 5_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Divid by 2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Loop Array If_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Linear Search_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Counting Times_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Printing Single True_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - General Search Param_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Find Min_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L16 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Output from Functions: The return Command_2018",
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - useMinVal_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - writeMaxVal_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingMaxVal_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingConstrain_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - constrainTurtle_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_2018"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - wrapTurtle_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_2018"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L17 SFLP",
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - introCanvas_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_2018"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - 200dots_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_2018"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - transparentDots_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_2018"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - clickToAdd_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_2018"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - usingOffsetXY_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_2018"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - draw at click point_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_2018"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - changeToMouseMove_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_2018"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - shiftKey_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_2018"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - appendToArray_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_2018"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - delete_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_2018"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_2018"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom2_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_2018"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawOriginal_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_2018"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_2018"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction fix Orig_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_2018"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - One Dot sprayPaint_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_2018"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sprayPaint_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_2018"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sketch_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_2018"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - freePlay_2018",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_2018"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 4 MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A_2018",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-2019.script_json
+++ b/dashboard/config/scripts_json/csp5-2019.script_json
@@ -1,0 +1,11121 @@
+{
+  "script": {
+    "name": "csp5-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/unit5/{LESSON}",
+      "version_year": "2019",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-19/unit5"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csp5"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csp-19/unit5/vocab/"
+        ],
+        [
+          "codeIntroduced",
+          "https://curriculum.code.org/csp-19/unit5/code/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-19/unit5/standards/"
+        ],
+        [
+          "professionalLearning",
+          "https://code.org/educate/professional-learning/middle-high"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "csp5",
+    "seeding_key": {
+      "script.name": "csp5-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Event-Driven Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "csp5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Programming with Data Structures"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Buttons and Events",
+      "name": "Buttons and Events",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Multi-screen Apps",
+      "name": "Multi-screen Apps",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Building an App: Multi-Screen App",
+      "name": "Building an App: Multi-Screen App",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Controlling Memory with Variables",
+      "name": "Controlling Memory with Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Building an App: Clicker Game",
+      "name": "Building an App: Clicker Game",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 1",
+      "name": "Unit 5 Assessment 1",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "User Input and Strings",
+      "name": "User Input and Strings",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "\"If\" Statements Unplugged",
+      "name": "\"If\" Statements Unplugged",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Boolean Expressions and \"If\" Statements",
+      "name": "Boolean Expressions and \"If\" Statements",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "\"if-else-if\" and Conditional Logic",
+      "name": "\"if-else-if\" and Conditional Logic",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Building an App: Color Sleuth",
+      "name": "Building an App: Color Sleuth",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 2",
+      "name": "Unit 5 Assessment 2",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Building an App: Image Scroller",
+      "name": "Building an App: Image Scroller",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 3",
+      "name": "Unit 5 Assessment 3",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Building an App: Canvas Painter",
+      "name": "Building an App: Canvas Painter",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 4",
+      "name": "Unit 5 Assessment 4",
+      "absolute_position": 21,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "name": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "absolute_position": 22,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 23,
+      "lockable": true,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L01 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Design Mode in App Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Design Mode_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Design Mode_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_FirstTimeDesignMode_2018_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Design Mode 1_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How onEvent Works_2018_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How onEvent Works_2018_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_moveTurtleOnButtonClick_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Buttons and Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_turtleDriver_add2ndButton_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Event-Driven Programming Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Event-Driven Programming Patterns_2018_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Rules About Choosing Good IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Rules About Choosing Good IDs_2018_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Descriptive IDs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_addDescriptiveIDsToTurtleDriver_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Types"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_playWithEventTypes_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Intro to Debugging and Common Problems_2018_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_predict_applab_onEventWithWrongID_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging IDs case sensitive_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging 3_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How setPosition and screen dimensions work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_setPosition to fixed location_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - setPosition to move button_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Labels"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_AddLabelToChaserGame_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "How Images Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Images Work_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How Images Work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Chaser Game v.1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Finalize Your Chaser Game v.1_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 23,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L02 SFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L02 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Layering and Deleting in Design Mode_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Add onEvent from Design Mode_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 First Time Console.log_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Debugging with Console.log_2018_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 console.log in event v. global_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 console.log debug when mouse events happen_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Debugging Overlapping Objects and Screen Events_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Multiple Screens_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Making Multiple Screens_2018_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Add a 2nd Screen_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Multiple Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Use setScreen for first time_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Making a Multi Screen Chaser Game v.2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Add welcome screen to chaser game_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Add full screen image to bg of chaser game_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Multi-Screen Chaser Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5 Add game over screen_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L03 SFLP_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L03 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Driven Programming Recap"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Event Driven Programming Recap_2018_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Event Driven Programming Recap_2018_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Tips For Working on Your Own"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Tips For Working on Your Own_2018_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Project - Your Own Multi-Screen App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Project - Your Own Multi Screen App_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Describe Your Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Process_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L04 SFLP_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L04 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Basic mechanics of variables_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Basic mechanics of variables_2018_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - three basic ops of variables_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - fix the var name syntax error v2_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - write var and string with same name v2_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Create And Assign_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Text Mode_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values_2018_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Controlling Memory - Other ways to assign values_2018_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - concatenate simple_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression with Other Variables_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Assigning Random Value_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Mini Calculator embed_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - User Input Division calculator_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - test reassignment of two vars_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "The Mental Model for Variables_2018_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Variable ReAssignment pt2_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge3_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge4_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge5_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - moving memory challenge6_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - variable reassignment challenge pt2_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - MC variable reassignment_2018_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L05 SFLP_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L05 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Clicker Game Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 full clicker demo_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - practice with setText_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - DEMO up down count practice app_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - global var example count up_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - variable scoping problem debugging_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection on Debugging"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 spot the difference variable debugging_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variable Scope: Local vs. Global"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Variable Scope: Local vs. Global_2018_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - add code to make count down work_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug forget to set text_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug var not created globally_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug logic error wrong update_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - mini clicker update score_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Global Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 click add lives_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Simple Decisions with if-statements_2018_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Simple If-statements in UpDown App_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Add reset button to UpDown app_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debugging Simple If-statements =v==_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug if never triggers in UpDown app_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 21,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Clicker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 full clicker app_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Choosing an Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 AP Create Practice onEvent Doesnt Count_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_2018_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 1 MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L06 SFLP_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L06 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Demo_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - introStrings_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - doubleQuotes_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - textInput getText write_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - intro getText_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - User Input - Save getText To Variable_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - outputWithTextArea_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - toUpper_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Student Setup_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib setText_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib getText_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib toUpper_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Clear Input_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "String and Substring Free Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 Free Response 3_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L07 SFLP_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L07 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Big Picture: if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Big Picture: If-statements_2018_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Big Picture: If-statements_2018_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Worked Example: if-statements and Robot"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot_2018_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Worked Example: If-statements and Robot_2018_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Algorithms in Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Algorithms Map_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Algorithms Map_2018_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L08 SFLP_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L08 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Boolean Expressions_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Expressions and Comparison Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Boolean Expressions and Comparison Operators_2018_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Comparison Operators Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L18 comparison operators_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if Statements_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How If Statements Work pt 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_basic if - check driving age_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_basic if - DIY secret number_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 Check Password if statement lock image_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else Statements_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How If-Else Statements Work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else simple movie ratings example_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_basic if-else - driving age_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 Check Password if-else string_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How Dropdown Menus Work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else dropdown movie checker_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else dropdown guess dice_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else weeekend challenge_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L09 SFLP_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L09 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else-if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else-if Statements_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How \"if-else-if\" Works_2018_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else-if movie example_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 if-else-if quiz grade_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Else if_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Debug_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Compound Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Compound Boolean Expressions_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work_2018_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How the Boolean &&, || and ! Operators Work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple OR_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple AND_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work_2018_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How Compound Boolean Expressions Work_2018_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR Simple_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 compound boolean museum example_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 16,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Response - Score the Response"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5-AP-Algorithm-Does-It-Count_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L10 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Planning the App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App_2018_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Color Sleuth - Planning the App_2018_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How Set Property Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Set Property Works_2018_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How Set Property Works_2018_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 1_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 2 small color change_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to pick a random button_2018_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How to pick a random button_2018_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 3 pick random button_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How to make a random color_2018_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "How to make a random color_2018_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 4 make random RGB string_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 5 make setBoard function_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth add global var correct plus console.log_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 color sleuth check correct_2018_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 color sleuth check correct_2018_2019"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect make global var_2019"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part1 link to event handlers_2019"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2019"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns_2018_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Color Sleuth - How to switch player turns_2018_2019"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2019"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2019"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score_2018_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Color Sleuth - Keeping score_2018_2019"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt1 vars function stub console_2019"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt3 update UI for scoring_2019"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - How Does It End?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?_2018_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Color Sleuth - How does it end?_2018_2019"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 23,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Color Sleuth"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Project: Finish Color Sleuth_2019"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Epilogue"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue_2018_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Color Sleuth - Epilogue_2018_2019"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 25,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Abstraction Color Sleuth_2019"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 26,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5 AP Practice Choose the Algorithm_2019"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+        "progression": "AP Practice Responses - Algorithms and Abstraction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "U5 AP Practice Create Algorithm Color Sleuth_2019"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L11 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 1_2019"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 2_2019"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 3_2019"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Typing in Console_2019"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 4_2019"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 5_2019"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 8_2019"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 6_2019"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 7_2019"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 9_2019"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops -  Complex Condition_2019"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 10_2019"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 11_2019"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 12_2019"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Plus Plus_2019"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Minus Minus_2019"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - plus and minus = operator_2019"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - minus = operator_2019"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 14_2019"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 15_2019"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L12 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Hypothesis"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Make a Hypothesis_2018_2019"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 1_2019"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2_2019"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.1_2019"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.5_2019"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 3_2019"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 4_2019"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 5_2019"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment With Simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 6_2019"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L13 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 1_2019"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - createFirstArray_2019"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - appendItem_2019"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_2019"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - introIndex_2019"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - indexPractice_2019"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_2019"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment_2019"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment2_2019"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment3_2019"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - stringsInArrays_2019"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertingItems_2019"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - remove_2019"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertionErrors_2019"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_2019"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - length_2019"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - lengthMinus1_2019"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - expressionsAsIndexes_2019"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "\"My Favorite Things\" Demo App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Demo App_2019"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings giveIDs_2019"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings createArray_2019"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings firstOutput_2019"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Counting Variable_2019"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Next_2019"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Prev_2019"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 27,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings addItem_2019"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 28,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings bounds_2019"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 29,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings keepPlaying_2019"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 30,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 1_2019"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 31,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 2_2019"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L14 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Demo App_2019"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - drag out key event_2019"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Key Up and Down_2019"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - play sound when up key_2019"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Multiple Keys_2019"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Buttons and Keys_2019"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Functions_2019"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Using URLs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Add Image URLs_2019"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Image Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Project - Final Image Scroller_2019"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Reflection Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2019"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L15 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Processing Lists with Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_2019"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to for Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Intro For Loop_2019"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Printing an Array"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Print Array_2019"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Add 5_2019"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Divid by 2_2019"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Loop Array If_2019"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Linear Search_2019"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Counting Times_2019"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Printing Single True_2019"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2019"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function_2019"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2019"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - General Search Param_2019"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Find Min_2019"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L16 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Return Command"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "Using Output from Functions: The return Command_2018_2019"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using minVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - useMinVal_2019"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - writeMaxVal_2019"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingMaxVal_2019"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingConstrain_2019"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - constrainTurtle_2019"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_2019"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - wrapTurtle_2019"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP_2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP U5L17 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - introCanvas_2019"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_2019"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - 200dots_2019"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_2019"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - transparentDots_2019"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_2019"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - clickToAdd_2019"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_2019"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - usingOffsetXY_2019"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_2019"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - draw at click point_2019"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_2019"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - changeToMouseMove_2019"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_2019"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - shiftKey_2019"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Storing Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_2019"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - appendToArray_2019"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_2019"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - delete_2019"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_2019"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom_2019"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_2019"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom2_2019"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_2019"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawOriginal_2019"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_2019"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction_2019"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_2019"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction fix Orig_2019"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_2019"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - One Dot sprayPaint_2019"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_2019"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sprayPaint_2019"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Stored Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_2019"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sketch_2019"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 20,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_2019"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - freePlay_2019"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018_2019"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A_2018_2019"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Design Mode_2019",
+        "script_level.level_keys": [
+          "Introduction to Design Mode_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_FirstTimeDesignMode_2018_2019",
+        "script_level.level_keys": [
+          "CSPU5_FirstTimeDesignMode_2018_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Design Mode 1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Design Mode 1_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How onEvent Works_2018_2019",
+        "script_level.level_keys": [
+          "How onEvent Works_2018_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_moveTurtleOnButtonClick_2019",
+        "script_level.level_keys": [
+          "CSPU5_moveTurtleOnButtonClick_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_turtleDriver_add2ndButton_2019",
+        "script_level.level_keys": [
+          "CSPU5_turtleDriver_add2ndButton_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event-Driven Programming Patterns_2018_2019",
+        "script_level.level_keys": [
+          "Event-Driven Programming Patterns_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Rules About Choosing Good IDs_2018_2019",
+        "script_level.level_keys": [
+          "Rules About Choosing Good IDs_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_addDescriptiveIDsToTurtleDriver_2019",
+        "script_level.level_keys": [
+          "CSPU5_addDescriptiveIDsToTurtleDriver_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_playWithEventTypes_2019",
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Intro to Debugging and Common Problems_2018_2019",
+        "script_level.level_keys": [
+          "Intro to Debugging and Common Problems_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_predict_applab_onEventWithWrongID_2019",
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging IDs case sensitive_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2019",
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to one_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging 3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How setPosition and screen dimensions work_2018_2019",
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_setPosition to fixed location_2019",
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - setPosition to move button_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_AddLabelToChaserGame_2019",
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Images Work_2018_2019",
+        "script_level.level_keys": [
+          "How Images Work_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Finalize Your Chaser Game v.1_2019",
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-6-levelgroup-U5Ch1_2018_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 23,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L02 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L02 SFLP_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Layering and Deleting in Design Mode_2019",
+        "script_level.level_keys": [
+          "CSPU5 Layering and Deleting in Design Mode_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add onEvent from Design Mode_2019",
+        "script_level.level_keys": [
+          "CSPU5 Add onEvent from Design Mode_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 First Time Console.log_2019",
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging with Console.log_2018_2019",
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log in event v. global_2019",
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log debug when mouse events happen_2019",
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Debugging Overlapping Objects and Screen Events_2019",
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Multiple Screens_2018_2019",
+        "script_level.level_keys": [
+          "Making Multiple Screens_2018_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add a 2nd Screen_2019",
+        "script_level.level_keys": [
+          "CSPU5 Add a 2nd Screen_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Use setScreen for first time_2019",
+        "script_level.level_keys": [
+          "CSPU5 Use setScreen for first time_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Multi Screen Chaser Game v.2_2018_2019",
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add welcome screen to chaser game_2019",
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 13,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add full screen image to bg of chaser game_2019",
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 14,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add game over screen_2019",
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 15,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L03 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L03 SFLP_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Event Driven Programming Recap_2018_2019",
+        "script_level.level_keys": [
+          "Event Driven Programming Recap_2018_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tips For Working on Your Own_2018_2019",
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Your Own Multi Screen App_2019",
+        "script_level.level_keys": [
+          "Project - Your Own Multi Screen App_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Process_2019",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Process_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Multi-Screen App",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L04 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L04 SFLP_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Basic mechanics of variables_2018_2019",
+        "script_level.level_keys": [
+          "Basic mechanics of variables_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_2019",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - three basic ops of variables_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - fix the var name syntax error v2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - write var and string with same name v2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Create And Assign_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Text Mode_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Controlling Memory - Other ways to assign values_2018_2019",
+        "script_level.level_keys": [
+          "Controlling Memory - Other ways to assign values_2018_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - concatenate simple_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression with Other Variables_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Assigning Random Value_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Mini Calculator embed_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - User Input Division calculator_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - test reassignment of two vars_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 2_2019",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Mental Model for Variables_2018_2019",
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Variable ReAssignment pt2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge2_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge3_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge4_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge4_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge5_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge5_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - moving memory challenge6_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - moving memory challenge6_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - variable reassignment challenge pt2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 26,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - MC variable reassignment_2018_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - MC variable reassignment_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 27,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L05 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L05 SFLP_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 full clicker demo_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - practice with setText_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - DEMO up down count practice app_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - global var example count up_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - variable scoping problem debugging_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 spot the difference variable debugging_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 spot the difference variable debugging_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variable Scope: Local vs. Global_2018_2019",
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - add code to make count down work_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug forget to set text_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug var not created globally_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug var not created globally_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug logic error wrong update_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - mini clicker update score_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 click add lives_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Simple Decisions with if-statements_2018_2019",
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Simple If-statements in UpDown App_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Add reset button to UpDown app_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debugging Simple If-statements =v==_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown app_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug if never triggers in UpDown app_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug if never triggers in UpDown app_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 full clicker app_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 full clicker app_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Create Practice onEvent Doesnt Count_2019",
+        "script_level.level_keys": [
+          "U5 AP Create Practice onEvent Doesnt Count_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 1 MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 1 MC_2018_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 1",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L06 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L06 SFLP_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Demo_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - introStrings_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - doubleQuotes_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - textInput getText write_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - intro getText_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - User Input - Save getText To Variable_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - outputWithTextArea_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - toUpper_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - toUpper_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Student Setup_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib setText_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib getText_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib toUpper_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib toUpper_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Clear Input_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 Free Response 3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 Free Response 3_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L07 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L07 SFLP_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Big Picture: If-statements_2018_2019",
+        "script_level.level_keys": [
+          "Big Picture: If-statements_2018_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Worked Example: If-statements and Robot_2018_2019",
+        "script_level.level_keys": [
+          "Worked Example: If-statements and Robot_2018_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Algorithms Map_2018_2019",
+        "script_level.level_keys": [
+          "CSP Algorithms Map_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "\"If\" Statements Unplugged",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L08 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L08 SFLP_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Boolean Expressions_2019",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Expressions and Comparison Operators_2018_2019",
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L18 comparison operators_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if Statements_2019",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If Statements Work pt 1_2018_2019",
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - check driving age_2019",
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - DIY secret number_2019",
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if statement lock image_2019",
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else Statements_2019",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If-Else Statements Work_2018_2019",
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else simple movie ratings example_2019",
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if-else - driving age_2019",
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if-else string_2019",
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Dropdown Menus Work_2018_2019",
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown movie checker_2019",
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown guess dice_2019",
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 17,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else weeekend challenge_2019",
+        "script_level.level_keys": [
+          "U5 if-else weeekend challenge_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 18,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L09 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L09 SFLP_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else-if Statements_2019",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How \"if-else-if\" Works_2018_2019",
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if movie example_2019",
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if quiz grade_2019",
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Else if_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Debug_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Compound Boolean Expressions_2019",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How the Boolean &&, || and ! Operators Work_2018_2019",
+        "script_level.level_keys": [
+          "How the Boolean &&, || and ! Operators Work_2018_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple OR_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple AND_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Compound Boolean Expressions Work_2018_2019",
+        "script_level.level_keys": [
+          "How Compound Boolean Expressions Work_2018_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR Simple_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 13,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 compound boolean museum example_2019",
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 14,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 15,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5-AP-Algorithm-Does-It-Count_2019",
+        "script_level.level_keys": [
+          "U5-AP-Algorithm-Does-It-Count_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 16,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Planning the App_2018_2019",
+        "script_level.level_keys": [
+          "Color Sleuth - Planning the App_2018_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Set Property Works_2018_2019",
+        "script_level.level_keys": [
+          "How Set Property Works_2018_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 1_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 2 small color change_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to pick a random button_2018_2019",
+        "script_level.level_keys": [
+          "How to pick a random button_2018_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 3 pick random button_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How to make a random color_2018_2019",
+        "script_level.level_keys": [
+          "How to make a random color_2018_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 4 make random RGB string_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 5 make setBoard function_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth add global var correct plus console.log_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 color sleuth check correct_2018_2019",
+        "script_level.level_keys": [
+          "U5 color sleuth check correct_2018_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect make global var_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_2019"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part1 link to event handlers_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_2019"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check corre_2019"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How to switch player turns_2018_2019",
+        "script_level.level_keys": [
+          "Color Sleuth - How to switch player turns_2018_2019"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.log_2019"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_2019"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Keeping score_2018_2019",
+        "script_level.level_keys": [
+          "Color Sleuth - Keeping score_2018_2019"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt1 vars function stub console_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_2019"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt3 update UI for scoring_2019",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_2019"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 21,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - How does it end?_2018_2019",
+        "script_level.level_keys": [
+          "Color Sleuth - How does it end?_2018_2019"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 22,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project: Finish Color Sleuth_2019",
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 23,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Color Sleuth - Epilogue_2018_2019",
+        "script_level.level_keys": [
+          "Color Sleuth - Epilogue_2018_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 24,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Abstraction Color Sleuth_2019",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Abstraction Color Sleuth_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 25,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5 AP Practice Choose the Algorithm_2019",
+        "script_level.level_keys": [
+          "CSP U5 AP Practice Choose the Algorithm_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 26,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 AP Practice Create Algorithm Color Sleuth_2019",
+        "script_level.level_keys": [
+          "U5 AP Practice Create Algorithm Color Sleuth_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 27,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L11 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Typing in Console_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 4_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 5_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 8_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 6_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 7_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 9_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops -  Complex Condition_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 10_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 11_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 12_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Plus Plus_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Minus Minus_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - plus and minus = operator_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - minus = operator_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 14_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 15_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L12 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Make a Hypothesis_2018_2019",
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.5_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 1_2018_2019",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 4_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 5_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 2_2018_2019",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 6_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L13 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 1_2019",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - createFirstArray_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - appendItem_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_2019",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - introIndex_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - indexPractice_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_2019",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment3_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - stringsInArrays_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertingItems_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - remove_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertionErrors_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_2019",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - length_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - lengthMinus1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - expressionsAsIndexes_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Demo App_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings giveIDs_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings createArray_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings firstOutput_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Counting Variable_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Next_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Prev_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings addItem_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings bounds_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings keepPlaying_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 1_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L14 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Demo App_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - drag out key event_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Key Up and Down_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - play sound when up key_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Multiple Keys_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Buttons and Keys_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Functions_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Add Image URLs_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Final Image Scroller_2019",
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L15 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_2019",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Intro For Loop_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Print Array_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Add 5_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Divid by 2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Loop Array If_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Linear Search_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Counting Times_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Printing Single True_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list param_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - General Search Param_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Find Min_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L16 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Output from Functions: The return Command_2018_2019",
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - useMinVal_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - writeMaxVal_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingMaxVal_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingConstrain_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - constrainTurtle_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - wrapTurtle_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_2019"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L17 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP_2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - introCanvas_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - 200dots_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_2019"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - transparentDots_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_2019"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - clickToAdd_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_2019"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - usingOffsetXY_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_2019"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - draw at click point_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_2019"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - changeToMouseMove_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_2019"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - shiftKey_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_2019"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - appendToArray_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_2019"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - delete_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_2019"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_2019"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom2_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_2019"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawOriginal_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_2019"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_2019"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction fix Orig_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_2019"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - One Dot sprayPaint_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_2019"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sprayPaint_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_2019"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sketch_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_2019"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - freePlay_2019",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_2019"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 20,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A_2018_2019",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018_2019"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csp5-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-2020.script_json
+++ b/dashboard/config/scripts_json/csp5-2020.script_json
@@ -1,0 +1,3374 @@
+{
+  "script": {
+    "name": "csp5-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit5/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit5/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit5/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_lists",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Lists"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "csp_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "csp_traversals",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Traversals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lists Explore",
+      "name": "Lists Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Lists Investigate",
+      "name": "Lists Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Lists Practice",
+      "name": "Lists Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Lists Make",
+      "name": "Lists Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Loops Explore",
+      "name": "Loops Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Loops Investigate",
+      "name": "Loops Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Loops Practice",
+      "name": "Loops Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Loops Make",
+      "name": "Loops Make",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Traversals Explore",
+      "name": "Traversals Explore",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Traversals Investigate",
+      "name": "Traversals Investigate",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Traversals Practice",
+      "name": "Traversals Practice",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Traversals Make",
+      "name": "Traversals Make",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 1",
+      "name": "Semester Hackathon Part 1",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 2",
+      "name": "Semester Hackathon Part 2",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 3",
+      "name": "Semester Hackathon Part 3",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 4",
+      "name": "Semester Hackathon Part 4",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 5",
+      "name": "Semester Hackathon Part 5",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "key": "Lesson 18: Assessment Day",
+      "name": "Lesson 18: Assessment Day",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L01 Introduction to Lists"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "csp-20-21-u5-assess-lists"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Outfitly Code"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Bandly Code"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Partnersly Code"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "Random List Access Pattern"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "List Scrolling Pattern"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.75"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 10"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice Strings 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice Strings 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 5"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 9"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5L3 CFU Lists Psuedocode"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5L3 CFU Lists Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Sample App 2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project 2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Lists Make Project 2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "csp_applab_loops_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L5 CSP CFU Looping"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U3L5 CSP CFU Looping"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Coin Flipper App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper Predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Coin Flipper Predict"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Coin Flipper App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Coin Flipper"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Font Tester App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Font Tester"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Font Tester"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Element Looping"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U3L6 CSP CFU Element Looping"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops and Screen Elements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Sentence Randomizer"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Sentence Randomizer"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops and Screen Elements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Dice Roller"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Practice Dice Roller"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5L7 CFU Loops Psuedocode"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5L7 CFU Loops Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example 2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Example 2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App 2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App 2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Traversal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 L09 Traversals Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mile Tracker Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Mile Tracker Modify"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Datasets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L10 Traversals Investigate"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Dog Finder Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Dog Finder Modify"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "List Filter Pattern"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "List Reduce Pattern"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 CFU Traversals"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L10 CFU Traversals"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 7"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L11 CFU For Each Psuedocode"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5L11 CFU For Each Psuedocode"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Random Forecaster App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Sample App 2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Random Forecaster App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project 2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project 2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L15 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 3"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L16 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 4"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP 20-21"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L17 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 5"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L18 SFLP 20-21"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP U5L18 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 5 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      },
+      "level_keys": [
+        "CSP Unit 5 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L01 Introduction to Lists",
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-20-21-u5-assess-lists",
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Outfitly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Bandly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Partnersly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Random List Access Pattern",
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Scrolling Pattern",
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 1",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 2",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.75",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 10",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice Strings 2",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice Strings 3",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 4",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 9",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 6",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L3 CFU Lists Psuedocode",
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L3 CFU Lists Psuedocode 2",
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Sample App 2020",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project 2020",
+        "script_level.level_keys": [
+          "U5 Lists Make Project 2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_2018",
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L5 CSP CFU Looping",
+        "script_level.level_keys": [
+          "U3L5 CSP CFU Looping"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Coin Flipper Predict",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper Predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Coin Flipper",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Font Tester",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Font Tester"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L6 CSP CFU Element Looping",
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Element Looping"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Sentence Randomizer",
+        "script_level.level_keys": [
+          "U5 Loops Practice Sentence Randomizer"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Dice Roller",
+        "script_level.level_keys": [
+          "U5 Loops Practice Dice Roller"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L7 CFU Loops Psuedocode",
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L7 CFU Loops Psuedocode 2",
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Example 2020",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example 2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App 2020",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App 2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_2018",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L09 Traversals Exit Ticket",
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Mile Tracker Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 Traversals Investigate",
+        "script_level.level_keys": [
+          "CSP U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Dog Finder Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Filter Pattern",
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Reduce Pattern",
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 CFU Traversals",
+        "script_level.level_keys": [
+          "CSP U5L10 CFU Traversals"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 7",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L11 CFU For Each Psuedocode",
+        "script_level.level_keys": [
+          "U5L11 CFU For Each Psuedocode"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Sample App 2020",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project 2020",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project 2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 2",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L15 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 3",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 3"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L16 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 4",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L17 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP 20-21"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 5",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 5"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L18 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L18 SFLP 20-21"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 5 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-dlp-18.script_json
+++ b/dashboard/config/scripts_json/csp5-dlp-18.script_json
@@ -1,0 +1,327 @@
+{
+  "script": {
+    "name": "csp5-dlp-18",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training 2018-2019",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-dlp-18"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "key": "Complete Unit 5 Deeper Learning Reflections",
+      "name": "Complete Unit 5 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp - 2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "csp5-dlp-q1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "csp5-dlp-q2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      },
+      "level_keys": [
+        "csp5-dlp-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp - 2018",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp - 2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5-dlp-q1",
+        "script_level.level_keys": [
+          "csp5-dlp-q1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5-dlp-q2",
+        "script_level.level_keys": [
+          "csp5-dlp-q2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5-dlp-q3",
+        "script_level.level_keys": [
+          "csp5-dlp-q3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp-18"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-dlp.script_json
+++ b/dashboard/config/scripts_json/csp5-dlp.script_json
@@ -1,0 +1,330 @@
+{
+  "script": {
+    "name": "csp5-dlp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-dlp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "key": "Complete Unit 5 Deeper Learning Reflections",
+      "name": "Complete Unit 5 Deeper Learning Reflections",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "deeper learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "csp deeper learning timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "deeper learning recommendations- csp"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "peer review recommendations"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Connections and Philosophy"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "csp5dlp-lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tool Philosophy and Use"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "csp5dlp-tools"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Assessment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      },
+      "level_keys": [
+        "csp5dlp-assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "deeper learning",
+        "script_level.level_keys": [
+          "deeper learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp deeper learning timeline",
+        "script_level.level_keys": [
+          "csp deeper learning timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "deeper learning recommendations- csp",
+        "script_level.level_keys": [
+          "deeper learning recommendations- csp"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations",
+        "script_level.level_keys": [
+          "peer review recommendations"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5dlp-lessons",
+        "script_level.level_keys": [
+          "csp5dlp-lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5dlp-tools",
+        "script_level.level_keys": [
+          "csp5dlp-tools"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5dlp-assessment",
+        "script_level.level_keys": [
+          "csp5dlp-assessment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Complete Unit 5 Deeper Learning Reflections",
+        "lesson_group.key": "content",
+        "script.name": "csp5-dlp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp5-pilot-staging.script_json
@@ -1,0 +1,3330 @@
+{
+  "script": {
+    "name": "csp5-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_lists",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Lists"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_traversals",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Traversals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_libraries",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Libraries"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lists Explore",
+      "name": "Lists Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Lists Investigate",
+      "name": "Lists Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Lists Practice",
+      "name": "Lists Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Lists Make",
+      "name": "Lists Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Lists)",
+      "name": "Student Survey (Lists)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Survey (Lists)",
+      "name": "Teacher Survey (Lists)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Loops Explore",
+      "name": "Loops Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Loops Investigate and Practice",
+      "name": "Loops Investigate and Practice",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Traversals Explore",
+      "name": "Traversals Explore",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Traversals Investigate",
+      "name": "Traversals Investigate",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Traversals Practice",
+      "name": "Traversals Practice",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Traversals Make",
+      "name": "Traversals Make",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Traversals)",
+      "name": "Student Survey (Traversals)",
+      "absolute_position": 13,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Survey (Traversals)",
+      "name": "Teacher Survey (Traversals)",
+      "absolute_position": 14,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Mini PT",
+      "name": "Mini PT",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mini PT",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Mini PT)",
+      "name": "Student Survey (Mini PT)",
+      "absolute_position": 16,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Mini PT)",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 5 Mini Assessment",
+      "name": "Unit 5 Mini Assessment",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Mini Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Libraries Explore",
+      "name": "Libraries Explore",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Libraries Investigate",
+      "name": "Libraries Investigate",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Libraries)",
+      "name": "Student Survey (Libraries)",
+      "absolute_position": 20,
+      "lockable": true,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Survey (Libraries)",
+      "name": "Teacher Survey (Libraries)",
+      "absolute_position": 21,
+      "lockable": true,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "csp-20-21-u5-assess-lists"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L01 Introduction to Lists"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Outfitly App"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Bandly App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Partnersly App"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Outfitly Code"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Bandly Code"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Partnersly Code"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Random List Access Pattern"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "List Scrolling Pattern"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.75"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 9"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 6"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 10"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Sample App"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 3"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 4"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 5"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 6"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 6"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Lists)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Lists"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Student Late Spring Pilot Survey Lists"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Survey (Lists)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Lists"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Teacher Late Spring Pilot Survey Lists"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "csp_applab_loops_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Coin Flipper Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Coin Flipper"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulations Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 7"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulations Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 8"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulations Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 9"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Traversal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 L09 Traversals Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Mile Tracker"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Word Guess - clone"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Word Guess - clone"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder - clone"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Dog Finder - clone"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Mile Tracker Modify"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "The getList() Block"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Get List Explanation Video"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Get List Explanation Video"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Word Guess Modify"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Word Guess Modify"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Dog Finder Modify"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "List Filter Pattern"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "List Reduce Pattern"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Sample App"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 3"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 4"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 5"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Wacky Name Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 6"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Traversals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Traversals"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Student Late Spring Pilot Survey Traversals"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Survey (Traversals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Traversals"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Teacher Late Spring Pilot Survey Traversals"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Mini Practice PT"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Mini PT",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U5 Mini Practice PT"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Mini PT"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Pilot U5 Mini PT Project"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Mini PT",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "CSP Pilot U5 Mini PT Project"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Mini PT)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Mini PT"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Mini PT)",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Student Late Spring Pilot Survey Mini PT"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 5 Pilot Mini Assessment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Mini Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 5 Pilot Mini Assessment"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U7 L04 Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Painting"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries Investigate Painting"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries List Math Library"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries List Math Library"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Pig Latin"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries Investigate Pig Latin"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Libraries)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Student Late Spring Pilot Survey Libraries"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Survey (Libraries)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      },
+      "level_keys": [
+        "Teacher Late Spring Pilot Survey Libraries"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-20-21-u5-assess-lists",
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L01 Introduction to Lists",
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Outfitly App",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly App"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Bandly App",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Partnersly App",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly App"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Outfitly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Bandly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Partnersly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Random List Access Pattern",
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Scrolling Pattern",
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 1",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 2",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.75",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 4",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 9",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 6",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 10",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Sample App",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 1",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 2",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 3",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 4",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 5",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 6",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 6"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Student Late Spring Pilot Survey Lists",
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Lists"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teacher Late Spring Pilot Survey Lists",
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Lists"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Lists)",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_2018",
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection_2018",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Coin Flipper",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 7",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 8",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 9",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Loops Investigate and Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_2018",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L09 Traversals Exit Ticket",
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Mile Tracker",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Word Guess - clone",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Word Guess - clone"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Dog Finder - clone",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder - clone"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Mile Tracker Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Get List Explanation Video",
+        "script_level.level_keys": [
+          "U5 Traversals Get List Explanation Video"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Word Guess Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Word Guess Modify"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Dog Finder Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Filter Pattern",
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Reduce Pattern",
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 7",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 8",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Sample App",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 1",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 2",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 3",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 4",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 5",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 6",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Student Late Spring Pilot Survey Traversals",
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Traversals"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teacher Late Spring Pilot Survey Traversals",
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Traversals"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Traversals)",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Mini Practice PT",
+        "script_level.level_keys": [
+          "U5 Mini Practice PT"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Mini PT",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Pilot U5 Mini PT Project",
+        "script_level.level_keys": [
+          "CSP Pilot U5 Mini PT Project"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Mini PT",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Student Late Spring Pilot Survey Mini PT",
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Mini PT"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Mini PT)",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 5 Pilot Mini Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 5 Pilot Mini Assessment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Mini Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 L04 Exit Ticket",
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Investigate Painting",
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Painting"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries List Math Library",
+        "script_level.level_keys": [
+          "U7 Libraries List Math Library"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Investigate Pig Latin",
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Pig Latin"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Student Late Spring Pilot Survey Libraries",
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teacher Late Spring Pilot Survey Libraries",
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp5-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-pilot.script_json
+++ b/dashboard/config/scripts_json/csp5-pilot.script_json
@@ -1,0 +1,4311 @@
+{
+  "script": {
+    "name": "csp5-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit5/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_lists",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Lists"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "csp_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "csp_traversals",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Traversals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "optional_stages",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Optional Stages"
+      },
+      "seeding_key": {
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lists Explore",
+      "name": "Lists Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Lists Investigate",
+      "name": "Lists Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Lists Practice",
+      "name": "Lists Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Lists Make",
+      "name": "Lists Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Loops Explore",
+      "name": "Loops Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Loops Investigate",
+      "name": "Loops Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Loops Practice",
+      "name": "Loops Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Loops Make",
+      "name": "Loops Make",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Traversals Explore",
+      "name": "Traversals Explore",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Traversals Investigate",
+      "name": "Traversals Investigate",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Traversals Practice",
+      "name": "Traversals Practice",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Traversals Make",
+      "name": "Traversals Make",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 1",
+      "name": "Semester Hackathon Part 1",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 2",
+      "name": "Semester Hackathon Part 2",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 3",
+      "name": "Semester Hackathon Part 3",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 4",
+      "name": "Semester Hackathon Part 4",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Semester Hackathon Part 5",
+      "name": "Semester Hackathon Part 5",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Lesson 18: Assessment Day",
+      "name": "Lesson 18: Assessment Day",
+      "absolute_position": 18,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Unit 5 STUDENT Survey",
+      "name": "Unit 5 STUDENT Survey",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "Unit 5 TEACHER Survey",
+      "name": "Unit 5 TEACHER Survey",
+      "absolute_position": 20,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Lists Make",
+      "name": "[OLD] Lists Make",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Loops Make",
+      "name": "[OLD] Loops Make",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Traversals Make",
+      "name": "[OLD] Traversals Make",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L01 Introduction to Lists"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "csp-20-21-u5-assess-lists"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Outfitly Code"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Bandly Code"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Changing Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Investigate Partnersly Code"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Random List Access Pattern"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "List Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "List Scrolling Pattern"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting up Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.75"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 3.5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Accessing Elements in a List"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 10"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice Strings 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice Strings 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 5"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 9"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "List Operations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L03 Lists Practice 6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5L3 CFU Lists Psuedocode"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5L3 CFU Lists Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Sample App 2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project 2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project 2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "csp_applab_loops_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L5 CSP CFU Looping"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U3L5 CSP CFU Looping"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Coin Flipper App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper Predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Coin Flipper Predict"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Coin Flipper App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Coin Flipper"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Font Tester App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Investigate Font Tester"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Investigate Font Tester"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Element Looping"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U3L6 CSP CFU Element Looping"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "For Loop Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops and Screen Elements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Sentence Randomizer"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Sentence Randomizer"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops and Screen Elements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Practice Dice Roller"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Practice Dice Roller"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5L7 CFU Loops Psuedocode"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5L7 CFU Loops Psuedocode 2"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example 2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Example 2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App 2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App 2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Traversal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 L09 Traversals Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Turn on Data Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Full Year Pilot Experiments Dashboard"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "Full Year Pilot Experiments Dashboard"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mile Tracker Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Mile Tracker Modify"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Datasets"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L10 Traversals Investigate"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Dog Finder Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Investigate Dog Finder Modify"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "List Filter Pattern"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Patterns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "List Reduce Pattern"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L10 CFU Traversals"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L10 CFU Traversals"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L11 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice transforming"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice transforming"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversal Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Filter and Reduce Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 6"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Practice Part 7"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5L11 CFU For Each Psuedocode"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5L11 CFU For Each Psuedocode"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Random Forecaster App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Sample App 2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Random Forecaster App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project 2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project 2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L13 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L14 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L15 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 3"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP 20-21"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L16 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 4"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 4"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP 20-21"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L17 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Hackathon Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Hackathon Project Day 5"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L18 SFLP 20-21"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5L18 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 5 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 5 AP-Style Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 5 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 5 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "CSP U5 20-21 Teacher Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Sample App"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 1"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 2"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 3"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 4"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 5"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Reminders App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 6"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Lists Make Project Step 6"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Example"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Step 2"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Step 3"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Step 4"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Step 5"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Lock Screen Maker"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Loops Make Wallpaper App Step 6"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Sample App"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 1"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 3"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 5"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Poem Personalizer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      },
+      "level_keys": [
+        "U5 Traversals Make Project Step 6"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L01 Introduction to Lists",
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-20-21-u5-assess-lists",
+        "script_level.level_keys": [
+          "csp-20-21-u5-assess-lists"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Outfitly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Outfitly Code"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Bandly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Bandly Code"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_2018",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Investigate Partnersly Code",
+        "script_level.level_keys": [
+          "U5 Lists Investigate Partnersly Code"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Random List Access Pattern",
+        "script_level.level_keys": [
+          "Random List Access Pattern"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Scrolling Pattern",
+        "script_level.level_keys": [
+          "List Scrolling Pattern"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 8,
+        "lesson.key": "Lists Investigate",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 1",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 2",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.75",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.75"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 3.5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 3.5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 10",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice Strings 2",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice Strings 3",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice Strings 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 4",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 5",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 5"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 9",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 9"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L03 Lists Practice 6",
+        "script_level.level_keys": [
+          "U5 L03 Lists Practice 6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L3 CFU Lists Psuedocode",
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L3 CFU Lists Psuedocode 2",
+        "script_level.level_keys": [
+          "U5L3 CFU Lists Psuedocode 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Lists Practice",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Sample App 2020",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project 2020",
+        "script_level.level_keys": [
+          "U5 Lists Make Project 2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Lists Make",
+        "lesson_group.key": "csp_lists",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_loops_2018",
+        "script_level.level_keys": [
+          "csp_applab_loops_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L5 CSP CFU Looping",
+        "script_level.level_keys": [
+          "U3L5 CSP CFU Looping"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops Explore",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Coin Flipper Predict",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper Predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Coin Flipper",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Coin Flipper"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Investigate Font Tester",
+        "script_level.level_keys": [
+          "U5 Loops Investigate Font Tester"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L6 CSP CFU Element Looping",
+        "script_level.level_keys": [
+          "U3L6 CSP CFU Element Looping"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops Investigate",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 5"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Loops Practice Part 6"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Sentence Randomizer",
+        "script_level.level_keys": [
+          "U5 Loops Practice Sentence Randomizer"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Practice Dice Roller",
+        "script_level.level_keys": [
+          "U5 Loops Practice Dice Roller"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L7 CFU Loops Psuedocode",
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L7 CFU Loops Psuedocode 2",
+        "script_level.level_keys": [
+          "U5L7 CFU Loops Psuedocode 2"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Loops Practice",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Example 2020",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example 2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App 2020",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App 2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Loops Make",
+        "lesson_group.key": "csp_loops",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_2018",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L09 Traversals Exit Ticket",
+        "script_level.level_keys": [
+          "U5 L09 Traversals Exit Ticket"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Explore",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Full Year Pilot Experiments Dashboard",
+        "script_level.level_keys": [
+          "Full Year Pilot Experiments Dashboard"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Mile Tracker Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 Traversals Investigate",
+        "script_level.level_keys": [
+          "CSP U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Investigate Dog Finder Modify",
+        "script_level.level_keys": [
+          "U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Filter Pattern",
+        "script_level.level_keys": [
+          "List Filter Pattern"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "List Reduce Pattern",
+        "script_level.level_keys": [
+          "List Reduce Pattern"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L10 CFU Traversals",
+        "script_level.level_keys": [
+          "CSP U5L10 CFU Traversals"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Investigate",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L11 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP 20-21"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 1",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 2",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice transforming",
+        "script_level.level_keys": [
+          "U5 Traversals Practice transforming"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 3",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 4",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 5",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 6",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Practice Part 7",
+        "script_level.level_keys": [
+          "U5 Traversals Practice Part 7"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5L11 CFU For Each Psuedocode",
+        "script_level.level_keys": [
+          "U5L11 CFU For Each Psuedocode"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Traversals Practice",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Sample App 2020",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App 2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project 2020",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project 2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Traversals Make",
+        "lesson_group.key": "csp_traversals",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L13 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP 20-21"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L14 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP 20-21"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 2",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L15 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP 20-21"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 3",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 3"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L16 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP 20-21"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 4",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 4"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 4",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L17 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L17 SFLP 20-21"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Hackathon Project Day 5",
+        "script_level.level_keys": [
+          "U5 Hackathon Project Day 5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Semester Hackathon Part 5",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L18 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U5L18 SFLP 20-21"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 5 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 18: Assessment Day",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U5 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U5 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Sample App",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Sample App"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 1",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 1"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 2",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 2"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 3",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 3"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 4",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 4"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 5",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 5"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Lists Make Project Step 6",
+        "script_level.level_keys": [
+          "U5 Lists Make Project Step 6"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Lists Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Example",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Example"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Step 2",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Step 3",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Step 4",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Step 5",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Loops Make Wallpaper App Step 6",
+        "script_level.level_keys": [
+          "U5 Loops Make Wallpaper App Step 6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Loops Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Sample App",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Sample App"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 1",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 2",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 3",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 4",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 5",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 5"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Traversals Make Project Step 6",
+        "script_level.level_keys": [
+          "U5 Traversals Make Project Step 6"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "[OLD] Traversals Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp5-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-support.script_json
+++ b/dashboard/config/scripts_json/csp5-support.script_json
@@ -1,0 +1,1917 @@
+{
+  "script": {
+    "name": "csp5-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "CSP Support",
+      "peer_reviews_to_complete": 4,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 5 Overview",
+      "name": "Unit 5 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Event Driven Programming",
+      "name": "Event Driven Programming",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Variables and Strings",
+      "name": "Variables and Strings",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Conditionals and Boolean Logic",
+      "name": "Conditionals and Boolean Logic",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "While Loops and Introduction to Arrays",
+      "name": "While Loops and Introduction to Arrays",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Processing Arrays and Functions with Return Values",
+      "name": "Processing Arrays and Functions with Return Values",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "What's inside and how is it organized?"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Unit 5"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Introduction to Unit 5"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Philosophy and Commentary"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Concepts and AP Assessments"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Concepts and AP Assessments"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Practice Performance Task in Unit 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Practice Performance Task in Unit 5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.1 - 5.3 Lesson Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "5.1 - 5.3 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design Mode Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Design Mode Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Events Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Events Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Multi-Screen App"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Project Breakdown: Multi-Screen App"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "U5 L1 - 3: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.4 - 5.6 Lesson Connections"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "5.4 - 5.6 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variables Overview"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Variables Overview"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Clicker Game"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Project Breakdown: Clicker Game"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Strings Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Strings Overview"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "U5 L4 - 6: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.7- 5.10 Lesson Connections"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "5.7- 5.10 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Logic and Expression Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Boolean Logic and Expression Overview"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals Overview"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Conditionals Overview"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Color Sleuth"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Project Breakdown: Color Sleuth"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "U5 L7 - 10: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.11 - 5.14 Lesson Connections"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "5.11 - 5.14 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "While Loops Overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "While Loops Overview"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Arrays Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Arrays Overview"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Image Scroller"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Project Breakdown: Image Scroller"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L11 - 14: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "U5 L11 - 14: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "5.15 - 5.17 Lesson Connections"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "5.15 - 5.17 Lesson Connections"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Arrays"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Processing Arrays"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Functions that Return Values"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Functions that Return Values"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project Breakdown: Building a Canvas Painter"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Project Breakdown: Building a Canvas Painter"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L15 - 17: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "U5 L15 - 17: Teaching and Student Support Plan"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Classroom Management Tips for School Computer Labs"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Considerations for the 1-to-1 Classroom"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Designing Assessment Questions"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      },
+      "level_keys": [
+        "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "What's inside and how is it organized?",
+        "script_level.level_keys": [
+          "What's inside and how is it organized?"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Unit 5",
+        "script_level.level_keys": [
+          "Introduction to Unit 5"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Philosophy and Commentary",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Philosophy and Commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Concepts and AP Assessments",
+        "script_level.level_keys": [
+          "Unit 5 Concepts and AP Assessments"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Practice Performance Task in Unit 5",
+        "script_level.level_keys": [
+          "Practice Performance Task in Unit 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Self-Assessment",
+        "script_level.level_keys": [
+          "Unit 5 Self-Assessment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "required",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.1 - 5.3 Lesson Connections",
+        "script_level.level_keys": [
+          "5.1 - 5.3 Lesson Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design Mode Overview",
+        "script_level.level_keys": [
+          "Design Mode Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Events Overview",
+        "script_level.level_keys": [
+          "Events Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Multi-Screen App",
+        "script_level.level_keys": [
+          "Project Breakdown: Multi-Screen App"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L1 - 3: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L1 - 3: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Event Driven Programming",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.4 - 5.6 Lesson Connections",
+        "script_level.level_keys": [
+          "5.4 - 5.6 Lesson Connections"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variables Overview",
+        "script_level.level_keys": [
+          "Variables Overview"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Clicker Game",
+        "script_level.level_keys": [
+          "Project Breakdown: Clicker Game"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Strings Overview",
+        "script_level.level_keys": [
+          "Strings Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L4 - 6: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L4 - 6: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables and Strings",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.7- 5.10 Lesson Connections",
+        "script_level.level_keys": [
+          "5.7- 5.10 Lesson Connections"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Logic and Expression Overview",
+        "script_level.level_keys": [
+          "Boolean Logic and Expression Overview"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals Overview",
+        "script_level.level_keys": [
+          "Conditionals Overview"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Color Sleuth",
+        "script_level.level_keys": [
+          "Project Breakdown: Color Sleuth"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L7 - 10: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L7 - 10: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals and Boolean Logic",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.11 - 5.14 Lesson Connections",
+        "script_level.level_keys": [
+          "5.11 - 5.14 Lesson Connections"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "While Loops Overview",
+        "script_level.level_keys": [
+          "While Loops Overview"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Arrays Overview",
+        "script_level.level_keys": [
+          "Arrays Overview"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Image Scroller",
+        "script_level.level_keys": [
+          "Project Breakdown: Image Scroller"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L11 - 14: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L11 - 14: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "While Loops and Introduction to Arrays",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "5.15 - 5.17 Lesson Connections",
+        "script_level.level_keys": [
+          "5.15 - 5.17 Lesson Connections"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Arrays",
+        "script_level.level_keys": [
+          "Processing Arrays"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Functions that Return Values",
+        "script_level.level_keys": [
+          "Functions that Return Values"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project Breakdown: Building a Canvas Painter",
+        "script_level.level_keys": [
+          "Project Breakdown: Building a Canvas Painter"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L15 - 17: Teaching and Student Support Plan",
+        "script_level.level_keys": [
+          "U5 L15 - 17: Teaching and Student Support Plan"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays and Functions with Return Values",
+        "lesson_group.key": "content",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Management Tips for School Computer Labs",
+        "script_level.level_keys": [
+          "Classroom Management Tips for School Computer Labs"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Considerations for the 1-to-1 Classroom",
+        "script_level.level_keys": [
+          "Considerations for the 1-to-1 Classroom"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Balancing Teacher and Tools"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Discovery Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Discovery Learning"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Designing Assessment Questions",
+        "script_level.level_keys": [
+          "Designing Assessment Questions"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Unit 5 Teaching Practice Plan: Assessing Student Learning",
+        "script_level.level_keys": [
+          "Unit 5 Teaching Practice Plan: Assessing Student Learning"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "csp5-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-virtual-part2.script_json
+++ b/dashboard/config/scripts_json/csp5-virtual-part2.script_json
@@ -1,0 +1,4586 @@
+{
+  "script": {
+    "name": "csp5-virtual-part2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-virtual-part2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp5_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Event-Driven Programming"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "csp5_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Programming with Data Structures"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 5 Assessment 2",
+      "name": "Unit 5 Assessment 2",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Building an App: Image Scroller",
+      "name": "Building an App: Image Scroller",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 3",
+      "name": "Unit 5 Assessment 3",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Building an App: Canvas Painter",
+      "name": "Building an App: Canvas Painter",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 4",
+      "name": "Unit 5 Assessment 4",
+      "absolute_position": 10,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "name": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L11 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 1_virtual"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 2_virtual"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 3_virtual"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Typing in Console_virtual"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 4_virtual"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating Variables in Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 5_virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 8_virtual"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 6_virtual"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 7_virtual"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 9_virtual"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops -  Complex Condition_virtual"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Uses of Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 10_virtual"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 11_virtual"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 12_virtual"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "New Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Plus Plus_virtual"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - Minus Minus_virtual"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - plus and minus = operator_virtual"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - minus = operator_virtual"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 14_virtual"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops Continued"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops - 15_virtual"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L12 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make a Hypothesis"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018_2019_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Make a Hypothesis_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 1_virtual"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2_virtual"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.1_virtual"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Simulations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 2.5_virtual"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018_2019_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 1_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 3_virtual"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 4_virtual"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Simulation Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 5_virtual"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Update your Hypothesis - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Update your Hypothesis - Part 2_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Experiment With Simulation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Simulation - 6_virtual"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L13 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 1_virtual"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - createFirstArray_virtual"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - appendItem_virtual"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 2_virtual"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - introIndex_virtual"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "List Basics"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - indexPractice_virtual"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 3_virtual"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment_virtual"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment2_virtual"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - assignment3_virtual"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - stringsInArrays_virtual"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertingItems_virtual"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - remove_virtual"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating and Assigning Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - insertionErrors_virtual"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists - Part 4"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Introduction to Lists - Part 4_virtual"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - length_virtual"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - lengthMinus1_virtual"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+        "progression": "Length and Indexes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - expressionsAsIndexes_virtual"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+        "progression": "\"My Favorite Things\" Demo App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Demo App_virtual"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings giveIDs_virtual"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings createArray_virtual"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings firstOutput_virtual"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Counting Variable_virtual"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Next_virtual"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings Prev_virtual"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 27,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings addItem_virtual"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 28,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings bounds_virtual"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 29,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - favThings keepPlaying_virtual"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 30,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 1_virtual"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 31,
+      "assessment": null,
+      "properties": {
+        "progression": "Array Reflection Questions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Arrays - Wrap Up 2_virtual"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L14 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Demo App_virtual"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - drag out key event_virtual"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Key Up and Down_virtual"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3L25 - play sound when up key_virtual"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Multiple Keys_virtual"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Key Event"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Buttons and Keys_virtual"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Functions_virtual"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Images Using URLs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Keys - Add Image URLs_virtual"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Image Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Project - Final Image Scroller_virtual"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "My Favorite Things Reflection Question"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3- Keys - Code Refactoring Exit Ticket_virtual"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L15 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Processing Lists with Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Processing Lists with Loops_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Processing Lists with Loops_virtual"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to for Loops"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Intro For Loop_virtual"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Printing an Array"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Print Array_virtual"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Add 5_virtual"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Math and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Divid by 2_virtual"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Loop Array If_virtual"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Linear Search_virtual"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Counting Times_virtual"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Printing Single True_virtual"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Booleans, if Statements, and Arrays"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_virtual"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function_virtual"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list pa_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Make it a Function - add list pa_virtual"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - General Search Param_virtual"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Arrays and Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Loops And Arrays - Find Min_virtual"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP U5L16 SFLP_virtual"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "The Return Command"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018_2019_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "Using Output from Functions: The return Command_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using minVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - useMinVal_virtual"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - writeMaxVal_virtual"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingMaxVal_virtual"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Writing and Debugging maxVal"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - debuggingConstrain_virtual"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - constrainTurtle_virtual"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Return Values in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Return Values - wrapTurtle_virtual"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - introCanvas_virtual"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - 200dots_virtual"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Canvas Painter Introduction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - transparentDots_virtual"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - clickToAdd_virtual"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - usingOffsetXY_virtual"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - draw at click point_virtual"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - changeToMouseMove_virtual"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events in Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - shiftKey_virtual"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Storing Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - appendToArray_virtual"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - delete_virtual"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom_virtual"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_virtual"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawRandom2_virtual"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_virtual"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - redrawOriginal_virtual"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_virtual"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction_virtual"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_virtual"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - movementFunction fix Orig_virtual"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_virtual"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - One Dot sprayPaint_virtual"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding More Features to Your App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_virtual"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sprayPaint_virtual"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Stored Information"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_virtual"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - sketch_virtual"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+        "progression": "Project: Canvas Painter"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_virtual"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Canvas - freePlay_virtual"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018_2019_virtual"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      },
+      "level_keys": [
+        "CSP Cumulative Assess A_2018_2019_virtual"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019_virtual",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 2 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 2",
+        "lesson_group.key": "csp5_1",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L11 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L11 SFLP_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 1_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 1_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 2_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 3_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 3_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Typing in Console_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Typing in Console_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 4_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 4_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 5_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 5_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 8_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 8_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 6_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 6_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 7_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 7_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 9_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 9_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops -  Complex Condition_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops -  Complex Condition_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 10_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 10_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 11_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 11_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 12_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 12_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Plus Plus_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Plus Plus_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - Minus Minus_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - Minus Minus_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - plus and minus = operator_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - plus and minus = operator_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - minus = operator_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - minus = operator_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 14_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 14_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops - 15_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops - 15_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019_virtual",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-7-levelgroup-U5Ch2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L12 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L12 SFLP_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Make a Hypothesis_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Make a Hypothesis_2018_2019_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 1_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 1_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.1_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.1_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 2.5_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 2.5_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 1_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 1_2018_2019_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 3_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 3_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 4_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 4_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 5_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 5_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Update your Hypothesis - Part 2_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Update your Hypothesis - Part 2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Simulation - 6_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Simulation - 6_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L13 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L13 SFLP_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 1_virtual",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 1_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - createFirstArray_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - createFirstArray_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - appendItem_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - appendItem_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 2_virtual",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 2_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - introIndex_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - introIndex_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - indexPractice_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - indexPractice_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 3_virtual",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 3_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment2_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - assignment3_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - assignment3_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - stringsInArrays_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - stringsInArrays_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertingItems_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertingItems_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - remove_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - remove_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - insertionErrors_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - insertionErrors_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Lists - Part 4_virtual",
+        "script_level.level_keys": [
+          "Introduction to Lists - Part 4_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - length_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - length_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - lengthMinus1_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - lengthMinus1_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - expressionsAsIndexes_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - expressionsAsIndexes_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Demo App_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Demo App_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings giveIDs_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings giveIDs_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings createArray_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings createArray_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings firstOutput_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings firstOutput_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Counting Variable_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Counting Variable_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Next_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Next_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings Prev_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings Prev_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings addItem_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings addItem_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings bounds_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings bounds_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 28,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - favThings keepPlaying_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - favThings keepPlaying_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 29,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 1_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 1_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 30,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Arrays - Wrap Up 2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Arrays - Wrap Up 2_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 31,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L14 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L14 SFLP_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Demo App_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Demo App_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - drag out key event_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - drag out key event_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Key Up and Down_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Key Up and Down_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L25 - play sound when up key_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L25 - play sound when up key_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Multiple Keys_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Multiple Keys_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Buttons and Keys_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Buttons and Keys_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Functions_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Functions_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Keys - Add Image URLs_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Keys - Add Image URLs_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project - Final Image Scroller_virtual",
+        "script_level.level_keys": [
+          "Project - Final Image Scroller_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Keys - Code Refactoring Exit Ticket_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3- Keys - Code Refactoring Exit Ticket_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Image Scroller",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019_virtual",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 3 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 3",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L15 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L15 SFLP_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Processing Lists with Loops_virtual",
+        "script_level.level_keys": [
+          "Processing Lists with Loops_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Intro For Loop_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Intro For Loop_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Print Array_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Print Array_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Add 5_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Add 5_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Divid by 2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Divid by 2_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Loop Array If_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Loop Array If_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Linear Search_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Linear Search_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Counting Times_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Counting Times_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Printing Single True_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Printing Single True_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Search with Boolean Var_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Make it a Function - add list pa_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Make it a Function - add list pa_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - General Search Param_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - General Search Param_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Loops And Arrays - Find Min_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Loops And Arrays - Find Min_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 15,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L16 SFLP_virtual",
+        "script_level.level_keys": [
+          "CSP U5L16 SFLP_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Using Output from Functions: The return Command_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Using Output from Functions: The return Command_2018_2019_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - useMinVal_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - useMinVal_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - writeMaxVal_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - writeMaxVal_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingMaxVal_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingMaxVal_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - debuggingConstrain_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - debuggingConstrain_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - constrainTurtle_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - constrainTurtle_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Return Values - wrapTurtle_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Return Values - wrapTurtle_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - introCanvas_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - introCanvas_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - 200dots_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - 200dots_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - transparentDots_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - transparentDots_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - clickToAdd_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - clickToAdd_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - usingOffsetXY_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - usingOffsetXY_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - draw at click point_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - draw at click point_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - changeToMouseMove_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - changeToMouseMove_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - shiftKey_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - shiftKey_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - appendToArray_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - appendToArray_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - delete_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - delete_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawRandom2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawRandom2_virtual"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - redrawOriginal_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - redrawOriginal_virtual"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction_virtual"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - movementFunction fix Orig_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - movementFunction fix Orig_virtual"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - One Dot sprayPaint_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - One Dot sprayPaint_virtual"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sprayPaint_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sprayPaint_virtual"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - sketch_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - sketch_virtual"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Canvas - freePlay_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Canvas - freePlay_virtual"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 19,
+        "lesson.key": "Building an App: Canvas Painter",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019_virtual",
+        "script_level.level_keys": [
+          "CSP Unit 5 Cumulative Assessment 4 MC_2018_2019_virtual"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 4",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Cumulative Assess A_2018_2019_virtual",
+        "script_level.level_keys": [
+          "CSP Cumulative Assess A_2018_2019_virtual"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Assessment 5 - AP Pseudocode Practice Questions",
+        "lesson_group.key": "csp5_2",
+        "script.name": "csp5-virtual-part2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp5-virtual.script_json
+++ b/dashboard/config/scripts_json/csp5-virtual.script_json
@@ -1,0 +1,4833 @@
+{
+  "script": {
+    "name": "csp5-virtual",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp5-virtual"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to App Lab",
+      "name": "Intro to App Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Buttons and Events",
+      "name": "Buttons and Events",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Multi-screen Apps",
+      "name": "Multi-screen Apps",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Building an App: Clicker Game",
+      "name": "Building an App: Clicker Game",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "If-Statements",
+      "name": "If-Statements",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "User Input and Strings",
+      "name": "User Input and Strings",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Boolean Expressions and \"If\" Statements",
+      "name": "Boolean Expressions and \"If\" Statements",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "\"if-else-if\" and Conditional Logic",
+      "name": "\"if-else-if\" and Conditional Logic",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Building an App: Color Sleuth",
+      "name": "Building an App: Color Sleuth",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "key": "Keep Going!",
+      "name": "Keep Going!",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Keep Going!",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Setting Properties"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make it Interactive"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Images and Sounds"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual12"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual13"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Design Mode"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual15"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_HOC_virtual15"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_video_new_debugging_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_video_new_debugging_virtual"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_predict_applab_onEventWithWrongID_virtual"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to _virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_Debugging predict unexpected behavior - two onEvents to _virtual"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging IDs case sensitive_virtual"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Debugging and Common Problems"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L13 - Debugging 3_virtual"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How setPosition and screen dimensions work_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_setPosition to fixed location_virtual"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How setPosition and Screen Dimensions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - setPosition to move button_virtual"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Labels"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_AddLabelToChaserGame_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Event Types"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_playWithEventTypes_virtual"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "How Images Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Images Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How Images Work_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Chaser Game v.1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Finalize Your Chaser Game v.1_virtual"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 First Time Console.log_virtual"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 console.log in event v. global_virtual"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 console.log debug when mouse events happen_virtual"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 Debugging Overlapping Objects and Screen Events_virtual"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with Console.log"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018_2019_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Debugging with Console.log_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018_2019_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Tips For Working on Your Own_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Making a Multi Screen Chaser Game v.2_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 Add welcome screen to chaser game_virtual"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Multi-Screen Chaser Game v.2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 Add full screen image to bg of chaser game_virtual"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Multi-Screen Chaser Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 Add game over screen_virtual"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 1_virtual"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - three basic ops of variables_virtual"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - fix the var name syntax error v2_virtual"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - write var and string with same name v2_virtual"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Create And Assign_virtual"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Basic Mechanics of Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3- Variables - Text Mode_virtual"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression_virtual"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - concatenate simple_virtual"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple2_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - concatenate simple2_virtual"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Variables - Set to Expression with Other Variables_virtual"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Assigning Random Value_virtual"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Mini Calculator embed_virtual"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - User Input Division calculator_virtual"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Other Ways to Assign Values to Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - test reassignment of two vars_virtual"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Variables - Part 2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Variables - Part 2_virtual"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018_2019_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "The Mental Model for Variables_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 17,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L14 - Variable ReAssignment pt2_virtual"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "The Mental Model for Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 18,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L19 - variable reassignment challenge pt2_virtual"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Clicker Game Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 full clicker demo_virtual"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - practice with setText_virtual"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - DEMO up down count practice app_virtual"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - global var example count up_virtual"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AppLab Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - variable scoping problem debugging_virtual"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018_2019_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Variable Scope: Local vs. Global_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - add code to make count down work_virtual"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug forget to set text_virtual"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - count upDown bug logic error wrong update_virtual"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - mini clicker update score_virtual"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 click add lives_virtual"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018_2019_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Simple Decisions with if-statements_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Simple If-statements in UpDown App_virtual"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Add reset button to UpDown app_virtual"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debugging Simple If-statements =v==_virtual"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Simple Decisions with if-statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown ap_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L15 - Debug forget to update var on reset in UpDown ap_virtual"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Demonstration"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Demo_virtual"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - introStrings_virtual"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - doubleQuotes_virtual"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - textInput getText write_virtual"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - intro getText_virtual"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - User Input - Save getText To Variable_virtual"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Strings in Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 - outputWithTextArea_virtual"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Student Setup_virtual"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib setText_virtual"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib getText_virtual"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mad Lib Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L16 Mad Lib Clear Input_virtual"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Boolean Expressions_virtual"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean Expressions and Comparison Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018_2019_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Boolean Expressions and Comparison Operators_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Comparison Operators Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3L18 comparison operators_virtual"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if Statements_virtual"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018_2019_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How If Statements Work pt 1_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_basic if - check driving age_virtual"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_basic if - DIY secret number_virtual"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 Check Password if statement lock image_virtual"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else Statements_virtual"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How If-Else Statements Work_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 if-else simple movie ratings example_virtual"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_basic if-else - driving age_virtual"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "if-else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 Check Password if-else string_virtual"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How Dropdown Menus Work_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 if-else dropdown movie checker_virtual"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Dropdown Menus"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 if-else dropdown guess dice_virtual"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: if-else-if Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: if-else-if Statements_virtual"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018_2019_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How \"if-else-if\" Works_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 if-else-if movie example_virtual"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 if-else-if quiz grade_virtual"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Else if_virtual"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How \"if-else-if\" Works"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - High Low - Debug_virtual"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Conditionals: Compound Boolean Expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Introduction to Conditionals: Compound Boolean Expressions_virtual"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple OR_virtual"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "How the Boolean &&, || and ! Operators Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Simple AND_virtual"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR Simple_virtual"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 compound boolean museum example_virtual"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "How Compound Boolean Expressions Work"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5_U3 - Conditionals - Combine AND OR and NOT_virtual"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Color Sleuth - Demo and Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPU5 Color Sleuth Demo_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSPU5 Color Sleuth Demo_virtual"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "RGB Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP5 virtual RGB intro_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "CSP5 virtual RGB intro_virtual"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Specifying Colors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "How Set Property Works_2018_2019_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "How Set Property Works_2018_2019_virtual"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_virtual"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 1_virtual"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using setProperty"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_virtual"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 2 small color change_virtual"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Pick a Random Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_virtual"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 3 pick random button_virtual"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Random Color"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_virtual"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 4 make random RGB string_virtual"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_applab_functions_virtual"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "csp_applab_functions_virtual"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_virtual"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth part 5 make setBoard function_virtual"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions in Your Color Sleuth App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_virtual"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth add global var correct plus console.log_virtual"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_virtual"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect make global var_virtual"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_virtual"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part1 link to event handlers_virtual"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Activating Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check co_virtual"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth checkCorrect part2 add if statement to check co_virtual"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.l_virtual"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt1 add var and function and console.l_virtual"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Switch Player Turns"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_virtual"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_virtual"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_virtual"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt1 vars function stub console_virtual"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Updating the Score"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_virtual"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "U5 ColorSleuth scoring pt3 update UI for scoring_virtual"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Project: Color Sleuth"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_virtual"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "Project: Finish Color Sleuth_virtual"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5 virtual bubblechoice"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "Keep Going!",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "csp5 virtual bubblechoice"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp5 virtual ending"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 2,
+        "lesson.key": "Keep Going!",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      },
+      "level_keys": [
+        "csp5 virtual ending"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual1",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual2",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual3",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual4",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual5",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual6",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual7",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual8",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual9",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual10",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual11",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual12",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual13",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_HOC_virtual15",
+        "script_level.level_keys": [
+          "CSPU5_HOC_virtual15"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Intro to App Lab",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_video_new_debugging_virtual",
+        "script_level.level_keys": [
+          "CSPU5_video_new_debugging_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_predict_applab_onEventWithWrongID_virtual",
+        "script_level.level_keys": [
+          "CSPU5_predict_applab_onEventWithWrongID_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_Debugging predict unexpected behavior - two onEvents to _virtual",
+        "script_level.level_keys": [
+          "CSPU5_Debugging predict unexpected behavior - two onEvents to _virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging IDs case sensitive_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging IDs case sensitive_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L13 - Debugging 3_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L13 - Debugging 3_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How setPosition and screen dimensions work_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How setPosition and screen dimensions work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_setPosition to fixed location_virtual",
+        "script_level.level_keys": [
+          "CSPU5_setPosition to fixed location_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - setPosition to move button_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - setPosition to move button_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_AddLabelToChaserGame_virtual",
+        "script_level.level_keys": [
+          "CSPU5_AddLabelToChaserGame_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_playWithEventTypes_virtual",
+        "script_level.level_keys": [
+          "CSPU5_playWithEventTypes_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Images Work_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How Images Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Finalize Your Chaser Game v.1_virtual",
+        "script_level.level_keys": [
+          "Finalize Your Chaser Game v.1_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 First Time Console.log_virtual",
+        "script_level.level_keys": [
+          "CSPU5 First Time Console.log_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log in event v. global_virtual",
+        "script_level.level_keys": [
+          "CSPU5 console.log in event v. global_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 console.log debug when mouse events happen_virtual",
+        "script_level.level_keys": [
+          "CSPU5 console.log debug when mouse events happen_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Debugging Overlapping Objects and Screen Events_virtual",
+        "script_level.level_keys": [
+          "CSPU5 Debugging Overlapping Objects and Screen Events_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging with Console.log_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Debugging with Console.log_2018_2019_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tips For Working on Your Own_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Tips For Working on Your Own_2018_2019_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Multi Screen Chaser Game v.2_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Making a Multi Screen Chaser Game v.2_2018_2019_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add welcome screen to chaser game_virtual",
+        "script_level.level_keys": [
+          "CSPU5 Add welcome screen to chaser game_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add full screen image to bg of chaser game_virtual",
+        "script_level.level_keys": [
+          "CSPU5 Add full screen image to bg of chaser game_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Add game over screen_virtual",
+        "script_level.level_keys": [
+          "CSPU5 Add game over screen_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 1_virtual",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 1_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - three basic ops of variables_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - three basic ops of variables_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - fix the var name syntax error v2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - fix the var name syntax error v2_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - write var and string with same name v2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - write var and string with same name v2_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Create And Assign_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Create And Assign_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3- Variables - Text Mode_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3- Variables - Text Mode_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - concatenate simple_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - concatenate simple2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - concatenate simple2_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Variables - Set to Expression with Other Variables_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Variables - Set to Expression with Other Variables_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Assigning Random Value_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Assigning Random Value_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Mini Calculator embed_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Mini Calculator embed_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - User Input Division calculator_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - User Input Division calculator_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - test reassignment of two vars_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - test reassignment of two vars_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 14,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Variables - Part 2_virtual",
+        "script_level.level_keys": [
+          "Introduction to Variables - Part 2_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 15,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Mental Model for Variables_2018_2019_virtual",
+        "script_level.level_keys": [
+          "The Mental Model for Variables_2018_2019_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 16,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L14 - Variable ReAssignment pt2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L14 - Variable ReAssignment pt2_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 17,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L19 - variable reassignment challenge pt2_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L19 - variable reassignment challenge pt2_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 18,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 full clicker demo_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 full clicker demo_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - practice with setText_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - practice with setText_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - DEMO up down count practice app_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - DEMO up down count practice app_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - global var example count up_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - global var example count up_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - variable scoping problem debugging_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - variable scoping problem debugging_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Variable Scope: Local vs. Global_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Variable Scope: Local vs. Global_2018_2019_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - add code to make count down work_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - add code to make count down work_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug forget to set text_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug forget to set text_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - count upDown bug logic error wrong update_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - count upDown bug logic error wrong update_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - mini clicker update score_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - mini clicker update score_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 click add lives_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 click add lives_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Clicker Game",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Simple Decisions with if-statements_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Simple Decisions with if-statements_2018_2019_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Simple If-statements in UpDown App_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Simple If-statements in UpDown App_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Add reset button to UpDown app_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Add reset button to UpDown app_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debugging Simple If-statements =v==_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debugging Simple If-statements =v==_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L15 - Debug forget to update var on reset in UpDown ap_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L15 - Debug forget to update var on reset in UpDown ap_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "If-Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Demo_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Demo_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - introStrings_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - introStrings_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - doubleQuotes_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - doubleQuotes_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - textInput getText write_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - textInput getText write_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - intro getText_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - intro getText_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - User Input - Save getText To Variable_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - User Input - Save getText To Variable_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 - outputWithTextArea_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 - outputWithTextArea_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Student Setup_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Student Setup_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib setText_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib setText_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib getText_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib getText_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L16 Mad Lib Clear Input_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L16 Mad Lib Clear Input_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Boolean Expressions_virtual",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Boolean Expressions_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Boolean Expressions and Comparison Operators_2018_2019_virtual",
+        "script_level.level_keys": [
+          "Boolean Expressions and Comparison Operators_2018_2019_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3L18 comparison operators_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3L18 comparison operators_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if Statements_virtual",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if Statements_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If Statements Work pt 1_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How If Statements Work pt 1_2018_2019_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - check driving age_virtual",
+        "script_level.level_keys": [
+          "CSPU5_basic if - check driving age_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if - DIY secret number_virtual",
+        "script_level.level_keys": [
+          "CSPU5_basic if - DIY secret number_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if statement lock image_virtual",
+        "script_level.level_keys": [
+          "U5 Check Password if statement lock image_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else Statements_virtual",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else Statements_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How If-Else Statements Work_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How If-Else Statements Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else simple movie ratings example_virtual",
+        "script_level.level_keys": [
+          "U5 if-else simple movie ratings example_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_basic if-else - driving age_virtual",
+        "script_level.level_keys": [
+          "CSPU5_basic if-else - driving age_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 Check Password if-else string_virtual",
+        "script_level.level_keys": [
+          "U5 Check Password if-else string_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 13,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Dropdown Menus Work_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How Dropdown Menus Work_2018_2019_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 14,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown movie checker_virtual",
+        "script_level.level_keys": [
+          "U5 if-else dropdown movie checker_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 15,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else dropdown guess dice_virtual",
+        "script_level.level_keys": [
+          "U5 if-else dropdown guess dice_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 16,
+        "lesson.key": "Boolean Expressions and \"If\" Statements",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: if-else-if Statements_virtual",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: if-else-if Statements_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How \"if-else-if\" Works_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How \"if-else-if\" Works_2018_2019_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if movie example_virtual",
+        "script_level.level_keys": [
+          "U5 if-else-if movie example_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 if-else-if quiz grade_virtual",
+        "script_level.level_keys": [
+          "U5 if-else-if quiz grade_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Else if_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Else if_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - High Low - Debug_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - High Low - Debug_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Introduction to Conditionals: Compound Boolean Expressions_virtual",
+        "script_level.level_keys": [
+          "Introduction to Conditionals: Compound Boolean Expressions_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple OR_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple OR_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Simple AND_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Simple AND_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR Simple_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR Simple_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 compound boolean museum example_virtual",
+        "script_level.level_keys": [
+          "U5 compound boolean museum example_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5_U3 - Conditionals - Combine AND OR and NOT_virtual",
+        "script_level.level_keys": [
+          "CSPU5_U3 - Conditionals - Combine AND OR and NOT_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "\"if-else-if\" and Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPU5 Color Sleuth Demo_virtual",
+        "script_level.level_keys": [
+          "CSPU5 Color Sleuth Demo_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP5 virtual RGB intro_virtual",
+        "script_level.level_keys": [
+          "CSP5 virtual RGB intro_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "How Set Property Works_2018_2019_virtual",
+        "script_level.level_keys": [
+          "How Set Property Works_2018_2019_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 1_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 1_virtual"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 2 small color change_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 2 small color change_virtual"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 3 pick random button_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 3 pick random button_virtual"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 4 make random RGB string_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 4 make random RGB string_virtual"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_applab_functions_virtual",
+        "script_level.level_keys": [
+          "csp_applab_functions_virtual"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth part 5 make setBoard function_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth part 5 make setBoard function_virtual"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth add global var correct plus console.log_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth add global var correct plus console.log_virtual"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect make global var_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect make global var_virtual"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part1 link to event handlers_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part1 link to event handlers_virtual"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth checkCorrect part2 add if statement to check co_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth checkCorrect part2 add if statement to check co_virtual"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt1 add var and function and console.l_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt1 add var and function and console.l_virtual"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth nextTurn pt2 update UI to indicate turn_virtual"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt1 vars function stub console_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt1 vars function stub console_virtual"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 16,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 ColorSleuth scoring pt3 update UI for scoring_virtual",
+        "script_level.level_keys": [
+          "U5 ColorSleuth scoring pt3 update UI for scoring_virtual"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 17,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Project: Finish Color Sleuth_virtual",
+        "script_level.level_keys": [
+          "Project: Finish Color Sleuth_virtual"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 18,
+        "lesson.key": "Building an App: Color Sleuth",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5 virtual bubblechoice",
+        "script_level.level_keys": [
+          "csp5 virtual bubblechoice"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 1,
+        "lesson.key": "Keep Going!",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp5 virtual ending",
+        "script_level.level_keys": [
+          "csp5 virtual ending"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 2,
+        "lesson.key": "Keep Going!",
+        "lesson_group.key": "",
+        "script.name": "csp5-virtual"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp6-2020.script_json
+++ b/dashboard/config/scripts_json/csp6-2020.script_json
@@ -1,0 +1,830 @@
+{
+  "script": {
+    "name": "csp6-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit6/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit6/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp6-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_unit6_2020",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 6: Algorithms"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms Solve Problems",
+      "name": "Algorithms Solve Problems",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "key": "Algorithm Efficiency",
+      "name": "Algorithm Efficiency",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "key": "Unreasonable Time",
+      "name": "Unreasonable Time",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "key": "The Limits of Algorithms",
+      "name": "The Limits of Algorithms",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "key": "Parallel and Distributed Algorithms",
+      "name": "Parallel and Distributed Algorithms",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "key": "Lesson 6: Assessment Day",
+      "name": "Lesson 6: Assessment Day",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L01 Algorithms vs Problems"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6 L01 Algorithms vs Problems"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Ticket Generator"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L2 Ticket Generator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L2 Ticket Generator"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L2 CFU Binary Search Steps"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6L2 CFU Binary Search Steps"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L2 CFU Efficiency and Algorithms"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6L2 CFU Efficiency and Algorithms"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L3 CFU Reasonable vs Unreasonable"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6L3 CFU Reasonable vs Unreasonable"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L03 Evaluate Reasonable or Not"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6 L03 Evaluate Reasonable or Not"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Traveling Salesman"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 Traveling Salesman"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L4 Traveling Salesman"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Traveling Salesman - Random Nodes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 Random Traveling Salesman"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L4 Random Traveling Salesman"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L4 CFU Reason for Heuristics"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6L4 CFU Reason for Heuristics"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L04 Unreasonable vs Undecidable"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6 L04 Unreasonable vs Undecidable"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L5 CFU Calculate Speedup"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6L5 CFU Calculate Speedup"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L05 Speedup Forever"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "U6 L05 Speedup Forever"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP U6L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 6 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 6 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      },
+      "level_keys": [
+        "CSP Unit 6 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L01 Algorithms vs Problems",
+        "script_level.level_keys": [
+          "U6 L01 Algorithms vs Problems"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L2 Ticket Generator",
+        "script_level.level_keys": [
+          "CSP U6L2 Ticket Generator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L2 CFU Binary Search Steps",
+        "script_level.level_keys": [
+          "U6L2 CFU Binary Search Steps"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L2 CFU Efficiency and Algorithms",
+        "script_level.level_keys": [
+          "U6L2 CFU Efficiency and Algorithms"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L3 CFU Reasonable vs Unreasonable",
+        "script_level.level_keys": [
+          "U6L3 CFU Reasonable vs Unreasonable"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L03 Evaluate Reasonable or Not",
+        "script_level.level_keys": [
+          "U6 L03 Evaluate Reasonable or Not"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 Traveling Salesman",
+        "script_level.level_keys": [
+          "CSP U6L4 Traveling Salesman"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 Random Traveling Salesman",
+        "script_level.level_keys": [
+          "CSP U6L4 Random Traveling Salesman"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L4 CFU Reason for Heuristics",
+        "script_level.level_keys": [
+          "U6L4 CFU Reason for Heuristics"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L04 Unreasonable vs Undecidable",
+        "script_level.level_keys": [
+          "U6 L04 Unreasonable vs Undecidable"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L5 CFU Calculate Speedup",
+        "script_level.level_keys": [
+          "U6L5 CFU Calculate Speedup"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L05 Speedup Forever",
+        "script_level.level_keys": [
+          "U6 L05 Speedup Forever"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 6 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 6 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "csp_unit6_2020",
+        "script.name": "csp6-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp6-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp6-pilot-staging.script_json
@@ -1,0 +1,3613 @@
+{
+  "script": {
+    "name": "csp6-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp6-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp6-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp6-pilot.script_json
+++ b/dashboard/config/scripts_json/csp6-pilot.script_json
@@ -1,0 +1,921 @@
+{
+  "script": {
+    "name": "csp6-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit6/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp6-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms Solve Problems",
+      "name": "Algorithms Solve Problems",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Algorithm Efficiency",
+      "name": "Algorithm Efficiency",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Unreasonable Time",
+      "name": "Unreasonable Time",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "The Limits of Algorithms",
+      "name": "The Limits of Algorithms",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Parallel and Distributed Algorithms",
+      "name": "Parallel and Distributed Algorithms",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Lesson 6: Assessment Day",
+      "name": "Lesson 6: Assessment Day",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Unit 6 STUDENT Survey",
+      "name": "Unit 6 STUDENT Survey",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "key": "Unit 6 TEACHER Survey",
+      "name": "Unit 6 TEACHER Survey",
+      "absolute_position": 8,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L01 Algorithms vs Problems"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6 L01 Algorithms vs Problems"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Ticket Generator"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L2 Ticket Generator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L2 Ticket Generator"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L2 CFU Binary Search Steps"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6L2 CFU Binary Search Steps"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L2 CFU Efficiency and Algorithms"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6L2 CFU Efficiency and Algorithms"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L3 CFU Reasonable vs Unreasonable"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6L3 CFU Reasonable vs Unreasonable"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L03 Evaluate Reasonable or Not"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6 L03 Evaluate Reasonable or Not"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Traveling Salesman"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 Traveling Salesman"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L4 Traveling Salesman"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Widget: Traveling Salesman - Random Nodes"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L4 Random Traveling Salesman"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L4 Random Traveling Salesman"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L4 CFU Reason for Heuristics"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6L4 CFU Reason for Heuristics"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L04 Unreasonable vs Undecidable"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6 L04 Unreasonable vs Undecidable"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6L5 CFU Calculate Speedup"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6L5 CFU Calculate Speedup"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 L05 Speedup Forever"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "U6 L05 Speedup Forever"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 6 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 6 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 6 AP-Style Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 6 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 6 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U6 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      },
+      "level_keys": [
+        "CSP U6 20-21 Teacher Pilot Survey"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L01 Algorithms vs Problems",
+        "script_level.level_keys": [
+          "U6 L01 Algorithms vs Problems"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Solve Problems",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L2 Ticket Generator",
+        "script_level.level_keys": [
+          "CSP U6L2 Ticket Generator"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L2 CFU Binary Search Steps",
+        "script_level.level_keys": [
+          "U6L2 CFU Binary Search Steps"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L2 CFU Efficiency and Algorithms",
+        "script_level.level_keys": [
+          "U6L2 CFU Efficiency and Algorithms"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Algorithm Efficiency",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L3 CFU Reasonable vs Unreasonable",
+        "script_level.level_keys": [
+          "U6L3 CFU Reasonable vs Unreasonable"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L03 Evaluate Reasonable or Not",
+        "script_level.level_keys": [
+          "U6 L03 Evaluate Reasonable or Not"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Unreasonable Time",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 Traveling Salesman",
+        "script_level.level_keys": [
+          "CSP U6L4 Traveling Salesman"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L4 Random Traveling Salesman",
+        "script_level.level_keys": [
+          "CSP U6L4 Random Traveling Salesman"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L4 CFU Reason for Heuristics",
+        "script_level.level_keys": [
+          "U6L4 CFU Reason for Heuristics"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L04 Unreasonable vs Undecidable",
+        "script_level.level_keys": [
+          "U6 L04 Unreasonable vs Undecidable"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "The Limits of Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6L5 CFU Calculate Speedup",
+        "script_level.level_keys": [
+          "U6L5 CFU Calculate Speedup"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 L05 Speedup Forever",
+        "script_level.level_keys": [
+          "U6 L05 Speedup Forever"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Parallel and Distributed Algorithms",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U6L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 6 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 6 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 6: Assessment Day",
+        "lesson_group.key": "content",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U6 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U6 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U6 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp6-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp6-support.script_json
+++ b/dashboard/config/scripts_json/csp6-support.script_json
@@ -1,0 +1,28 @@
+{
+  "script": {
+    "name": "csp6-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "CSP Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp6-support"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/csp6.script_json
+++ b/dashboard/config/scripts_json/csp6.script_json
@@ -1,0 +1,438 @@
+{
+  "script": {
+    "name": "csp6",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp6"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+      "name": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Create PT Prep - Reviewing the Task",
+      "name": "Create PT Prep - Reviewing the Task",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Create PT Prep - Making a Plan",
+      "name": "Create PT Prep - Making a Plan",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Explore PT Prep - Reviewing the Task",
+      "name": "Explore PT Prep - Reviewing the Task",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Explore PT - Making a Plan",
+      "name": "Explore PT - Making a Plan",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Explore PT - Complete the Task",
+      "name": "Explore PT - Complete the Task",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "key": "Participate in a longitudinal study!",
+      "name": "Participate in a longitudinal study!",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Participate in a longitudinal study!",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 AP Performance Task Tech Setup - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 AP Performance Task Tech Setup - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 AP Performance Task Tech Setup - Student Links"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Create PT Review - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Create PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Create PT - Make a Plan - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Create PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Create PT - Complete the Task - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Create PT - Complete the Task - Student Links"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Explore PT Review - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Explore PT Review - Student Links"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Explore PT - Make a Plan - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Explore PT - Make a Plan - Student Links"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "U6 Explore PT - Complete the Task - Student Links"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "U6 Explore PT - Complete the Task - Student Links"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click Here!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Participate in a longitudinal study!",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U6 AP Performance Task Tech Setup - Student Links",
+        "script_level.level_keys": [
+          "U6 AP Performance Task Tech Setup - Student Links"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Tech Setup - Your AP Digital Portfolio and Other Tools",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT Review - Student Links"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Create PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Create PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT Review - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT Review - Student Links"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep - Reviewing the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Make a Plan - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Make a Plan - Student Links"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Making a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 Explore PT - Complete the Task - Student Links",
+        "script_level.level_keys": [
+          "U6 Explore PT - Complete the Task - Student Links"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Participate in a longitudinal study!",
+        "lesson_group.key": "",
+        "script.name": "csp6"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp7-2020.script_json
+++ b/dashboard/config/scripts_json/csp7-2020.script_json
@@ -1,0 +1,1668 @@
+{
+  "script": {
+    "name": "csp7-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit7/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit7/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp7-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_parameters_return_values",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Parameters and Return Values"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "csp_libraries",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Libraries"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Parameters and Return Explore",
+      "name": "Parameters and Return Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Parameters and Return Investigate",
+      "name": "Parameters and Return Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Parameters and Return Practice",
+      "name": "Parameters and Return Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Parameters and Return Make",
+      "name": "Parameters and Return Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Libraries Explore",
+      "name": "Libraries Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Libraries Investigate",
+      "name": "Libraries Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Libraries Practice",
+      "name": "Libraries Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 1",
+      "name": "Project - Make a Library Part 1",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 2",
+      "name": "Project - Make a Library Part 2",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 3",
+      "name": "Project - Make a Library Part 3",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "key": "Lesson 11: Assessment Day",
+      "name": "Lesson 11: Assessment Day",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L1 CFU Return"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7L1 CFU Return"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Rock"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Investigate Poetry App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Investigate Poetry App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L2 CSP CFU Param and Return"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7L2 CSP CFU Param and Return"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Investigate Calculator App"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Practice App 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "MOD Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice MOD"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Practice MOD"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U73 CFU Param Return AP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U73 CFU Param Return AP"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App Project_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App Project_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 L04 Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "States App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 States App Investigation"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7L6 States App Investigation"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pigify App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 Pigify App Investigation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7L6 Pigify App Investigation"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 CSP CFU Libraries"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7L6 CSP CFU Libraries"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 3"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 4"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 4"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Test a Classmate's Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Test a Library"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Project Test a Library"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 3"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP U7L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 7 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 7 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      },
+      "level_keys": [
+        "CSP Unit 7 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L1 CFU Return",
+        "script_level.level_keys": [
+          "U7L1 CFU Return"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Rock",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Investigate Poetry App",
+        "script_level.level_keys": [
+          "U7 Param Investigate Poetry App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L2 CSP CFU Param and Return",
+        "script_level.level_keys": [
+          "U7L2 CSP CFU Param and Return"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 1",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 2",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 4",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 3",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 5",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Investigate Calculator App",
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Practice App 2",
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice MOD",
+        "script_level.level_keys": [
+          "U7 Param Return Practice MOD"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U73 CFU Param Return AP",
+        "script_level.level_keys": [
+          "U73 CFU Param Return AP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App_2020",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App Project_2020",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App Project_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 L04 Exit Ticket",
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 States App Investigation",
+        "script_level.level_keys": [
+          "U7L6 States App Investigation"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 Pigify App Investigation",
+        "script_level.level_keys": [
+          "U7L6 Pigify App Investigation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 CSP CFU Libraries",
+        "script_level.level_keys": [
+          "U7L6 CSP CFU Libraries"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 3",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 5",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 2",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 1",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 4",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 4"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 1",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 2",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Test a Library",
+        "script_level.level_keys": [
+          "U7 Libraries Project Test a Library"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 3",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 7 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 7 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp7-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp7-pilot-staging.script_json
@@ -1,0 +1,1061 @@
+{
+  "script": {
+    "name": "csp7-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp7-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_parameters_return_values",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Parameters and Return Values"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_libraries",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Libraries"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Parameters and Return Values Explore",
+      "name": "Parameters and Return Values Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Values Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Parameters and Return Values Investigate",
+      "name": "Parameters and Return Values Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Parameters and Return Values Practice",
+      "name": "Parameters and Return Values Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Libraries Explore",
+      "name": "Libraries Explore",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Libraries Investigate",
+      "name": "Libraries Investigate",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Libraries Project",
+      "name": "Libraries Project",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Libraries)",
+      "name": "Student Survey (Libraries)",
+      "absolute_position": 7,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Survey (Libraries)",
+      "name": "Teacher Survey (Libraries)",
+      "absolute_position": 8,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "More with Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 L01 More with Functions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 L01 More with Functions"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Thermostat Embed"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Thermostat Embed"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock Embed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Rock Embed"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Weather Embed"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Weather Embed"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Thermostat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Thermostat"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Rock"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Weather"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Weather"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Investigate Calculator App"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Param Practice App 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 L04 Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Painting"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries Investigate Painting"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries List Math Library"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries List Math Library"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Pig Latin"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries Investigate Pig Latin"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Video: Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Explanation Video"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "U7 Libraries Explanation Video"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "One Function Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "CSP Pilot U7 Libraries Make Pt 1"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "One Function Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "CSP Pilot U7 Libraries Make Pt 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Libraries Playground"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "CSP Pilot U7 Libraries Make Pt 3"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Libraries Playground"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "CSP Pilot U7 Libraries Make Pt 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Libraries)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "Student Late Spring Pilot Survey Libraries"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Survey (Libraries)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      },
+      "level_keys": [
+        "Teacher Late Spring Pilot Survey Libraries"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U7 L01 More with Functions",
+        "script_level.level_keys": [
+          "U7 L01 More with Functions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Thermostat Embed",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Thermostat Embed"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Rock Embed",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock Embed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Weather Embed",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Weather Embed"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Thermostat",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Thermostat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Rock",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Weather",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Weather"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Values Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 1",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 2",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 4",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 3",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 5",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Investigate Calculator App",
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Practice App 2",
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Values Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 L04 Exit Ticket",
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Investigate Painting",
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Painting"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries List Math Library",
+        "script_level.level_keys": [
+          "U7 Libraries List Math Library"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Investigate Pig Latin",
+        "script_level.level_keys": [
+          "U7 Libraries Investigate Pig Latin"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Explanation Video",
+        "script_level.level_keys": [
+          "U7 Libraries Explanation Video"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Pilot U7 Libraries Make Pt 1",
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 1"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Pilot U7 Libraries Make Pt 2",
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Pilot U7 Libraries Make Pt 3",
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Pilot U7 Libraries Make Pt 4",
+        "script_level.level_keys": [
+          "CSP Pilot U7 Libraries Make Pt 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Project",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Student Late Spring Pilot Survey Libraries",
+        "script_level.level_keys": [
+          "Student Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Teacher Late Spring Pilot Survey Libraries",
+        "script_level.level_keys": [
+          "Teacher Late Spring Pilot Survey Libraries"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Survey (Libraries)",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp7-pilot.script_json
+++ b/dashboard/config/scripts_json/csp7-pilot.script_json
@@ -1,0 +1,2037 @@
+{
+  "script": {
+    "name": "csp7-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit7/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp7-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_parameters_return_values",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Parameters and Return Values"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "csp_libraries",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Libraries"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "optional_stages",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Optional Stages"
+      },
+      "seeding_key": {
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Parameters and Return Explore",
+      "name": "Parameters and Return Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Parameters and Return Investigate",
+      "name": "Parameters and Return Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Parameters and Return Practice",
+      "name": "Parameters and Return Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Parameters and Return Make",
+      "name": "Parameters and Return Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Libraries Explore",
+      "name": "Libraries Explore",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Libraries Investigate",
+      "name": "Libraries Investigate",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Libraries Practice",
+      "name": "Libraries Practice",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 1",
+      "name": "Project - Make a Library Part 1",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 2",
+      "name": "Project - Make a Library Part 2",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Project - Make a Library Part 3",
+      "name": "Project - Make a Library Part 3",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Lesson 11: Assessment Day",
+      "name": "Lesson 11: Assessment Day",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Unit 7 STUDENT Survey",
+      "name": "Unit 7 STUDENT Survey",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 7 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "Unit 7 TEACHER Survey",
+      "name": "Unit 7 TEACHER Survey",
+      "absolute_position": 13,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 7 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "key": "[OLD] Parameters and Return Make",
+      "name": "[OLD] Parameters and Return Make",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L1 CFU Return"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7L1 CFU Return"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Investigate Rock"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "App Investigation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Investigate Poetry App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Investigate Poetry App"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L2 CSP CFU Param and Return"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7L2 CSP CFU Param and Return"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "console.log Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Investigate Calculator App"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "App Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Practice App 2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "MOD Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Practice MOD"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Practice MOD"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding: AP Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U73 CFU Param Return AP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U73 CFU Param Return AP"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Make the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App Project_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App Project_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L5 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 L04 Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Turn On Student Created Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Full Year Pilot Experiments Dashboard - Libraries"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "Full Year Pilot Experiments Dashboard - Libraries"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "States App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 States App Investigation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7L6 States App Investigation"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pigify App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 Pigify App Investigation"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7L6 Pigify App Investigation"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7L6 CSP CFU Libraries"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7L6 CSP CFU Libraries"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 3"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 5"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Testing Libraries"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Practice 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Practice 4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Test a Classmate's Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Test a Library"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Project Test a Library"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Build Your Library"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Libraries Project Part 3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7L12 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 7 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 7 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 7 AP-Style Assessment _2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 7 STUDENT Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Unit 7 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7 20-21 Student Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 7 TEACHER Survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U7 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Unit 7 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "CSP U7 20-21 Teacher Pilot Survey"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Try the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Build the Rock Paper Scissors App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      },
+      "level_keys": [
+        "U7 Param Return Make RPS App 6"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L1 CFU Return",
+        "script_level.level_keys": [
+          "U7L1 CFU Return"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Explore",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Investigate Rock",
+        "script_level.level_keys": [
+          "U7 Param Return Investigate Rock"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Investigate Poetry App",
+        "script_level.level_keys": [
+          "U7 Param Investigate Poetry App"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L2 CSP CFU Param and Return",
+        "script_level.level_keys": [
+          "U7L2 CSP CFU Param and Return"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Investigate",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 1",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 2",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 4",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 3",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice Part 5",
+        "script_level.level_keys": [
+          "U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Investigate Calculator App",
+        "script_level.level_keys": [
+          "U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Practice App 2",
+        "script_level.level_keys": [
+          "U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Practice MOD",
+        "script_level.level_keys": [
+          "U7 Param Return Practice MOD"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 9,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U73 CFU Param Return AP",
+        "script_level.level_keys": [
+          "U73 CFU Param Return AP"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 10,
+        "lesson.key": "Parameters and Return Practice",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App_2020",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App Project_2020",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App Project_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Parameters and Return Make",
+        "lesson_group.key": "csp_parameters_return_values",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L5 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L5 SFLP 20-21"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 L04 Exit Ticket",
+        "script_level.level_keys": [
+          "U7 L04 Exit Ticket"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Explore",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Full Year Pilot Experiments Dashboard - Libraries",
+        "script_level.level_keys": [
+          "Full Year Pilot Experiments Dashboard - Libraries"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 States App Investigation",
+        "script_level.level_keys": [
+          "U7L6 States App Investigation"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 Pigify App Investigation",
+        "script_level.level_keys": [
+          "U7L6 Pigify App Investigation"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7L6 CSP CFU Libraries",
+        "script_level.level_keys": [
+          "U7L6 CSP CFU Libraries"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Investigate",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 3",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 3"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 5",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 5"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 2",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 1",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Practice 4",
+        "script_level.level_keys": [
+          "U7 Libraries Practice 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Libraries Practice",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 1",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 1",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 2",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Test a Library",
+        "script_level.level_keys": [
+          "U7 Libraries Project Test a Library"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Project - Make a Library Part 2",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Libraries Project Part 3",
+        "script_level.level_keys": [
+          "U7 Libraries Project Part 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Project - Make a Library Part 3",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7L12 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U7L12 SFLP 20-21"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 7 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 7 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 11: Assessment Day",
+        "lesson_group.key": "csp_libraries",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7 20-21 Student Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U7 20-21 Student Pilot Survey"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Unit 7 STUDENT Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U7 20-21 Teacher Pilot Survey",
+        "script_level.level_keys": [
+          "CSP U7 20-21 Teacher Pilot Survey"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Unit 7 TEACHER Survey",
+        "lesson_group.key": "required",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 1",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 2",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 3",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 4",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 5",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U7 Param Return Make RPS App 6",
+        "script_level.level_keys": [
+          "U7 Param Return Make RPS App 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "[OLD] Parameters and Return Make",
+        "lesson_group.key": "optional_stages",
+        "script.name": "csp7-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp8-2020.script_json
+++ b/dashboard/config/scripts_json/csp8-2020.script_json
@@ -1,0 +1,283 @@
+{
+  "script": {
+    "name": "csp8-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit8/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit8"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit8/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp8-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Create PT - Review the Task",
+      "name": "Create PT - Review the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "key": "Create PT - Make a Plan",
+      "name": "Create PT - Make a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      },
+      "level_keys": [
+        "CSP U8L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      },
+      "level_keys": [
+        "CSP U8L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      },
+      "level_keys": [
+        "CSP U8L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tech Setup and Tools for Create PT"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT Coding Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Create PT Workspace 2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      },
+      "level_keys": [
+        "Create PT Workspace 2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2020",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Create PT Workspace 2020",
+        "script_level.level_keys": [
+          "Create PT Workspace 2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp8-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp8-pilot-staging.script_json
@@ -1,0 +1,3613 @@
+{
+  "script": {
+    "name": "csp8-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp8-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp8-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp8-pilot.script_json
+++ b/dashboard/config/scripts_json/csp8-pilot.script_json
@@ -1,0 +1,262 @@
+{
+  "script": {
+    "name": "csp8-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/create-20-21/create-pt-prep/{LESSON}/",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp8-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Create PT - Review the Task",
+      "name": "Create PT - Review the Task",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "key": "Create PT - Make a Plan",
+      "name": "Create PT - Make a Plan",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "key": "Create PT - Complete the Task",
+      "name": "Create PT - Complete the Task",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      },
+      "level_keys": [
+        "CSP U8L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      },
+      "level_keys": [
+        "CSP U8L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U8L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      },
+      "level_keys": [
+        "CSP U8L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Tech Setup and Tools for Create PT"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      },
+      "level_keys": [
+        "csp-pt-tech-setup-and-tools_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create PT Coding Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Create PT Workspace 2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      },
+      "level_keys": [
+        "Create PT Workspace 2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Review the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Make a Plan",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U8L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U8L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pt-tech-setup-and-tools_2020",
+        "script_level.level_keys": [
+          "csp-pt-tech-setup-and-tools_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Create PT Workspace 2020",
+        "script_level.level_keys": [
+          "Create PT Workspace 2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Create PT - Complete the Task",
+        "lesson_group.key": "",
+        "script.name": "csp8-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp9-2020.script_json
+++ b/dashboard/config/scripts_json/csp9-2020.script_json
@@ -1,0 +1,1268 @@
+{
+  "script": {
+    "name": "csp9-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}",
+      "announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit9/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit9/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp9-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_unit9_2020",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Unit 9: Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Learning From Data",
+      "name": "Learning From Data",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Exploring One Column",
+      "name": "Exploring One Column",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Filtering and Cleaning Data",
+      "name": "Filtering and Cleaning Data",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Exploring Two Columns",
+      "name": "Exploring Two Columns",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Big Data, Crowdsourcing, and Machine Learning",
+      "name": "Big Data, Crowdsourcing, and Machine Learning",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Machine Learning and Bias",
+      "name": "Machine Learning and Bias",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story - Part 1",
+      "name": "Project - Tell a Data Story - Part 1",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story - Part 2",
+      "name": "Project - Tell a Data Story - Part 2",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "key": "Lesson 9: Assessment Day",
+      "name": "Lesson 9: Assessment Day",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring Metadata"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L1 Metadata"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L1 Metadata"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L1 google trends CFU"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "U9L1 google trends CFU"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Bar Charts and Histograms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L2 Making Bar Charts and Histograms"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L2 Making Bar Charts and Histograms"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L2 CFU Histogram vs Bar Chart"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "U9L2 CFU Histogram vs Bar Chart"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Cleaning Data"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 Data Cleaning"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L3 Data Cleaning"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Filtering Data"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 Data Filtering"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L3 Data Filtering"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L3 CFU manually cleaning data"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "U9L3 CFU manually cleaning data"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Crosstab and Scatter Charts"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L4 Making Crosstabs and Scatter Plots"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L4 Making Crosstabs and Scatter Plots"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "What Type of Chart?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Which Type of Chart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Which Type of Chart"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L4 CFU Two Column vs One"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "U9L4 CFU Two Column vs One"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L6 CFU ML Bias"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "U9L6 CFU ML Bias"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Story Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9 Data Story Day 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Data Story Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9 Data Story Day 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP U9L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 9 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 9 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      },
+      "level_keys": [
+        "CSP Unit 9 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L1 Metadata",
+        "script_level.level_keys": [
+          "CSP U9L1 Metadata"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L1 google trends CFU",
+        "script_level.level_keys": [
+          "U9L1 google trends CFU"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L2 Making Bar Charts and Histograms",
+        "script_level.level_keys": [
+          "CSP U9L2 Making Bar Charts and Histograms"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L2 CFU Histogram vs Bar Chart",
+        "script_level.level_keys": [
+          "U9L2 CFU Histogram vs Bar Chart"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 Data Cleaning",
+        "script_level.level_keys": [
+          "CSP U9L3 Data Cleaning"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 Data Filtering",
+        "script_level.level_keys": [
+          "CSP U9L3 Data Filtering"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L3 CFU manually cleaning data",
+        "script_level.level_keys": [
+          "U9L3 CFU manually cleaning data"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L4 Making Crosstabs and Scatter Plots",
+        "script_level.level_keys": [
+          "CSP U9L4 Making Crosstabs and Scatter Plots"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Which Type of Chart",
+        "script_level.level_keys": [
+          "Which Type of Chart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L4 CFU Two Column vs One",
+        "script_level.level_keys": [
+          "U9L4 CFU Two Column vs One"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Short",
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Long",
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L6 CFU ML Bias",
+        "script_level.level_keys": [
+          "U9L6 CFU ML Bias"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9 Data Story Day 1",
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9 Data Story Day 2",
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 9 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 9 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "csp_unit9_2020",
+        "script.name": "csp9-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp9-pilot-staging.script_json
+++ b/dashboard/config/scripts_json/csp9-pilot-staging.script_json
@@ -1,0 +1,3613 @@
+{
+  "script": {
+    "name": "csp9-pilot-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "curriculum_umbrella": "CSP",
+      "project_sharing": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp9-pilot-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "csp9-pilot-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csp9-pilot.script_json
+++ b/dashboard/config/scripts_json/csp9-pilot.script_json
@@ -1,0 +1,1246 @@
+{
+  "script": {
+    "name": "csp9-pilot",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/cspilot/unit9/{LESSON}",
+      "pilot_experiment": "csp-piloters",
+      "curriculum_umbrella": "CSP",
+      "has_verified_resources": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "csp9-pilot"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Learning From Data",
+      "name": "Learning From Data",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Exploring One Column",
+      "name": "Exploring One Column",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Filtering and Cleaning Data",
+      "name": "Filtering and Cleaning Data",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Exploring Two Columns",
+      "name": "Exploring Two Columns",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Big Data, Crowdsourcing, and Machine Learning",
+      "name": "Big Data, Crowdsourcing, and Machine Learning",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Machine Learning and Bias",
+      "name": "Machine Learning and Bias",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story - Part 1",
+      "name": "Project - Tell a Data Story - Part 1",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story - Part 2",
+      "name": "Project - Tell a Data Story - Part 2",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "key": "Lesson 9: Assessment Day",
+      "name": "Lesson 9: Assessment Day",
+      "absolute_position": 9,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L1 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Exploring Metadata"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L1 Metadata"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L1 Metadata"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L1 google trends CFU"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "U9L1 google trends CFU"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L2 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Bar Charts and Histograms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L2 Making Bar Charts and Histograms"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L2 Making Bar Charts and Histograms"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L2 CFU Histogram vs Bar Chart"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "U9L2 CFU Histogram vs Bar Chart"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L3 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Cleaning Data"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 Data Cleaning"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L3 Data Cleaning"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Filtering Data"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L3 Data Filtering"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L3 Data Filtering"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L3 CFU manually cleaning data"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "U9L3 CFU manually cleaning data"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L4 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Crosstab and Scatter Charts"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L4 Making Crosstabs and Scatter Plots"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L4 Making Crosstabs and Scatter Plots"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "What Type of Chart?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Which Type of Chart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Which Type of Chart"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check For Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L4 CFU Two Column vs One"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "U9L4 CFU Two Column vs One"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L6 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L7 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "AI for Oceans - Machine Learning"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "Oceans_Long"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U9L6 CFU ML Bias"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "U9L6 CFU ML Bias"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L8 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Data Story Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9 Data Story Day 1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L9 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Data Story Workspace"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9 Data Story Day 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U9L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP U9L10 SFLP 20-21"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Unit 9 Exam"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 9 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      },
+      "level_keys": [
+        "CSP Unit 9 AP-Style Assessment _2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L1 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L1 SFLP 20-21"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L1 Metadata",
+        "script_level.level_keys": [
+          "CSP U9L1 Metadata"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L1 google trends CFU",
+        "script_level.level_keys": [
+          "U9L1 google trends CFU"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learning From Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L2 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L2 SFLP 20-21"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L2 Making Bar Charts and Histograms",
+        "script_level.level_keys": [
+          "CSP U9L2 Making Bar Charts and Histograms"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L2 CFU Histogram vs Bar Chart",
+        "script_level.level_keys": [
+          "U9L2 CFU Histogram vs Bar Chart"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Exploring One Column",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L3 SFLP 20-21"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 Data Cleaning",
+        "script_level.level_keys": [
+          "CSP U9L3 Data Cleaning"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L3 Data Filtering",
+        "script_level.level_keys": [
+          "CSP U9L3 Data Filtering"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L3 CFU manually cleaning data",
+        "script_level.level_keys": [
+          "U9L3 CFU manually cleaning data"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Filtering and Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L4 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L4 SFLP 20-21"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L4 Making Crosstabs and Scatter Plots",
+        "script_level.level_keys": [
+          "CSP U9L4 Making Crosstabs and Scatter Plots"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Which Type of Chart",
+        "script_level.level_keys": [
+          "Which Type of Chart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L4 CFU Two Column vs One",
+        "script_level.level_keys": [
+          "U9L4 CFU Two Column vs One"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Exploring Two Columns",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L6 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L6 SFLP 20-21"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Big Data, Crowdsourcing, and Machine Learning",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L7 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L7 SFLP 20-21"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Short",
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Long",
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U9L6 CFU ML Bias",
+        "script_level.level_keys": [
+          "U9L6 CFU ML Bias"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Machine Learning and Bias",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L8 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L8 SFLP 20-21"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9 Data Story Day 1",
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 1",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L9 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L9 SFLP 20-21"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9 Data Story Day 2",
+        "script_level.level_keys": [
+          "CSP U9 Data Story Day 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Project - Tell a Data Story - Part 2",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U9L10 SFLP 20-21",
+        "script_level.level_keys": [
+          "CSP U9L10 SFLP 20-21"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 9 AP-Style Assessment _2020",
+        "script_level.level_keys": [
+          "CSP Unit 9 AP-Style Assessment _2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Lesson 9: Assessment Day",
+        "lesson_group.key": "",
+        "script.name": "csp9-pilot"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspassessment.script_json
+++ b/dashboard/config/scripts_json/cspassessment.script_json
@@ -1,0 +1,167 @@
+{
+  "script": {
+    "name": "cspassessment",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspassessment"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+      "name": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    },
+    {
+      "key": "RQB Questions test",
+      "name": "RQB Questions test",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "RQB Questions test",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      },
+      "level_keys": [
+        "CSP_Final_instructions"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      },
+      "level_keys": [
+        "CSP Culminating Assessment"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RQB test levelgroup"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "RQB Questions test",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      },
+      "level_keys": [
+        "RQB test levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP_Final_instructions",
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Culminating Assessment",
+        "script_level.level_keys": [
+          "CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RQB test levelgroup",
+        "script_level.level_keys": [
+          "RQB test levelgroup"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "RQB Questions test",
+        "lesson_group.key": "",
+        "script.name": "cspassessment"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspexam1-mWU7ilDYM9.script_json
+++ b/dashboard/config/scripts_json/cspexam1-mWU7ilDYM9.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "cspexam1-mWU7ilDYM9",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspexam1-mWU7ilDYM9"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Culminating Assessment Part 1",
+      "name": "CS Principles Culminating Assessment Part 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Culminating Assessment Part 1",
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Culminating Assessment Part 1",
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      },
+      "level_keys": [
+        "CSP_Final_instructions"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Part 1 - CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Culminating Assessment Part 1",
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      },
+      "level_keys": [
+        "Part 1 - CSP Culminating Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP_Final_instructions",
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Culminating Assessment Part 1",
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Part 1 - CSP Culminating Assessment",
+        "script_level.level_keys": [
+          "Part 1 - CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Culminating Assessment Part 1",
+        "lesson_group.key": "",
+        "script.name": "cspexam1-mWU7ilDYM9"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspexam2-AKwgAh1ac5.script_json
+++ b/dashboard/config/scripts_json/cspexam2-AKwgAh1ac5.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "cspexam2-AKwgAh1ac5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspexam2-AKwgAh1ac5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CS Principles Culminating Assessment Part 2",
+      "name": "CS Principles Culminating Assessment Part 2",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Culminating Assessment Part 2",
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Culminating Assessment Part 2",
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      },
+      "level_keys": [
+        "CSP_Final_instructions"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Part 2 - CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Culminating Assessment Part 2",
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      },
+      "level_keys": [
+        "Part 2 - CSP Culminating Assessment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP_Final_instructions",
+        "script_level.level_keys": [
+          "CSP_Final_instructions"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Culminating Assessment Part 2",
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Part 2 - CSP Culminating Assessment",
+        "script_level.level_keys": [
+          "Part 2 - CSP Culminating Assessment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Culminating Assessment Part 2",
+        "lesson_group.key": "",
+        "script.name": "cspexam2-AKwgAh1ac5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspfacilitator.script_json
+++ b/dashboard/config/scripts_json/cspfacilitator.script_json
@@ -1,0 +1,1218 @@
+{
+  "script": {
+    "name": "cspfacilitator",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspfacilitator"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "Pixelation Widget",
+      "name": "Pixelation Widget",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "Text Compression Widget",
+      "name": "Text Compression Widget",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "Internet Simulator",
+      "name": "Internet Simulator",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "App Lab",
+      "name": "App Lab",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "Broadcast Lesson",
+      "name": "Broadcast Lesson",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "key": "Text Compression Lesson",
+      "name": "Text Compression Lesson",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPfac intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "CSPfac intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "a bit about pixels"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "a bit about pixels"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make your own B and W Image"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Text Compression"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L4 NetSim SendAB"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 NetSim numbers no decimal"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L8 NetSim numbers no decimal"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 NetSim Classroom Internet"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L5 NetSim Classroom Internet"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L7 NetSim Need for Packets"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L7 NetSim Need for Packets"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L10 NetSim Automatic DNS"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Starry Night Starter Code"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L07 - Starry Night Starter Code"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - Enchantment Under the Sea"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L08 - Enchantment Under the Sea"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L13 - Turtle move with button"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U3L16 - use images"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "broadcast lesson plan"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "broadcast lesson plan"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L2 NetSim Hub Mode"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L02 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U2L02 Assessment2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "text compression lesson plan"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "text compression lesson plan"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Student Lesson Summary"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Text Compression"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Reflection Free Response"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Reflection Free Response"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Reflection 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      },
+      "level_keys": [
+        "U1L13 Reflection 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPfac intro",
+        "script_level.level_keys": [
+          "CSPfac intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "a bit about pixels",
+        "script_level.level_keys": [
+          "a bit about pixels"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make your own B and W Image",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Pixelation Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Text Compression",
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression Widget",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 NetSim SendAB",
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 NetSim numbers no decimal",
+        "script_level.level_keys": [
+          "U1L8 NetSim numbers no decimal"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 NetSim Classroom Internet",
+        "script_level.level_keys": [
+          "U2L5 NetSim Classroom Internet"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L7 NetSim Need for Packets",
+        "script_level.level_keys": [
+          "U2L7 NetSim Need for Packets"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 NetSim Automatic DNS",
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Starry Night Starter Code",
+        "script_level.level_keys": [
+          "U3L07 - Starry Night Starter Code"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - Enchantment Under the Sea",
+        "script_level.level_keys": [
+          "U3L08 - Enchantment Under the Sea"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Turtle move with button",
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - use images",
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "App Lab",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "broadcast lesson plan",
+        "script_level.level_keys": [
+          "broadcast lesson plan"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 NetSim Hub Mode",
+        "script_level.level_keys": [
+          "U2L2 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Free Response Reflection",
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment2",
+        "script_level.level_keys": [
+          "U2L02 Assessment2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "text compression lesson plan",
+        "script_level.level_keys": [
+          "text compression lesson plan"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Student Lesson Summary",
+        "script_level.level_keys": [
+          "U1L13 Student Lesson Summary"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Text Compression",
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 1",
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 2",
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Reflection Free Response",
+        "script_level.level_keys": [
+          "U1L13 Reflection Free Response"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Reflection 1",
+        "script_level.level_keys": [
+          "U1L13 Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Reflection 2",
+        "script_level.level_keys": [
+          "U1L13 Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Text Compression Lesson",
+        "lesson_group.key": "",
+        "script.name": "cspfacilitator"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspnovice.script_json
+++ b/dashboard/config/scripts_json/cspnovice.script_json
@@ -1,0 +1,652 @@
+{
+  "script": {
+    "name": "cspnovice",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Facilitator in Training",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspnovice"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome",
+      "name": "Welcome",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome",
+        "lesson_group.key": "required",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "key": "Tuesday",
+      "name": "Tuesday",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "key": "Wednesday",
+      "name": "Wednesday",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "key": "Thursday",
+      "name": "Thursday",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-csp-novice"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome",
+        "lesson_group.key": "required",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "welcome-csp-novice"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-unit"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-tuesday-unit"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-unit2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-tuesday-unit2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-tuesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-facilitation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-tuesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-unit"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-wednesday-unit"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-wednesday-unit2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-wednesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-facilitation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-wednesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-unit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-thursday-unit"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-unit2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-thursday-unit2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-thursday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-thursday-pedagogy2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-facilitation"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-thursday-facilitation"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-novice-congrats"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      },
+      "level_keys": [
+        "csp-novice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-csp-novice",
+        "script_level.level_keys": [
+          "welcome-csp-novice"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome",
+        "lesson_group.key": "required",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-unit",
+        "script_level.level_keys": [
+          "csp-tuesday-unit"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-unit2",
+        "script_level.level_keys": [
+          "csp-tuesday-unit2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-pedagogy",
+        "script_level.level_keys": [
+          "csp-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-facilitation",
+        "script_level.level_keys": [
+          "csp-tuesday-facilitation"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Tuesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-unit",
+        "script_level.level_keys": [
+          "csp-wednesday-unit"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-unit2",
+        "script_level.level_keys": [
+          "csp-wednesday-unit2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-pedagogy",
+        "script_level.level_keys": [
+          "csp-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-facilitation",
+        "script_level.level_keys": [
+          "csp-wednesday-facilitation"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Wednesday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-unit",
+        "script_level.level_keys": [
+          "csp-thursday-unit"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-unit2",
+        "script_level.level_keys": [
+          "csp-thursday-unit2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-pedagogy",
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-pedagogy2",
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-facilitation",
+        "script_level.level_keys": [
+          "csp-thursday-facilitation"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Thursday",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-novice-congrats",
+        "script_level.level_keys": [
+          "csp-novice-congrats"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "cspnovice"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspoptional.script_json
+++ b/dashboard/config/scripts_json/cspoptional.script_json
@@ -1,0 +1,1288 @@
+{
+  "script": {
+    "name": "cspoptional",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspoptional"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 1 - Sending Bits in the Real World",
+      "name": "Unit 1 - Sending Bits in the Real World",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 1 - Encoding Numbers in the Real World",
+      "name": "Unit 1 - Encoding Numbers in the Real World",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 - Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+      "name": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 1 - Algorithms Detour - Shortest Path",
+      "name": "Unit 1 - Algorithms Detour - Shortest Path",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 1 - How Routers Learn",
+      "name": "Unit 1 - How Routers Learn",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+      "name": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+      "name": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sending Bits Real World Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "Sending Bits Real World Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U1L5 How the Internet Works - Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U1L5 Matching Assessment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Encoding Numbers Real World Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "Encoding Numbers Real World Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Free Response Assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U1L9 Free Response Assessment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Algo MST Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "Algo MST Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06 - Matching: Label the Diagram"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L06 - Matching: Label the Diagram"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06- MC: what is an MST?"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L06- MC: what is an MST?"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06 - MC: Which is an MST?"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L06 - MC: Which is an MST?"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Algo Shortest Path Student Lesson Introduction"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "Algo Shortest Path Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L07 Assessment 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U1L07 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L07 Assessment2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L07 Assessment3"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L07 Assessment4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment5"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L07 Assessment5"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Algo How Routers Learn Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "Algo How Routers Learn Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L08 Free Response 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L08 Free Response 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L08 Free Response 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Assessment 0"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L08 Assessment 0"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Assessment 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L08 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Assessment 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Assessment 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L16 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L16 Free Response Assessment 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L18 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Response Getting Started"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Responses Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 Free Responses Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 - Vocabulary matching"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L17 - Vocabulary matching"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Getting Started"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L18 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L18 Assessment"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      },
+      "level_keys": [
+        "U2L18 Free Response Wrap Up"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Sending Bits Real World Student Lesson Introduction",
+        "script_level.level_keys": [
+          "Sending Bits Real World Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 How the Internet Works - Video",
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Matching Assessment",
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Encoding Numbers Real World Student Lesson Introduction",
+        "script_level.level_keys": [
+          "Encoding Numbers Real World Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Free Response Assessment",
+        "script_level.level_keys": [
+          "U1L9 Free Response Assessment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Algo MST Student Lesson Introduction",
+        "script_level.level_keys": [
+          "Algo MST Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06 - Matching: Label the Diagram",
+        "script_level.level_keys": [
+          "U2L06 - Matching: Label the Diagram"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06- MC: what is an MST?",
+        "script_level.level_keys": [
+          "U2L06- MC: what is an MST?"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06 - MC: Which is an MST?",
+        "script_level.level_keys": [
+          "U2L06 - MC: Which is an MST?"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Algo Shortest Path Student Lesson Introduction",
+        "script_level.level_keys": [
+          "Algo Shortest Path Student Lesson Introduction"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L07 Assessment 1",
+        "script_level.level_keys": [
+          "U1L07 Assessment 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment2",
+        "script_level.level_keys": [
+          "U2L07 Assessment2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment3",
+        "script_level.level_keys": [
+          "U2L07 Assessment3"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment4",
+        "script_level.level_keys": [
+          "U2L07 Assessment4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment5",
+        "script_level.level_keys": [
+          "U2L07 Assessment5"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 - Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Algo How Routers Learn Student Lesson Introduction",
+        "script_level.level_keys": [
+          "Algo How Routers Learn Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 3",
+        "script_level.level_keys": [
+          "U2L08 Free Response 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 1",
+        "script_level.level_keys": [
+          "U2L08 Free Response 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 2",
+        "script_level.level_keys": [
+          "U2L08 Free Response 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Assessment 0",
+        "script_level.level_keys": [
+          "U2L08 Assessment 0"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Assessment 1",
+        "script_level.level_keys": [
+          "U2L08 Assessment 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1 - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Assessment 1",
+        "script_level.level_keys": [
+          "U2L17 Assessment 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Assessment 2",
+        "script_level.level_keys": [
+          "U2L17 Assessment 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L16 Free Response Assessment 3",
+        "script_level.level_keys": [
+          "U2L16 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L17 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 - Hard Problems - The Traveling Salesperson Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L17 Free Response Getting Started"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Responses Assessment 1",
+        "script_level.level_keys": [
+          "U2L17 Free Responses Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 - Vocabulary matching",
+        "script_level.level_keys": [
+          "U2L17 - Vocabulary matching"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L18 Free Response Getting Started"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Assessment",
+        "script_level.level_keys": [
+          "U2L18 Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L18 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 - One-Way Functions - The WiFi Hotspot Problem",
+        "lesson_group.key": "",
+        "script.name": "cspoptional"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspplayground.script_json
+++ b/dashboard/config/scripts_json/cspplayground.script_json
@@ -1,0 +1,3661 @@
+{
+  "script": {
+    "name": "cspplayground",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspplayground"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_variables",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "csp_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "csp_functions",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "csp_project",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Variables Explore",
+      "name": "Variables Explore",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Variables Investigate",
+      "name": "Variables Investigate",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Variables Practice",
+      "name": "Variables Practice",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Variables Make",
+      "name": "Variables Make",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Student Survey (Variables)",
+      "name": "Student Survey (Variables)",
+      "absolute_position": 5,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Variables)",
+      "name": "Teacher Surveys (Variables)",
+      "absolute_position": 6,
+      "lockable": true,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Conditionals Explore",
+      "name": "Conditionals Explore",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Conditionals Investigate",
+      "name": "Conditionals Investigate",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Conditionals Practice",
+      "name": "Conditionals Practice",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Conditional Make",
+      "name": "Conditional Make",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Student Survey (Conditionals)",
+      "name": "Student Survey (Conditionals)",
+      "absolute_position": 11,
+      "lockable": true,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Teacher Surveys (Conditionals)",
+      "name": "Teacher Surveys (Conditionals)",
+      "absolute_position": 12,
+      "lockable": true,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Functions Explore / Investigate",
+      "name": "Functions Explore / Investigate",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Functions Practice",
+      "name": "Functions Practice",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Functions Make",
+      "name": "Functions Make",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Practice PT Part 1",
+      "name": "Practice PT Part 1",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Practice PT Part 2",
+      "name": "Practice PT Part 2",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Practice PT Part 3",
+      "name": "Practice PT Part 3",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Unit 4 Assessment",
+      "name": "Unit 4 Assessment",
+      "absolute_position": 19,
+      "lockable": true,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "key": "Lists Explore",
+      "name": "Lists Explore",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "CSP U4 My Pet Rock Example App"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L01 Poetry App"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L01 Thermostat App"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U1 L02 CYU MC"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v1 Code"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Thermostat App v3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 Thermostat App v3 pt3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L02 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Assigning Numbers and Strings"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables and Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging Scope Issues"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Scope Issue"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Putting it Together"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L03 Variables operator practice 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Photo Liker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L04 Variables Make Project 4"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Pilot Student Survey"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Variables)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys CSP2021"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Introduction to Conditionals: Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L05 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if Statements"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v4 Code"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else Statements"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: if-else-if Statements"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Else Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v5 Code"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators: AND OR"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 Thermostat App v6 Code"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Patterns: If-else-if"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Checking Multiple Conditions with If-elseif"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L06 CYU Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Boolean expressions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 10"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "If-Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Logical Operators"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L07 Conditionals Practice 9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Sample"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L08 Conditionals Make Project Flowchart"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 4"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Museum Ticket Generator App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L08 Museum Ticket Generator 5"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Student Survey (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Pilot Student Survey Conditionals"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Teacher Surveys (Conditionals)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Pilot Teacher Surveys Conditionals CSP2021"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L09 Functions Song"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4L09 Intro to Functions Video"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L09 Score Clicker Investigate"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declaring and Calling Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L09 Thermostat App v7"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Update Screen Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "updateScreen Pattern"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice Calling Functions 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 2"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Practice 3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Declare and Call Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Build Practice 2"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "Debugging Variable Scope and Functions"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Function Scope"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Functions Scope Practice 1 v2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "When to Make Functions Map"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "When to Declare Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L10 Making Functions Practice"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 3"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.5"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 4.75"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 5"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Make the Quote Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L11 Functions Make 6"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Apps"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Create the Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 3"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Add onEvents"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L13 Practice PT 4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Test Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Submit Your Decision Maker App"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U4 L14 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "CSP 20-21 Unit 4 Assessment"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introduction to Lists"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      },
+      "level_keys": [
+        "U5 L01 Introduction to Lists"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U4 My Pet Rock Example App",
+        "script_level.level_keys": [
+          "CSP U4 My Pet Rock Example App"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Poetry App",
+        "script_level.level_keys": [
+          "U4 L01 Poetry App"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L01 Thermostat App",
+        "script_level.level_keys": [
+          "U4 L01 Thermostat App"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1 L02 CYU MC",
+        "script_level.level_keys": [
+          "U1 L02 CYU MC"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Variables Explore",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v1 Code",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v1 Code"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt2",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 Thermostat App v3 pt3",
+        "script_level.level_keys": [
+          "U4 L02 Thermostat App v3 pt3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L02 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L02 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 7,
+        "lesson.key": "Variables Investigate",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Scope Issue",
+        "script_level.level_keys": [
+          "U4 L03 Scope Issue"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L03 Variables operator practice 4",
+        "script_level.level_keys": [
+          "U4 L03 Variables operator practice 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Variables Practice",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project Sample"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 1",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 2",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 3",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L04 Variables Make Project 4",
+        "script_level.level_keys": [
+          "U4 L04 Variables Make Project 4"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Variables Make",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey",
+        "script_level.level_keys": [
+          "Pilot Student Survey"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys CSP2021"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Variables)",
+        "lesson_group.key": "csp_variables",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Introduction to Conditionals: Boolean Expressions",
+        "script_level.level_keys": [
+          "U4 L06 Introduction to Conditionals: Boolean Expressions"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L05 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L05 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Explore",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if Statements"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v4 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v4 Code"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else Statements"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: if-else-if Statements",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: if-else-if Statements"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v5 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v5 Code"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Introduction to Conditionals: Compound Boolean Expressions",
+        "script_level.level_keys": [
+          "U4L06 Introduction to Conditionals: Compound Boolean Expressions"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 Thermostat App v6 Code",
+        "script_level.level_keys": [
+          "U4 L06 Thermostat App v6 Code"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Checking Multiple Conditions with If-elseif",
+        "script_level.level_keys": [
+          "Checking Multiple Conditions with If-elseif"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L06 CYU Exit Ticket",
+        "script_level.level_keys": [
+          "U4 L06 CYU Exit Ticket"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Investigate",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 1",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 2",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 3",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 10",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 10"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 4",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 5",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 6",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 7",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 8",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L07 Conditionals Practice 9",
+        "script_level.level_keys": [
+          "U4 L07 Conditionals Practice 9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Practice",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Sample",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Sample"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L08 Conditionals Make Project Flowchart",
+        "script_level.level_keys": [
+          "U4 L08 Conditionals Make Project Flowchart"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 1",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 2",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 4",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 4"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Museum Ticket Generator 5",
+        "script_level.level_keys": [
+          "U4L08 Museum Ticket Generator 5"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Make",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Student Survey Conditionals",
+        "script_level.level_keys": [
+          "Pilot Student Survey Conditionals"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Student Survey (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pilot Teacher Surveys Conditionals CSP2021",
+        "script_level.level_keys": [
+          "Pilot Teacher Surveys Conditionals CSP2021"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Teacher Surveys (Conditionals)",
+        "lesson_group.key": "csp_conditionals",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Functions Song",
+        "script_level.level_keys": [
+          "U4 L09 Functions Song"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Intro to Functions Video",
+        "script_level.level_keys": [
+          "U4L09 Intro to Functions Video"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Score Clicker Investigate",
+        "script_level.level_keys": [
+          "U4 L09 Score Clicker Investigate"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L09 Thermostat App v7",
+        "script_level.level_keys": [
+          "U4 L09 Thermostat App v7"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "updateScreen Pattern",
+        "script_level.level_keys": [
+          "updateScreen Pattern"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Functions Explore / Investigate",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice Calling Functions 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice Calling Functions 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 1",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 2"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Practice 3",
+        "script_level.level_keys": [
+          "U4 L10 Functions Practice 3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Build Practice 2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Build Practice 2"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Debugging Variable Scope and Functions",
+        "script_level.level_keys": [
+          "Debugging Variable Scope and Functions"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Functions Scope Practice 1 v2",
+        "script_level.level_keys": [
+          "U4 L10 Functions Scope Practice 1 v2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "When to Make Functions Map",
+        "script_level.level_keys": [
+          "When to Make Functions Map"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L10 Making Functions Practice",
+        "script_level.level_keys": [
+          "U4 L10 Making Functions Practice"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Functions Practice",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 1",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 2",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 3",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 3"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 3,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 4,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.5"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 5,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 4.75",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 4.75"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 6,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 5",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 5"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 7,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L11 Functions Make 6",
+        "script_level.level_keys": [
+          "U4 L11 Functions Make 6"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 8,
+        "lesson.key": "Functions Make",
+        "lesson_group.key": "csp_functions",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 1",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 1"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 2"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 3",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 3"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L13 Practice PT 4",
+        "script_level.level_keys": [
+          "U4 L13 Practice PT 4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Practice PT Part 2",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 1",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 L14 Practice PT 2",
+        "script_level.level_keys": [
+          "U4 L14 Practice PT 2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT Part 3",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP 20-21 Unit 4 Assessment",
+        "script_level.level_keys": [
+          "CSP 20-21 Unit 4 Assessment"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Assessment",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 L01 Introduction to Lists",
+        "script_level.level_keys": [
+          "U5 L01 Introduction to Lists"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Lists Explore",
+        "lesson_group.key": "csp_project",
+        "script.name": "cspplayground"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csppostap-2017.script_json
+++ b/dashboard/config/scripts_json/csppostap-2017.script_json
@@ -1,0 +1,2858 @@
+{
+  "script": {
+    "name": "csppostap-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://docs.google.com/document/d/1K5BE3odBGkcPIOrV38fOqQZD59v30_d_D530Uh8LFDY/edit",
+      "version_year": "2017",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true
+    },
+    "new_name": "csppostap-2017",
+    "family_name": "csppostap",
+    "seeding_key": {
+      "script.name": "csppostap-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Deleting Records",
+      "name": "Deleting Records",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Updating Records",
+      "name": "Updating Records",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Importing and Exporting Data",
+      "name": "Importing and Exporting Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Visualizing Data",
+      "name": "Visualizing Data",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Sample Apps",
+      "name": "Sample Apps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Final Project",
+      "name": "Final Project",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Final Project",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "key": "Post-Course Survey",
+      "name": "Post-Course Survey",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - deleteRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Default Block"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Callback Success Parameter"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Update Nonexistent Record"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit UI"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit event handler"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Save edited contact"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - ImportExport - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Charts - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - User Login"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Class Survey"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Clicker Game"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Flashcards"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Final Project - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "U6 - Final Project - Project Level"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here! Complete the CS Principles post-course survey"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Participate in a longitudinal study!"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      },
+      "level_keys": [
+        "Click Here!"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - deleteRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Default Block",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Callback Success Parameter",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Update Nonexistent Record",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit UI",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit event handler",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Save edited contact",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - ImportExport - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Charts - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - User Login",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Class Survey",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Clicker Game",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Flashcards",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Project Level",
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "content",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Click Here!",
+        "script_level.level_keys": [
+          "Click Here!"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 2,
+        "lesson.key": "Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csppostap-2018.script_json
+++ b/dashboard/config/scripts_json/csppostap-2018.script_json
@@ -1,0 +1,4086 @@
+{
+  "script": {
+    "name": "csppostap-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-18/post-ap/{LESSON}",
+      "announcements": [
+        {
+          "notice": "No Lesson Plans for Chapter 2",
+          "details": "Chapter 2 of this unit does not currently have lesson plans available. \"Lesson Plan\" links for that chapter will not work as expected.",
+          "link": "",
+          "type": "information"
+        },
+        {
+          "notice": "What's Next After High School?",
+          "details": "Continue your journey with CS! Explore career and academic pathways, job and mentorship opportunities, and online courses available through our partners.",
+          "link": "https://code.org/student/hsgrads",
+          "type": "success",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "Computer Science Beyond High School",
+          "details": "It's the perfect time to help your students explore their next CS opportunities. These resources can help them explore pathways, internships, and online courses.",
+          "link": "https://code.org/student/hsgrads",
+          "type": "success",
+          "visibility": "Teacher-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Please complete this important survey. It takes less than 10 minutes! Simply click the Learn More button to go directly to it, or scroll to the bottom of page to find it there.",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Student-only"
+        },
+        {
+          "notice": "CS Principles Post-Course Survey for Students Now Open!",
+          "details": "Teachers, please ask your students to complete this important survey. It takes less than 10 minutes! Check it out: you can find a link to the survey at the bottom of this unit page or click the Learn More button to go directly to it. Click the \"View Lesson Plan\" button next to the survey for instructions. Thanks!",
+          "link": "https://studio.code.org/s/csp-post-survey-2018",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2018",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": "csppostap",
+    "seeding_key": {
+      "script.name": "csppostap-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_postap_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Manipulating and Visualizing Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "csp_postap_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Apps and Databases"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to Data",
+      "name": "Intro to Data",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Good and Bad Data Visualizations",
+      "name": "Good and Bad Data Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Making Data Visualizations",
+      "name": "Making Data Visualizations",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Discover a Data Story",
+      "name": "Discover a Data Story",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Cleaning Data",
+      "name": "Cleaning Data",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Creating Summary Tables",
+      "name": "Creating Summary Tables",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story",
+      "name": "Project - Tell a Data Story",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Chapter 1 Assessment",
+      "name": "Chapter 1 Assessment",
+      "absolute_position": 8,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Deleting Records",
+      "name": "Deleting Records",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Updating Records",
+      "name": "Updating Records",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Importing and Exporting Data",
+      "name": "Importing and Exporting Data",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Visualizing Data",
+      "name": "Visualizing Data",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Sample Apps",
+      "name": "Sample Apps",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "Final Project",
+      "name": "Final Project",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "key": "CS Principles Post-Course Survey",
+      "name": "CS Principles Post-Course Survey",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L07 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L07 SFLP"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L10 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L10 SFLP"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection A: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Collection A: Good and Bad Visualizations_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection B: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Collection B: Good and Bad Visualizations_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L10 FR why best worst viz_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L11 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L11 SFLP"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Downloading the Data Set"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Downloading the Data Set_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Downloading the Data Set_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Scatter Plot"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Scatter Plot_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Making a Scatter Plot_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Line Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Line Chart_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Making a Line Chart_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Bar Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Bar Chart_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Making a Bar Chart_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Editing Chart Appearance"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Editing Chart Appearance_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Editing Chart Appearance_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Data Visualizations - Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Free Play_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L10 FR describe what you made from lesson prompt_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L12 SFLP"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L12 SFLP"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L12 FR reflection on collaboration_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L13 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L13 SFLP"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting to Know Your Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Getting to Know Your Data_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Getting to Know Your Data_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cleaning Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cleaning Data_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Cleaning Data_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Categorizing Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Categorizing Data_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Categorizing Data_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L13 Cleaning Data MC_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L13 FR Reflection data analysis objective_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L14 SFLP"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L14 SFLP"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 1 - The Basics"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 1 - The Basics_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 2 - Manipulation and Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 2 - Manipulation and Visualization_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 3_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U2L14 Summary Tables MC_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L15 SFLP"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP U2L15 SFLP"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "csp_affirmation_control_2_2018": {
+            "experiments": [
+              "rene-control-control",
+              "rene-belonging-control"
+            ]
+          },
+          "csp_affirmation_intervention_2_2018": {
+            "active": false,
+            "experiments": [
+              "rene-control-affirmation",
+              "rene-belonging-affirmation"
+            ]
+          }
+        },
+        "progression": "Pre-test reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_affirmation_control_2_2018",
+          "csp_affirmation_intervention_2_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "csp_affirmation_control_2_2018",
+        "csp_affirmation_intervention_2_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "CSP Unit 2 Ch2 Cumulative Assessment MC_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - deleteRecord - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Default Block_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Callback Success Parameter_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Update Nonexistent Record_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit UI_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit event handler_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Save edited contact_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - ImportExport - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Charts - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1_2018"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2_2018"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1_2018"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2_2018"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - User Login_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Class Survey_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Clicker Game_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Flashcards_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Final Project - Student Introduction_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "U6 - Final Project - Project Level_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Post-Course Survey Instructions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2018"
+      },
+      "level_keys": [
+        "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L07 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L07 SFLP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L10 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L10 SFLP"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection A: Good and Bad Visualizations_2018",
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection B: Good and Bad Visualizations_2018",
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR why best worst viz_2018",
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L11 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L11 SFLP"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Downloading the Data Set_2018",
+        "script_level.level_keys": [
+          "Downloading the Data Set_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Scatter Plot_2018",
+        "script_level.level_keys": [
+          "Making a Scatter Plot_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Line Chart_2018",
+        "script_level.level_keys": [
+          "Making a Line Chart_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Bar Chart_2018",
+        "script_level.level_keys": [
+          "Making a Bar Chart_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Editing Chart Appearance_2018",
+        "script_level.level_keys": [
+          "Editing Chart Appearance_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Free Play_2018",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR describe what you made from lesson prompt_2018",
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L12 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L12 SFLP"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L12 FR reflection on collaboration_2018",
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L13 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L13 SFLP"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Getting to Know Your Data_2018",
+        "script_level.level_keys": [
+          "Getting to Know Your Data_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cleaning Data_2018",
+        "script_level.level_keys": [
+          "Cleaning Data_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Categorizing Data_2018",
+        "script_level.level_keys": [
+          "Categorizing Data_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Cleaning Data MC_2018",
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 FR Reflection data analysis objective_2018",
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L14 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L14 SFLP"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 1 - The Basics_2018",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 2 - Manipulation and Visualization_2018",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 3_2018",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Summary Tables MC_2018",
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L15 SFLP",
+        "script_level.level_keys": [
+          "CSP U2L15 SFLP"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_control_2_2018",
+        "script_level.level_keys": [
+          "csp_affirmation_control_2_2018",
+          "csp_affirmation_intervention_2_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_affirmation_intervention_2_2018",
+        "script_level.level_keys": [
+          "csp_affirmation_control_2_2018",
+          "csp_affirmation_intervention_2_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Unit 2 Ch2 Cumulative Assessment MC_2018",
+        "script_level.level_keys": [
+          "CSP Unit 2 Ch2 Cumulative Assessment MC_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Chapter 1 Assessment",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video_2018",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage_2018",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction_2018",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5_2018",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand_2018",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive_2018",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand_2018",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App_2018",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table_2018",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts_2018",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction_2018",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1_2018",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External_2018",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2_2018",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3_2018",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - deleteRecord - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation_2018",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0_2018",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1_2018",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object_2018",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4_2018",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work_2018",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Default Block_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Callback Success Parameter_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Update Nonexistent Record_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit UI_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit event handler_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Save edited contact_2018",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - ImportExport - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Charts - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1_2018"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2_2018"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1_2018"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2_2018",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2_2018"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction_2018"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - User Login_2018",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Class Survey_2018",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Clicker Game_2018",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Flashcards_2018",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Student Introduction_2018",
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Project Level_2018",
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-2018-markdown-with-link-to-survey_v2",
+        "script_level.level_keys": [
+          "csp-post-survey-2018-markdown-with-link-to-survey_v2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post-Course Survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/csppostap-2019.script_json
+++ b/dashboard/config/scripts_json/csppostap-2019.script_json
@@ -1,0 +1,3976 @@
+{
+  "script": {
+    "name": "csppostap-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-19/post-ap/{LESSON}",
+      "announcements": [
+        {
+          "notice": "No Lesson Plans in Chapter 2",
+          "details": "Please note there are no lesson plans for Chapter 2 of this unit.",
+          "link": "",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "version_year": "2019",
+      "has_verified_resources": true,
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": "csppostap",
+    "seeding_key": {
+      "script.name": "csppostap-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csp_postap_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Chapter 1: Manipulating and Visualizing Data"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "csp_postap_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Apps and Databases"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to Data",
+      "name": "Intro to Data",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Good and Bad Data Visualizations",
+      "name": "Good and Bad Data Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Making Data Visualizations",
+      "name": "Making Data Visualizations",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Discover a Data Story",
+      "name": "Discover a Data Story",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Cleaning Data",
+      "name": "Cleaning Data",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Creating Summary Tables",
+      "name": "Creating Summary Tables",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Project - Tell a Data Story",
+      "name": "Project - Tell a Data Story",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Deleting Records",
+      "name": "Deleting Records",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Updating Records",
+      "name": "Updating Records",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Importing and Exporting Data",
+      "name": "Importing and Exporting Data",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Visualizing Data",
+      "name": "Visualizing Data",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Sample Apps",
+      "name": "Sample Apps",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "Final Project",
+      "name": "Final Project",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "key": "CS Principles Post Course survey",
+      "name": "CS Principles Post Course survey",
+      "absolute_position": 17,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L07 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L07 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Quick Check-In"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L10 SFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L10 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection A: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Collection A: Good and Bad Visualizations_2018_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collection B: Good and Bad Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations_2018_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Collection B: Good and Bad Visualizations_2018_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L10 FR why best worst viz_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L11 SFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L11 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Downloading the Data Set"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Downloading the Data Set_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Downloading the Data Set_2018_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Scatter Plot"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Scatter Plot_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Making a Scatter Plot_2018_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Line Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Line Chart_2018_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Making a Line Chart_2018_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Making a Bar Chart"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making a Bar Chart_2018_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Making a Bar Chart_2018_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Editing Chart Appearance"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Editing Chart Appearance_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Editing Chart Appearance_2018_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Data Visualizations - Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Free Play_2018_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L10 FR describe what you made from lesson prompt_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L12 SFLP_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L12 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L12 FR reflection on collaboration_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L13 SFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L13 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Getting to Know Your Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Getting to Know Your Data_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Getting to Know Your Data_2018_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Cleaning Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Cleaning Data_2018_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Cleaning Data_2018_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Categorizing Data"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Categorizing Data_2018_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Categorizing Data_2018_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L13 Cleaning Data MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L13 FR Reflection data analysis objective_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L14 SFLP_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L14 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 1 - The Basics"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics_2018_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 1 - The Basics_2018_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 2 - Manipulation and Visualizations"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "Making Pivot Tables Part 2 - Manipulation and Visualization_2018_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Making Pivot Tables Part 3"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 3_2018_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+        "progression": "Check Your Understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U2L14 Summary Tables MC_2018_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U2L15 SFLP_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "CSP U2L15 SFLP_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video_2018_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External_2018_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External_2018_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - deleteRecord - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation_2018_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation_2018_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Default Block_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Callback Success Parameter_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Update Nonexistent Record_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit UI_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit event handler_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Save edited contact_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - ImportExport - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Charts - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - User Login_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Class Survey_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Clicker Game_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Flashcards_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Final Project - Student Introduction_2018_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "U6 - Final Project - Project Level_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-intro-2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      },
+      "level_keys": [
+        "csp-post-survey-levelgroup-2019.2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L07 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L07 SFLP_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019",
+        "script_level.level_keys": [
+          "csp-pulse-check-survey-3-levelgroup-U2Ch2_2018_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L10 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L10 SFLP_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection A: Good and Bad Visualizations_2018_2019",
+        "script_level.level_keys": [
+          "Collection A: Good and Bad Visualizations_2018_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collection B: Good and Bad Visualizations_2018_2019",
+        "script_level.level_keys": [
+          "Collection B: Good and Bad Visualizations_2018_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR why best worst viz_2019",
+        "script_level.level_keys": [
+          "U2L10 FR why best worst viz_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L11 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L11 SFLP_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Downloading the Data Set_2018_2019",
+        "script_level.level_keys": [
+          "Downloading the Data Set_2018_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Scatter Plot_2018_2019",
+        "script_level.level_keys": [
+          "Making a Scatter Plot_2018_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Line Chart_2018_2019",
+        "script_level.level_keys": [
+          "Making a Line Chart_2018_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making a Bar Chart_2018_2019",
+        "script_level.level_keys": [
+          "Making a Bar Chart_2018_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Editing Chart Appearance_2018_2019",
+        "script_level.level_keys": [
+          "Editing Chart Appearance_2018_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Free Play_2018_2019",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play_2018_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 FR describe what you made from lesson prompt_2019",
+        "script_level.level_keys": [
+          "U2L10 FR describe what you made from lesson prompt_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 8,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L12 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L12 SFLP_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L12 FR reflection on collaboration_2019",
+        "script_level.level_keys": [
+          "U2L12 FR reflection on collaboration_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L13 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L13 SFLP_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Getting to Know Your Data_2018_2019",
+        "script_level.level_keys": [
+          "Getting to Know Your Data_2018_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Cleaning Data_2018_2019",
+        "script_level.level_keys": [
+          "Cleaning Data_2018_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Categorizing Data_2018_2019",
+        "script_level.level_keys": [
+          "Categorizing Data_2018_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Cleaning Data MC_2018_2019",
+        "script_level.level_keys": [
+          "U2L13 Cleaning Data MC_2018_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 FR Reflection data analysis objective_2019",
+        "script_level.level_keys": [
+          "U2L13 FR Reflection data analysis objective_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L14 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L14 SFLP_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 1 - The Basics_2018_2019",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 1 - The Basics_2018_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Making Pivot Tables Part 2 - Manipulation and Visualization_2018_2019",
+        "script_level.level_keys": [
+          "Making Pivot Tables Part 2 - Manipulation and Visualization_2018_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 3_2018_2019",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3_2018_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Summary Tables MC_2018_2019",
+        "script_level.level_keys": [
+          "U2L14 Summary Tables MC_2018_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U2L15 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U2L15 SFLP_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Project - Tell a Data Story",
+        "lesson_group.key": "csp_postap_1",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video_2018_2019",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video_2018_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage_2019",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction_2018_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5_2019",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand_2019",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive_2019",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand_2019",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App_2019",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table_2019",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts_2019",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction_2018_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1_2019",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External_2018_2019",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External_2018_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2_2019",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3_2019",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - deleteRecord - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation_2018_2019",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation_2018_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0_2019",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1_2019",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object_2019",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4_2019",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work_2019",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Default Block_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Callback Success Parameter_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Update Nonexistent Record_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit UI_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit event handler_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Save edited contact_2019",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - ImportExport - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Charts - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2_2019",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - User Login_2019",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Class Survey_2019",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Clicker Game_2019",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Flashcards_2019",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Student Introduction_2018_2019",
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction_2018_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Project Level_2019",
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "csp_postap_2",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-intro-2019",
+        "script_level.level_keys": [
+          "csp-post-survey-intro-2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-post-survey-levelgroup-2019.2",
+        "script_level.level_keys": [
+          "csp-post-survey-levelgroup-2019.2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "CS Principles Post Course survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "csppostap-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit1-support-test.script_json
+++ b/dashboard/config/scripts_json/cspunit1-support-test.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "cspunit1-support-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit1-support-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Unit 1 Overview",
+      "name": "Unit 1 Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "plc csp1 introduction to unit"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      },
+      "level_keys": [
+        "plc csp1 introduction to unit"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "plc csp1 chapter overviews"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      },
+      "level_keys": [
+        "plc csp1 chapter overviews"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "plc csp1 philosophy and commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      },
+      "level_keys": [
+        "plc csp1 philosophy and commentary"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "plc csp1 introduction to unit",
+        "script_level.level_keys": [
+          "plc csp1 introduction to unit"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "plc csp1 chapter overviews",
+        "script_level.level_keys": [
+          "plc csp1 chapter overviews"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "plc csp1 philosophy and commentary",
+        "script_level.level_keys": [
+          "plc csp1 philosophy and commentary"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1 Overview",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-support-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit1-support.script_json
+++ b/dashboard/config/scripts_json/cspunit1-support.script_json
@@ -1,0 +1,661 @@
+{
+  "script": {
+    "name": "cspunit1-support",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit1-support"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to the Unit",
+      "name": "Intro to the Unit",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Chapter Overviews",
+      "name": "Chapter Overviews",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Chapter Overviews",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Tool Talk: Intro to Netsim",
+      "name": "Tool Talk: Intro to Netsim",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Sending Binary Messages",
+      "name": "Sending Binary Messages",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Encoding and Sending Numbers",
+      "name": "Encoding and Sending Numbers",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Supporting Peer Learning",
+      "name": "Supporting Peer Learning",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Supporting Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Running a Constructive Classroom",
+      "name": "Running a Constructive Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Running a Constructive Classroom",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "key": "Strategies for Student Writing",
+      "name": "Strategies for Student Writing",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Strategies for Student Writing",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sample Free Response"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Sample Free Response"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "U1L5 How the Internet Works - Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sample External Resource"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Sample External Resource"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Chapter Overviews",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Sample CSP Assessment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Sample CSP Assessment"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "Empty Markdown Level"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Supporting Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "U3L2 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Running a Constructive Classroom",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "U3L2 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Strategies for Student Writing",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      },
+      "level_keys": [
+        "U3L2 Free Response Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Sample Free Response",
+        "script_level.level_keys": [
+          "Sample Free Response"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 How the Internet Works - Video",
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sample External Resource",
+        "script_level.level_keys": [
+          "Sample External Resource"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro to the Unit",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Chapter Overviews",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Sample CSP Assessment",
+        "script_level.level_keys": [
+          "Sample CSP Assessment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Tool Talk: Intro to Netsim",
+        "lesson_group.key": "required",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Empty Markdown Level",
+        "script_level.level_keys": [
+          "Empty Markdown Level"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Numbers",
+        "lesson_group.key": "content",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Supporting Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Running a Constructive Classroom",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L2 Free Response Reflection"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Strategies for Student Writing",
+        "lesson_group.key": "practice",
+        "script.name": "cspunit1-support"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit1-tools.script_json
+++ b/dashboard/config/scripts_json/cspunit1-tools.script_json
@@ -1,0 +1,84 @@
+{
+  "script": {
+    "name": "cspunit1-tools",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit1-tools"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit1-tools"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "netsim",
+      "name": "netsim",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "netsim",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-tools"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "plc csp1 intro to tools"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "netsim",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-tools"
+      },
+      "level_keys": [
+        "plc csp1 intro to tools"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "plc csp1 intro to tools",
+        "script_level.level_keys": [
+          "plc csp1 intro to tools"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "netsim",
+        "lesson_group.key": "",
+        "script.name": "cspunit1-tools"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit1.script_json
+++ b/dashboard/config/scripts_json/cspunit1.script_json
@@ -1,0 +1,2688 @@
+{
+  "script": {
+    "name": "cspunit1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Personal Innovations",
+      "name": "Personal Innovations",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Binary Messages",
+      "name": "Sending Binary Messages",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Complex Messages",
+      "name": "Sending Complex Messages",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Binary Messages with the Internet Simulator",
+      "name": "Sending Binary Messages with the Internet Simulator",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Bits in the Real World",
+      "name": "Sending Bits in the Real World",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Number Systems",
+      "name": "Number Systems",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Binary Numbers",
+      "name": "Binary Numbers",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Numbers",
+      "name": "Sending Numbers",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Encoding Numbers in the Real World",
+      "name": "Encoding Numbers in the Real World",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Encoding and Sending Text",
+      "name": "Encoding and Sending Text",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Sending Formatted Text",
+      "name": "Sending Formatted Text",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Bytes and File Sizes",
+      "name": "Bytes and File Sizes",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Encoding B&W Images",
+      "name": "Encoding B&W Images",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Encoding Color Images",
+      "name": "Encoding Color Images",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Lossy Compression and File Formats",
+      "name": "Lossy Compression and File Formats",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "key": "Encode a Complex Thing",
+      "name": "Encode an Experience",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encode a Complex Thing",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L1 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 Innovation - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L1 Innovation - Video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 - FR computer science word association"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L1 - FR computer science word association"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L2 Multiple Choice Assessment Question"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L2 Free response assessment question"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L2 Free response reflection question"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L2 Free response reflection question"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L3 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L3 Free response reflection question"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L3 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L3 Free Response"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L3 Free Response"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L4 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L4 NetSim SendAB"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L4 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L4 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L5 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L5 How the Internet Works - Video"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L5 Matching Assessment"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L6 Assessment multiple choice"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L6 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L7 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Odometer"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L7 Free Response Assessment"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L7 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L8 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 NetSim numbers with decimal"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L8 NetSim numbers with decimal"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L8 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Free Response2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L8 Free Response2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L8 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L9 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Free Response Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L9 Free Response Assessment"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 NetSim numbers with decimal"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L10 NetSim numbers with decimal"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Assessment Free Response"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L10 Assessment Free Response"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 NetSim numbers with Ascii"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 NetSim numbers with Ascii"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Assessment 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Reflection Free Response"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 Reflection Free Response"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Collaboration Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L11 Collaboration Reflection"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L12 Reflection Free Response"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Student Lesson Summary"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 Text Compression"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 - Assess Text Compression reverse process"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 Assess Text Compression amount"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L13 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 Student Lesson Summary"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L14 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make the Letter A"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Fix bit offset"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 14 - Make your own B and W Image"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 Assessment 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L14 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L14 - Assessment 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L15 Student Lesson Summary"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L15 Student Lesson Summary"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation Flappy"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation Bee"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Favicon Instructions"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Favicon Instructions"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Free Play"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Free Play"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "a bit about pixels"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "a bit about pixels"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L16 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L16 - Matching File Compression Types"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L16 - Matching File Compression Types"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Encode a Complex Thing",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      },
+      "level_keys": [
+        "U1L17 Student Lesson Introduction"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U1L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L1 Innovation - Video",
+        "script_level.level_keys": [
+          "U1L1 Innovation - Video"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L1 - FR computer science word association",
+        "script_level.level_keys": [
+          "U1L1 - FR computer science word association"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Multiple Choice Assessment Question",
+        "script_level.level_keys": [
+          "U1L2 Multiple Choice Assessment Question"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Free response assessment question",
+        "script_level.level_keys": [
+          "U1L2 Free response assessment question"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L2 Free response reflection question",
+        "script_level.level_keys": [
+          "U1L2 Free response reflection question"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free response reflection question",
+        "script_level.level_keys": [
+          "U1L3 Free response reflection question"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L3 Multiple Choice"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L3 Free Response",
+        "script_level.level_keys": [
+          "U1L3 Free Response"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Sending Complex Messages",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 NetSim SendAB",
+        "script_level.level_keys": [
+          "U1L4 NetSim SendAB"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L4 Multiple Choice"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L4 Free Response Reflection"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Sending Binary Messages with the Internet Simulator",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 How the Internet Works - Video",
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 Matching Assessment",
+        "script_level.level_keys": [
+          "U1L5 Matching Assessment"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sending Bits in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Assessment multiple choice",
+        "script_level.level_keys": [
+          "U1L6 Assessment multiple choice"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L6 Free Response Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Number Systems",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Odometer",
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Assessment",
+        "script_level.level_keys": [
+          "U1L7 Free Response Assessment"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L7 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L7 Free Response Reflection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Binary Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 NetSim numbers with decimal",
+        "script_level.level_keys": [
+          "U1L8 NetSim numbers with decimal"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Free Response Reflection",
+        "script_level.level_keys": [
+          "U1L8 Free Response Reflection"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Free Response2",
+        "script_level.level_keys": [
+          "U1L8 Free Response2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L8 Multiple Choice",
+        "script_level.level_keys": [
+          "U1L8 Multiple Choice"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Free Response Assessment",
+        "script_level.level_keys": [
+          "U1L9 Free Response Assessment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Numbers in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 NetSim numbers with decimal",
+        "script_level.level_keys": [
+          "U1L10 NetSim numbers with decimal"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 1",
+        "script_level.level_keys": [
+          "U1L10 Assessment 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment 2",
+        "script_level.level_keys": [
+          "U1L10 Assessment 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Assessment Free Response",
+        "script_level.level_keys": [
+          "U1L10 Assessment Free Response"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Encoding and Sending Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 NetSim numbers with Ascii",
+        "script_level.level_keys": [
+          "U1L11 NetSim numbers with Ascii"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 1",
+        "script_level.level_keys": [
+          "U1L11 Assessment 1"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Assessment 2",
+        "script_level.level_keys": [
+          "U1L11 Assessment 2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Reflection Free Response",
+        "script_level.level_keys": [
+          "U1L11 Reflection Free Response"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Collaboration Reflection",
+        "script_level.level_keys": [
+          "U1L11 Collaboration Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Sending Formatted Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L12 Reflection Free Response",
+        "script_level.level_keys": [
+          "U1L12 Reflection Free Response"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Bytes and File Sizes",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Student Lesson Summary",
+        "script_level.level_keys": [
+          "U1L13 Student Lesson Summary"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Text Compression",
+        "script_level.level_keys": [
+          "U1L13 Text Compression"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 - Assess Text Compression reverse process",
+        "script_level.level_keys": [
+          "U1L13 - Assess Text Compression reverse process"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 3,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assess Text Compression amount",
+        "script_level.level_keys": [
+          "U1L13 Assess Text Compression amount"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 4,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 1",
+        "script_level.level_keys": [
+          "U1L13 Assessment 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 5,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L13 Assessment 2",
+        "script_level.level_keys": [
+          "U1L13 Assessment 2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 6,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 Student Lesson Summary",
+        "script_level.level_keys": [
+          "U1L14 Student Lesson Summary"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make the Letter A",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make the Letter A"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Fix bit offset",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Fix bit offset"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 14 - Make your own B and W Image",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 14 - Make your own B and W Image"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 Assessment 1",
+        "script_level.level_keys": [
+          "U1L14 Assessment 1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L14 - Assessment 2",
+        "script_level.level_keys": [
+          "U1L14 - Assessment 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Encoding B&W Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L15 Student Lesson Summary",
+        "script_level.level_keys": [
+          "U1L15 Student Lesson Summary"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy",
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee",
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Favicon Instructions",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Favicon Instructions"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Free Play",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Free Play"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "a bit about pixels",
+        "script_level.level_keys": [
+          "a bit about pixels"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Encoding Color Images",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L16 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L16 - Matching File Compression Types",
+        "script_level.level_keys": [
+          "U1L16 - Matching File Compression Types"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "Lossy Compression and File Formats",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L17 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Encode a Complex Thing",
+        "lesson_group.key": "",
+        "script.name": "cspunit1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit2.script_json
+++ b/dashboard/config/scripts_json/cspunit2.script_json
@@ -1,0 +1,4200 @@
+{
+  "script": {
+    "name": "cspunit2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Internet",
+      "name": "The Internet Is for Everyone",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "The Need for Addressing",
+      "name": "The Need for Addressing",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Invent an Addressing Protocol",
+      "name": "Invent an Addressing Protocol",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Routers and Redundancy",
+      "name": "Routers and Redundancy",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Packets and Making a Reliable Internet",
+      "name": "Packets and Making a Reliable Internet",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Algorithms Detour - Minimum Spanning Tree",
+      "name": "Algorithms Detour - Minimum Spanning Tree",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Algorithms Detour - Shortest Path",
+      "name": "Algorithms Detour - Shortest Path",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Algorithms Detour - How Routers Learn",
+      "name": "How Routers Learn",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "The Need for DNS",
+      "name": "The Need for DNS",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "DNS in the Real World",
+      "name": "DNS in the Real World",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "HTTP and Abstraction",
+      "name": "HTTP and Abstraction on the Internet",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Practice PT - The Internet and Society",
+      "name": "Practice PT - The Internet and Society",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Tell Me a Secret - Encrypting Text",
+      "name": "The Need for Encryption",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Cracking the Code",
+      "name": "Cracking the Code",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Encryption Algorithms",
+      "name": "Keys and Passwords",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Algorithms Detour - Hard Problems TSP",
+      "name": "Hard Problems - The Traveling Salesperson Problem",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "One Way Functions - Ice Cream Vans",
+      "name": "One-Way Functions - The WiFi Hotspot Problem",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Alice and Bob and Asymmetric Keys",
+      "name": "Asymmetric Keys - Cups and Beans",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Public Key Crypto",
+      "name": "Public Key Cryptography",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "key": "Practice PT - Cybersecurity Innovations",
+      "name": "Practice PT - Cybersecurity Innovations",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L1 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L01 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L01 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L01 Assessment 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L01 Assessment 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L01 Assessment 4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L2 NetSim Hub Mode"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L02 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L02 Assessment 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L02 Assessment 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L02 Assessment 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L02 Assessment 5"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3: IP DNS Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3: IP DNS Video"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 Assessment"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 NetSim Hub Mode"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 Assessment 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Assessment 4"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L3 Assessment 4"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L4 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 - NetSim Routers with Addresses"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 - NetSim Routers with Addresses"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 Assessment4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 Assessment5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L04 Assessment3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L04 Assessment3"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L5 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 - NetSim - Packets and Building TCP"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L05 - NetSim - Packets and Building TCP"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L5 Packets and Reliability - Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L5 Packets and Reliability - Video"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L05 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Assessment 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L05 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L05 Reflection 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L05 Reflection 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L6 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06 - Matching: Label the Diagram"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L06 - Matching: Label the Diagram"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06- MC: what is an MST?"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L06- MC: what is an MST?"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L06 - MC: Which is an MST?"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L06 - MC: Which is an MST?"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L7 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L07 Assessment 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U1L07 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L07 Assessment2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L07 Assessment3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L07 Assessment4"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L07 Assessment5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L07 Assessment5"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L8 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L08 Free Response 3"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L08 Free Response 1"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Free Response 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L08 Free Response 2"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Assessment 0"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L08 Assessment 0"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L08 Assessment 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L08 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L9 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 NetSim Automatic DNS"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L09 Assessment1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Assessment2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L09 Assessment2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L09 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Free Response Getting Started"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Assessment1"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Assessment2"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Assessment3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Assessment3"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L10 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 HTTP and HTML - Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 HTTP and HTML - Video"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L11 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Assessment 2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L11 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L11 Free Response"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L11 Free Response"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 frequency caesar"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 frequency caesar"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Assessment1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Assessment3"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Assessment4"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Assessment4"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L13 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 frequency random sub"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 frequency random sub"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 vigenere cipher"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 vigenere cipher"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Assessment"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Assessment2"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment3"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Assessment3"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L14 Assessment4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L14 Assessment4"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L15 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L15 Assessment1"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L15 Assessment2"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L15 Assessment3"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L15 Assessment4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L15 Assessment4"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Assessment 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Assessment 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L16 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L16 Free Response Assessment 3"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Response Getting Started"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 Free Responses Assessment 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 Free Responses Assessment 1"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L17 - Vocabulary matching"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L17 - Vocabulary matching"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Getting Started"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Assessment"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Assessment"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L16 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 Encryption and Public Keys - Video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 Encryption and Public Keys - Video"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Free Response Assessment 1"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Match terms to cups and beans analogy"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L18 Free Response Assessment 3"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 mutlichoice 20 mod 15"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 multichoice 13 MOD 17"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Assessment"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 Assessment"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L19 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L20 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2L20 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 The Internet: Cybersecurity and Crime - Video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 The Internet: Cybersecurity and Crime - Video"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2 Encryption and Public Keys - Video"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      },
+      "level_keys": [
+        "U2 Encryption and Public Keys - Video"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U2L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L1 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 1",
+        "script_level.level_keys": [
+          "U2L01 Assessment 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 2",
+        "script_level.level_keys": [
+          "U2L01 Assessment 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 3",
+        "script_level.level_keys": [
+          "U2L01 Assessment 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L01 Assessment 4",
+        "script_level.level_keys": [
+          "U2L01 Assessment 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "The Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 NetSim Hub Mode",
+        "script_level.level_keys": [
+          "U2L2 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Free Response Reflection",
+        "script_level.level_keys": [
+          "U2L02 Free Response Reflection"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 3",
+        "script_level.level_keys": [
+          "U2L02 Assessment 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 4",
+        "script_level.level_keys": [
+          "U2L02 Assessment 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L02 Assessment 5",
+        "script_level.level_keys": [
+          "U2L02 Assessment 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "The Need for Addressing",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L3 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3: IP DNS Video",
+        "script_level.level_keys": [
+          "U2L3: IP DNS Video"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment",
+        "script_level.level_keys": [
+          "U2L3 Assessment"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 NetSim Hub Mode",
+        "script_level.level_keys": [
+          "U2L3 NetSim Hub Mode"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 2",
+        "script_level.level_keys": [
+          "U2L3 Assessment 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 3",
+        "script_level.level_keys": [
+          "U2L3 Assessment 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Assessment 4",
+        "script_level.level_keys": [
+          "U2L3 Assessment 4"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Invent an Addressing Protocol",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L4 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L4 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 - NetSim Routers with Addresses",
+        "script_level.level_keys": [
+          "U2L04 - NetSim Routers with Addresses"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment1",
+        "script_level.level_keys": [
+          "U2L04 Assessment1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment4",
+        "script_level.level_keys": [
+          "U2L04 Assessment4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment5",
+        "script_level.level_keys": [
+          "U2L04 Assessment5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment2",
+        "script_level.level_keys": [
+          "U2L04 Assessment2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L04 Assessment3",
+        "script_level.level_keys": [
+          "U2L04 Assessment3"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 7,
+        "lesson.key": "Routers and Redundancy",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L5 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 - NetSim - Packets and Building TCP",
+        "script_level.level_keys": [
+          "U2L05 - NetSim - Packets and Building TCP"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L5 Packets and Reliability - Video",
+        "script_level.level_keys": [
+          "U2L5 Packets and Reliability - Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 1",
+        "script_level.level_keys": [
+          "U2L05 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Assessment 2",
+        "script_level.level_keys": [
+          "U2L05 Assessment 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L05 Reflection 1",
+        "script_level.level_keys": [
+          "U2L05 Reflection 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Packets and Making a Reliable Internet",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L6 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L6 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06 - Matching: Label the Diagram",
+        "script_level.level_keys": [
+          "U2L06 - Matching: Label the Diagram"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06- MC: what is an MST?",
+        "script_level.level_keys": [
+          "U2L06- MC: what is an MST?"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L06 - MC: Which is an MST?",
+        "script_level.level_keys": [
+          "U2L06 - MC: Which is an MST?"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Minimum Spanning Tree",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L7 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L7 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L07 Assessment 1",
+        "script_level.level_keys": [
+          "U1L07 Assessment 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment2",
+        "script_level.level_keys": [
+          "U2L07 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment3",
+        "script_level.level_keys": [
+          "U2L07 Assessment3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment4",
+        "script_level.level_keys": [
+          "U2L07 Assessment4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L07 Assessment5",
+        "script_level.level_keys": [
+          "U2L07 Assessment5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms Detour - Shortest Path",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L8 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L8 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 3",
+        "script_level.level_keys": [
+          "U2L08 Free Response 3"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 1",
+        "script_level.level_keys": [
+          "U2L08 Free Response 1"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Free Response 2",
+        "script_level.level_keys": [
+          "U2L08 Free Response 2"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Assessment 0",
+        "script_level.level_keys": [
+          "U2L08 Assessment 0"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L08 Assessment 1",
+        "script_level.level_keys": [
+          "U2L08 Assessment 1"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Algorithms Detour - How Routers Learn",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L9 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L9 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 NetSim Automatic DNS",
+        "script_level.level_keys": [
+          "U2L10 NetSim Automatic DNS"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment1",
+        "script_level.level_keys": [
+          "U2L09 Assessment1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Assessment2",
+        "script_level.level_keys": [
+          "U2L09 Assessment2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L09 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L09 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "The Need for DNS",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L10 Free Response Getting Started"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment1",
+        "script_level.level_keys": [
+          "U2L10 Assessment1"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment2",
+        "script_level.level_keys": [
+          "U2L10 Assessment2"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Assessment3",
+        "script_level.level_keys": [
+          "U2L10 Assessment3"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L10 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "DNS in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 HTTP and HTML - Video",
+        "script_level.level_keys": [
+          "U2 HTTP and HTML - Video"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 1",
+        "script_level.level_keys": [
+          "U2L11 Assessment 1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Assessment 2",
+        "script_level.level_keys": [
+          "U2L11 Assessment 2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L11 Free Response",
+        "script_level.level_keys": [
+          "U2L11 Free Response"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "HTTP and Abstraction",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - The Internet and Society",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 frequency caesar",
+        "script_level.level_keys": [
+          "U2 frequency caesar"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L13 Free Response Getting Started"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment1",
+        "script_level.level_keys": [
+          "U2L13 Assessment1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment3",
+        "script_level.level_keys": [
+          "U2L13 Assessment3"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Assessment4",
+        "script_level.level_keys": [
+          "U2L13 Assessment4"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L13 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L13 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Tell Me a Secret - Encrypting Text",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 frequency random sub",
+        "script_level.level_keys": [
+          "U2 frequency random sub"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 vigenere cipher",
+        "script_level.level_keys": [
+          "U2 vigenere cipher"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L14 Free Response Getting Started"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment",
+        "script_level.level_keys": [
+          "U2L14 Assessment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L14 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment2",
+        "script_level.level_keys": [
+          "U2L14 Assessment2"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment3",
+        "script_level.level_keys": [
+          "U2L14 Assessment3"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L14 Assessment4",
+        "script_level.level_keys": [
+          "U2L14 Assessment4"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Cracking the Code",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 1,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment1",
+        "script_level.level_keys": [
+          "U2L15 Assessment1"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 2,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment2",
+        "script_level.level_keys": [
+          "U2L15 Assessment2"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 3,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment3",
+        "script_level.level_keys": [
+          "U2L15 Assessment3"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 4,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L15 Assessment4",
+        "script_level.level_keys": [
+          "U2L15 Assessment4"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 5,
+        "lesson.key": "Encryption Algorithms",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Assessment 1",
+        "script_level.level_keys": [
+          "U2L17 Assessment 1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Assessment 2",
+        "script_level.level_keys": [
+          "U2L17 Assessment 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L16 Free Response Assessment 3",
+        "script_level.level_keys": [
+          "U2L16 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L17 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Algorithms Detour - Hard Problems TSP",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L17 Free Response Getting Started"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 2,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 Free Responses Assessment 1",
+        "script_level.level_keys": [
+          "U2L17 Free Responses Assessment 1"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 3,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L17 - Vocabulary matching",
+        "script_level.level_keys": [
+          "U2L17 - Vocabulary matching"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 4,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L18 Free Response Getting Started"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 5,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Assessment",
+        "script_level.level_keys": [
+          "U2L18 Assessment"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 6,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L18 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 7,
+        "lesson.key": "One Way Functions - Ice Cream Vans",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L16 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 Encryption and Public Keys - Video",
+        "script_level.level_keys": [
+          "U2 Encryption and Public Keys - Video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Assessment 1",
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Match terms to cups and beans analogy",
+        "script_level.level_keys": [
+          "U2L18 Match terms to cups and beans analogy"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L18 Free Response Assessment 3",
+        "script_level.level_keys": [
+          "U2L18 Free Response Assessment 3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Alice and Bob and Asymmetric Keys",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L19 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U2L19 Free Response Getting Started"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 mutlichoice 20 mod 15",
+        "script_level.level_keys": [
+          "U2L19 mutlichoice 20 mod 15"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 multichoice 13 MOD 17",
+        "script_level.level_keys": [
+          "U2L19 multichoice 13 MOD 17"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Assessment",
+        "script_level.level_keys": [
+          "U2L19 Assessment"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L19 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U2L19 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Public Key Crypto",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L20 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U2L20 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 The Internet: Cybersecurity and Crime - Video",
+        "script_level.level_keys": [
+          "U2 The Internet: Cybersecurity and Crime - Video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2 Encryption and Public Keys - Video",
+        "script_level.level_keys": [
+          "U2 Encryption and Public Keys - Video"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Cybersecurity Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit3.script_json
+++ b/dashboard/config/scripts_json/cspunit3.script_json
@@ -1,0 +1,11921 @@
+{
+  "script": {
+    "name": "cspunit3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Need For Programming Languages",
+      "name": "The Need For Programming Languages",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Using Simple Commands",
+      "name": "Using Simple Commands",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Creating Functions",
+      "name": "Creating Functions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Functions and Top-Down Design",
+      "name": "Functions and Top-Down Design",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "APIs and Function Parameters",
+      "name": "APIs and Function Parameters",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Creating Functions with Parameters",
+      "name": "Creating Functions with Parameters",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Looping and Random Numbers",
+      "name": "Looping and Random Numbers",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Practice PT - Design a Digital Scene",
+      "name": "Practice PT - Design a Digital Scene",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Events Unplugged",
+      "name": "Events Unplugged",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events Unplugged",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Event-Driven Programming and Debugging",
+      "name": "Event-Driven Programming and Debugging",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Beyond Buttons Toward Apps",
+      "name": "Beyond Buttons Toward Apps",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Introducing Design Mode",
+      "name": "Introducing Design Mode",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Multi-screen Apps",
+      "name": "Multi-screen Apps",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Controlling Memory with Variables",
+      "name": "Controlling Memory with Variables",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Using Variables in Apps",
+      "name": "Using Variables in Apps",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "User Input and Strings",
+      "name": "User Input and Strings",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Introduction to Digital Assistants",
+      "name": "Introduction to Digital Assistants",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Understanding Program Flow and Logic",
+      "name": "Understanding Program Flow and Logic",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Introduction to Conditional Logic",
+      "name": "Introduction to Conditional Logic",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Compound Conditional Logic",
+      "name": "Compound Conditional Logic",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Digital Assistant Project",
+      "name": "Digital Assistant Project",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Assistant Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Image Scroller with Key Events",
+      "name": "Image Scroller with Key Events",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Canvas and Arrays in Apps",
+      "name": "Canvas and Arrays in Apps",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "key": "Practice PT: Create",
+      "name": "Practice PT: Create",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L01 Assessment1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L01 Assessment3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L02 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L2 Using Simple Commands"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L2_TurtleSquare_right"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L2_Turtle3by3Grid"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L02 Assessment"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L02 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L02 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Define and use turnAround"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 - draw rect function"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 - draw step"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 - multiselect - properties of functions"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Assessment"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L03 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "u3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "u3L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L04 - snowflake"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L04 - 3 by 3 with functions"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L04 Assessment1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L04 Assessment2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L04 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 - moveForwardwithParams"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 1 triangle"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 2 purple square"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 3 fill pink"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 4 bullseye"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 6 squiggles"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 5 overlapping circles"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 7 smiley face"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Challenge 8 make your own"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Assessment2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06-API-multichoice"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L06 Assessment"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - drawSquareWithParam"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - createTriangleParam"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - squareTwoParams"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - createTwoParamTriangle"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - introUnderTheSea"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - paramsToStarfish"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - fish"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - multiParamFish"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - randomInput"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - freePlay"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 Assessment1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 Assessment2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - introSquare"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - randomSquare"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - randomDots1"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - loopsWithRandom"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - topDownDesign"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - bubbles"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - fish"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - seaStar"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - seaGrass"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - allSeaGrass"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - sunBeams"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - Free Play Loops and Random"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 - MC remove line of code loops"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L07 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - individualCode"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L08 - digitalScene"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L12 - Student Introduction 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Events Unplugged",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L12 - Student Introduction 1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Turtle move with button"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U313 drag Two Buttons"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U313 drag Two Buttons"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 eventsDetails"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 eventsDetails"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U313 Two Buttons with Ids"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U313 Two Buttons with Ids"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debug Id Problem"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Debug Id Problem"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debugging 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Debugging 1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debugging 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Debugging 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Debugging 3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Debugging 3"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Turtle Driver Project"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Turtle Driver Project"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 debugging Multi"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 debugging Multi"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 Free Response Reflection"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 Free Response Reflection"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - MC order of button and onEvent"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - MC order of button and onEvent"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - MC Duplicate Ids"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - MC Duplicate Ids"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - singleSetPosition"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - singleSetPosition"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - introSetPosition"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - introSetPosition"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - setPosition to move button"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - setPosition to move button"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - newEventTypes"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - newEventTypes"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Matching Events to Description"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Matching Events to Description"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - text labels"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - text labels"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - use images"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - chooseImages"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - chooseImages"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - chaserApp"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - chaserApp"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3- L12 -Design Mode SFLP"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3- L12 -Design Mode SFLP"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode 1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode 1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-Design Mode-ID and Event Handler"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3-Design Mode-ID and Event Handler"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode - WTF Console Log"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode - WTF Console Log"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode - Console Log"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode - Console Log"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode - Layers and Delete"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode - Layers and Delete"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode - Multi Screens"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode - Multi Screens"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode - Multi Screens 2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode - Multi Screens 2"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-Design Mode-Image"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3-Design Mode-Image"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Design Mode -Recreate Beyond Buttons"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Design Mode -Recreate Beyond Buttons"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 Student Facing Lesson Plan"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 Student Facing Lesson Plan"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L13 - Project"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L13 - Project"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 Student Lesson Intro"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 Student Lesson Intro"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Message - basic mechanics of variables"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Message - basic mechanics of variables"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - three basic ops of variables"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - three basic ops of variables"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - fix the var name syntax error v2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - fix the var name syntax error v2"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - write var and string with same name v2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - write var and string with same name v2"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3- Variables - Create And Assign"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3- Variables - Create And Assign"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3- Variables - Text Mode"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3- Variables - Text Mode"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Message - Other ways to assign values"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Message - Other ways to assign values"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Variables - Set to Expression"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Variables - Set to Expression"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - concatenate simple"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - concatenate simple"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Variables - Set to Expression with Other Variables"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Variables - Set to Expression with Other Variables"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Assigning Random Value"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Assigning Random Value"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Mini Calculator embed"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Mini Calculator embed"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - User Input Division calculator"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - User Input Division calculator"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - test reassignment of two vars"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - test reassignment of two vars"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3-Variables-Memory Breakdown"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3-Variables-Memory Breakdown"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - Variable ReAssignment pt2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - Variable ReAssignment pt2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge2"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge3"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge3"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge4"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge4"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge5"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge5"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge6"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - moving memory challenge6"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - variable reassignment challenge pt2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - variable reassignment challenge pt2"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 25,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L14 - MC variable reassignment"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L14 - MC variable reassignment"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 Student Lesson Intro - new"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 Student Lesson Intro - new"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 full clicker demo"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 full clicker demo"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - practice with setText"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - practice with setText"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - DEMO up down count practice app"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - DEMO up down count practice app"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - global var example count up"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - global var example count up"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - variable scoping problem debugging"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - variable scoping problem debugging"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 spot the difference variable debugging"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 spot the difference variable debugging"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L19 - variable scope explanation pt2"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L19 - variable scope explanation pt2"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - add code to make count down work"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - add code to make count down work"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug forget to set text"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - count upDown bug forget to set text"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug var not created globally"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - count upDown bug var not created globally"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug logic error wrong update"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - count upDown bug logic error wrong update"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - mini clicker update score"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - mini clicker update score"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 click add lives"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 14,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 click add lives"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - explanation of IF and =v=="
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 15,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - explanation of IF and =v=="
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - Simple If-statements in UpDown App"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 16,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - Simple If-statements in UpDown App"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - Add reset button to UpDown app"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 17,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - Add reset button to UpDown app"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - Debugging Simple If-statements =v=="
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 18,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - Debugging Simple If-statements =v=="
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - Debug forget to update var on reset in UpDown app"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 19,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - Debug forget to update var on reset in UpDown app"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 - Debug if never triggers in UpDown app"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 20,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 - Debug if never triggers in UpDown app"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L15 full clicker app"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 21,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L15 full clicker app"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L26 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L26 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Demo"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib Demo"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - introStrings"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - introStrings"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - doubleQuotes"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - doubleQuotes"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - textInput getText write"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - textInput getText write"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - intro getText"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - intro getText"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - User Input - Save getText To Variable"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - User Input - Save getText To Variable"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - outputWithTextArea"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - outputWithTextArea"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - toUpper"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - toUpper"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Student Setup"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib Student Setup"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib setText"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib setText"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib getText"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib getText"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib toUpper"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib toUpper"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Clear Input"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 Mad Lib Clear Input"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 Free Response 3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L25 Free Response 3"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L23 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L23 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L23 Free Response Getting Started"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L23 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Digital Assistant Target"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 Digital Assistant Target"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L16 - challenge say hi app"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L16 - challenge say hi app"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Digital Assistant Design"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 Digital Assistant Design"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Digital Assistant Set Text"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 Digital Assistant Set Text"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L23 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L23 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L20 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L20 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Boolean Expressions and Operators"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Boolean Expressions and Operators"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L18 comparison operators"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L18 comparison operators"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L18 Matching"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L18 Matching"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Translating Flowcharts - If Statement"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Translating Flowcharts - If Statement"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - High Low - If"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - High Low - If"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - High Low - Dropdown"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - High Low - Dropdown"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditional Basics - 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 8,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditional Basics - 6"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Introducing Else"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 9,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Introducing Else"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - High Low - Else"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 10,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - High Low - Else"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Translating Flowcharts - Chained"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 11,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Translating Flowcharts - Chained"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - High Low - Else if"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 12,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - High Low - Else if"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - High Low - Debug"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 13,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - High Low - Debug"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Dice - If"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 14,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Dice - If"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Dice - Dropdown and Score"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 15,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Dice - Dropdown and Score"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Dice - Dropdown with Strings"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 16,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Dice - Dropdown with Strings"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Dice - Nested"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 17,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Dice - Nested"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L24 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L24 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L23 Chatbot Conditionals 1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L23 Chatbot Conditionals 1"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Movie Bot - toLowerCase"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Movie Bot - toLowerCase"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L24 introIncludes"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L24 introIncludes"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L24 Nested Conditionals 1"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L24 Nested Conditionals 1"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Movie Bot - Nested Motivation"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Movie Bot - Nested Motivation"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L24 Nested Conditionals 2"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L24 Nested Conditionals 2"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 1,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L25 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Simple OR"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 2,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Simple OR"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Simple AND"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 3,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Simple AND"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L20 - combining And and Or explanation"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 4,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L20 - combining And and Or explanation"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Combine AND OR Simple"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 5,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Combine AND OR Simple"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Conditionals - Combine AND OR and NOT"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 6,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Conditionals - Combine AND OR and NOT"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L26 OR operator"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 7,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L26 OR operator"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Movie Bot - Multiple If Sequences"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 8,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Movie Bot - Multiple If Sequences"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L26 AND operator"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 9,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L26 AND operator"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Movie Bot - When Multiple If Statements"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 10,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Movie Bot - When Multiple If Statements"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L21 Student Lesson Introduction v2"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 1,
+        "lesson.key": "Digital Assistant Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L21 Student Lesson Introduction v2"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L24 Chatbot Basic Conditionals"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 2,
+        "lesson.key": "Digital Assistant Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L24 Chatbot Basic Conditionals"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L28 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L28 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 1"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 1"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 2"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 2"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 3"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 3"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - Typing in Console"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 4"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 4"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 5"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 5"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 8"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 8"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 6"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 6"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 7"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 7"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 9"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 9"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops -  Complex Condition"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 10"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 10"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 11"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 11"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 12"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 12"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - Plus Plus"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - Minus Minus"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - plus and minus = operator"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - minus = operator"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 14"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 14"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 15"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops - 15"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L29 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L29 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - Intro"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - Intro"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 1"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2.1"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2.5"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Simulation Updating Hypotheses"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 Simulation Updating Hypotheses"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 3"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 4"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 5"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Simulations Hypotheses Reflections"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 Simulations Hypotheses Reflections"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Simulation - 6"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L30 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L30 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - createFirstArray"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - appendItem"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - introIndex"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - indexPractice"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment2"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment3"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - stringsInArrays"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - insertingItems"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - remove"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - insertionErrors"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - length"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - length"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - lengthMinus1"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - expressionsAsIndexes"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - Demo App"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings giveIDs"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings createArray"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings firstOutput"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Counting Variable"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Next"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Prev"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings addItem"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings bounds"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings keepPlaying"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 26,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - Wrap Up 1"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 27,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays - Wrap Up 2"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L31 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L31 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 2,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Demo App"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 3,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L25 - drag out key event"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 4,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Key Up and Down"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 5,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L25 - play sound when up key"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 6,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Multiple Keys"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 7,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Buttons and Keys"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 8,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Functions"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 9,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Add Image URLs"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Final Image Scroller"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 10,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Keys - Final Image Scroller"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 11,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3- Keys - Code Refactoring Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L32 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L32 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Intro For Loop"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Print Array"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Add 5"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Divid by 2"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Loop Array If"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Linear Search"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Counting Times"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Printing Single True"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Search with Boolean Var"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Make it a Function"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Make it a Function - add list parameter"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - General Search Param"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Find Min"
+      ]
+    },
+    {
+      "chapter": 299,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L27 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L27 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 300,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays and Loops - Explain Functions with Returns"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Arrays and Loops - Explain Functions with Returns"
+      ]
+    },
+    {
+      "chapter": 301,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - useMinVal"
+      ]
+    },
+    {
+      "chapter": 302,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - writeMaxVal"
+      ]
+    },
+    {
+      "chapter": 303,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - debuggingMaxVal"
+      ]
+    },
+    {
+      "chapter": 304,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - debuggingConstrain"
+      ]
+    },
+    {
+      "chapter": 305,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - constrainTurtle"
+      ]
+    },
+    {
+      "chapter": 306,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Return Values - wrapTurtle"
+      ]
+    },
+    {
+      "chapter": 307,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L33 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 1,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L33 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 308,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 2,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - introCanvas"
+      ]
+    },
+    {
+      "chapter": 309,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 3,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - 200dots"
+      ]
+    },
+    {
+      "chapter": 310,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 4,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - transparentDots"
+      ]
+    },
+    {
+      "chapter": 311,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 5,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - clickToAdd"
+      ]
+    },
+    {
+      "chapter": 312,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 6,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - usingOffsetXY"
+      ]
+    },
+    {
+      "chapter": 313,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 7,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - draw at click point"
+      ]
+    },
+    {
+      "chapter": 314,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 8,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - changeToMouseMove"
+      ]
+    },
+    {
+      "chapter": 315,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 9,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - shiftKey"
+      ]
+    },
+    {
+      "chapter": 316,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 10,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - appendToArray"
+      ]
+    },
+    {
+      "chapter": 317,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 11,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - delete"
+      ]
+    },
+    {
+      "chapter": 318,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 12,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawRandom"
+      ]
+    },
+    {
+      "chapter": 319,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 13,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawRandom2"
+      ]
+    },
+    {
+      "chapter": 320,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 14,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawOriginal"
+      ]
+    },
+    {
+      "chapter": 321,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 15,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - movementFunction"
+      ]
+    },
+    {
+      "chapter": 322,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 16,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - movementFunction fix Orig"
+      ]
+    },
+    {
+      "chapter": 323,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - One Dot sprayPaint"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 17,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - One Dot sprayPaint"
+      ]
+    },
+    {
+      "chapter": 324,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 18,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - sprayPaint"
+      ]
+    },
+    {
+      "chapter": 325,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 19,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - sketch"
+      ]
+    },
+    {
+      "chapter": 326,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - freePlay"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 20,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Canvas - freePlay"
+      ]
+    },
+    {
+      "chapter": 327,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L34 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3L34 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 328,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Practice Create Performance Task"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      },
+      "level_keys": [
+        "U3 - Practice Create Performance Task"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment1",
+        "script_level.level_keys": [
+          "U3L01 Assessment1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L01 Assessment3",
+        "script_level.level_keys": [
+          "U3L01 Assessment3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Need For Programming Languages",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L02 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2 Using Simple Commands",
+        "script_level.level_keys": [
+          "U3L2 Using Simple Commands"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_TurtleSquare_right",
+        "script_level.level_keys": [
+          "U3L2_TurtleSquare_right"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L2_Turtle3by3Grid",
+        "script_level.level_keys": [
+          "U3L2_Turtle3by3Grid"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Assessment",
+        "script_level.level_keys": [
+          "U3L02 Assessment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L02 Free Response Getting Started"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L02 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L02 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Using Simple Commands",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Define and use turnAround",
+        "script_level.level_keys": [
+          "U3L03 Define and use turnAround"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw rect function",
+        "script_level.level_keys": [
+          "U3L03 - draw rect function"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - draw step",
+        "script_level.level_keys": [
+          "U3L03 - draw step"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps",
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond",
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 - multiselect - properties of functions",
+        "script_level.level_keys": [
+          "U3L03 - multiselect - properties of functions"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Assessment",
+        "script_level.level_keys": [
+          "U3L03 Assessment"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L03 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "u3L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "u3L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - snowflake",
+        "script_level.level_keys": [
+          "U3L04 - snowflake"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 - 3 by 3 with functions",
+        "script_level.level_keys": [
+          "U3L04 - 3 by 3 with functions"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment1",
+        "script_level.level_keys": [
+          "U3L04 Assessment1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Assessment2",
+        "script_level.level_keys": [
+          "U3L04 Assessment2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L04 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L04 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Top-Down Design",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L06 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 - moveForwardwithParams",
+        "script_level.level_keys": [
+          "U3L06 - moveForwardwithParams"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 1 triangle",
+        "script_level.level_keys": [
+          "U3L06 Challenge 1 triangle"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 2 purple square",
+        "script_level.level_keys": [
+          "U3L06 Challenge 2 purple square"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 3 fill pink",
+        "script_level.level_keys": [
+          "U3L06 Challenge 3 fill pink"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 4 bullseye",
+        "script_level.level_keys": [
+          "U3L06 Challenge 4 bullseye"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 6 squiggles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 6 squiggles"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 5 overlapping circles",
+        "script_level.level_keys": [
+          "U3L06 Challenge 5 overlapping circles"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 7 smiley face",
+        "script_level.level_keys": [
+          "U3L06 Challenge 7 smiley face"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Challenge 8 make your own",
+        "script_level.level_keys": [
+          "U3L06 Challenge 8 make your own"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment2",
+        "script_level.level_keys": [
+          "U3L06 Assessment2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06-API-multichoice",
+        "script_level.level_keys": [
+          "U3L06-API-multichoice"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L06 Assessment",
+        "script_level.level_keys": [
+          "U3L06 Assessment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "APIs and Function Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - drawSquareWithParam",
+        "script_level.level_keys": [
+          "U3L08 - drawSquareWithParam"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - createTriangleParam",
+        "script_level.level_keys": [
+          "U3L07 - createTriangleParam"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - squareTwoParams",
+        "script_level.level_keys": [
+          "U3L08 - squareTwoParams"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - createTwoParamTriangle",
+        "script_level.level_keys": [
+          "U3L08 - createTwoParamTriangle"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - introUnderTheSea",
+        "script_level.level_keys": [
+          "U3L08 - introUnderTheSea"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - paramsToStarfish",
+        "script_level.level_keys": [
+          "U3L08 - paramsToStarfish"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - seaGrass",
+        "script_level.level_keys": [
+          "U3L08 - seaGrass"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - fish",
+        "script_level.level_keys": [
+          "U3L08 - fish"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - multiParamFish",
+        "script_level.level_keys": [
+          "U3L08 - multiParamFish"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - randomInput",
+        "script_level.level_keys": [
+          "U3L08 - randomInput"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - freePlay",
+        "script_level.level_keys": [
+          "U3L08 - freePlay"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment1",
+        "script_level.level_keys": [
+          "U3L08 Assessment1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 Assessment2",
+        "script_level.level_keys": [
+          "U3L08 Assessment2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 14,
+        "lesson.key": "Creating Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - introSquare",
+        "script_level.level_keys": [
+          "U3L07 - introSquare"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomSquare",
+        "script_level.level_keys": [
+          "U3L07 - randomSquare"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - randomDots1",
+        "script_level.level_keys": [
+          "U3L07 - randomDots1"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - loopsWithRandom",
+        "script_level.level_keys": [
+          "U3L07 - loopsWithRandom"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - topDownDesign",
+        "script_level.level_keys": [
+          "U3L07 - topDownDesign"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - bubbles",
+        "script_level.level_keys": [
+          "U3L07 - bubbles"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - fish",
+        "script_level.level_keys": [
+          "U3L07 - fish"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaStar",
+        "script_level.level_keys": [
+          "U3L07 - seaStar"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - seaGrass",
+        "script_level.level_keys": [
+          "U3L07 - seaGrass"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - allSeaGrass",
+        "script_level.level_keys": [
+          "U3L07 - allSeaGrass"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - sunBeams",
+        "script_level.level_keys": [
+          "U3L07 - sunBeams"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - Free Play Loops and Random",
+        "script_level.level_keys": [
+          "U3L07 - Free Play Loops and Random"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 - MC remove line of code loops",
+        "script_level.level_keys": [
+          "U3L07 - MC remove line of code loops"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L07 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L07 Free Response Reflection"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 15,
+        "lesson.key": "Looping and Random Numbers",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - individualCode",
+        "script_level.level_keys": [
+          "U3L08 - individualCode"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L08 - digitalScene",
+        "script_level.level_keys": [
+          "U3L08 - digitalScene"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Practice PT - Design a Digital Scene",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L12 - Student Introduction 1",
+        "script_level.level_keys": [
+          "U3L12 - Student Introduction 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Events Unplugged",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Turtle move with button",
+        "script_level.level_keys": [
+          "U3L13 - Turtle move with button"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 2,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U313 drag Two Buttons",
+        "script_level.level_keys": [
+          "U313 drag Two Buttons"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 3,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 eventsDetails",
+        "script_level.level_keys": [
+          "U3L13 eventsDetails"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 4,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U313 Two Buttons with Ids",
+        "script_level.level_keys": [
+          "U313 Two Buttons with Ids"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 5,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debug Id Problem",
+        "script_level.level_keys": [
+          "U3L13 - Debug Id Problem"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 6,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debugging 1",
+        "script_level.level_keys": [
+          "U3L13 - Debugging 1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 7,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debugging 2",
+        "script_level.level_keys": [
+          "U3L13 - Debugging 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 8,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Debugging 3",
+        "script_level.level_keys": [
+          "U3L13 - Debugging 3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 9,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Turtle Driver Project",
+        "script_level.level_keys": [
+          "U3L13 - Turtle Driver Project"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 10,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 debugging Multi",
+        "script_level.level_keys": [
+          "U3L13 debugging Multi"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 11,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 Free Response Reflection",
+        "script_level.level_keys": [
+          "U3L13 Free Response Reflection"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 12,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - MC order of button and onEvent",
+        "script_level.level_keys": [
+          "U3L14 - MC order of button and onEvent"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 13,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - MC Duplicate Ids",
+        "script_level.level_keys": [
+          "U3L14 - MC Duplicate Ids"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 14,
+        "lesson.key": "Event-Driven Programming and Debugging",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - singleSetPosition",
+        "script_level.level_keys": [
+          "U3L16 - singleSetPosition"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - introSetPosition",
+        "script_level.level_keys": [
+          "U3L16 - introSetPosition"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - setPosition to move button",
+        "script_level.level_keys": [
+          "U3L16 - setPosition to move button"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - newEventTypes",
+        "script_level.level_keys": [
+          "U3L16 - newEventTypes"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Matching Events to Description",
+        "script_level.level_keys": [
+          "U3L14 - Matching Events to Description"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - text labels",
+        "script_level.level_keys": [
+          "U3L16 - text labels"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - use images",
+        "script_level.level_keys": [
+          "U3L16 - use images"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - chooseImages",
+        "script_level.level_keys": [
+          "U3L16 - chooseImages"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - chaserApp",
+        "script_level.level_keys": [
+          "U3L16 - chaserApp"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Beyond Buttons Toward Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3- L12 -Design Mode SFLP",
+        "script_level.level_keys": [
+          "U3- L12 -Design Mode SFLP"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode 1",
+        "script_level.level_keys": [
+          "U3 - Design Mode 1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-Design Mode-ID and Event Handler",
+        "script_level.level_keys": [
+          "U3-Design Mode-ID and Event Handler"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode - WTF Console Log",
+        "script_level.level_keys": [
+          "U3 - Design Mode - WTF Console Log"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode - Console Log",
+        "script_level.level_keys": [
+          "U3 - Design Mode - Console Log"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode - Layers and Delete",
+        "script_level.level_keys": [
+          "U3 - Design Mode - Layers and Delete"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode - Multi Screens",
+        "script_level.level_keys": [
+          "U3 - Design Mode - Multi Screens"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode - Multi Screens 2",
+        "script_level.level_keys": [
+          "U3 - Design Mode - Multi Screens 2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-Design Mode-Image",
+        "script_level.level_keys": [
+          "U3-Design Mode-Image"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Design Mode -Recreate Beyond Buttons",
+        "script_level.level_keys": [
+          "U3 - Design Mode -Recreate Beyond Buttons"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Introducing Design Mode",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 Student Facing Lesson Plan",
+        "script_level.level_keys": [
+          "U3L13 Student Facing Lesson Plan"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L13 - Project",
+        "script_level.level_keys": [
+          "U3L13 - Project"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 2,
+        "lesson.key": "Multi-screen Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 Student Lesson Intro",
+        "script_level.level_keys": [
+          "U3L19 Student Lesson Intro"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 1,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Message - basic mechanics of variables",
+        "script_level.level_keys": [
+          "U3L14 - Message - basic mechanics of variables"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 2,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - three basic ops of variables",
+        "script_level.level_keys": [
+          "U3L19 - three basic ops of variables"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 3,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - fix the var name syntax error v2",
+        "script_level.level_keys": [
+          "U3L19 - fix the var name syntax error v2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 4,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - write var and string with same name v2",
+        "script_level.level_keys": [
+          "U3L19 - write var and string with same name v2"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 5,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3- Variables - Create And Assign",
+        "script_level.level_keys": [
+          "U3- Variables - Create And Assign"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 6,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3- Variables - Text Mode",
+        "script_level.level_keys": [
+          "U3- Variables - Text Mode"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 7,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Message - Other ways to assign values",
+        "script_level.level_keys": [
+          "U3L14 - Message - Other ways to assign values"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 8,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Variables - Set to Expression",
+        "script_level.level_keys": [
+          "U3 - Variables - Set to Expression"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 9,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - concatenate simple",
+        "script_level.level_keys": [
+          "U3L14 - concatenate simple"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 10,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Variables - Set to Expression with Other Variables",
+        "script_level.level_keys": [
+          "U3 - Variables - Set to Expression with Other Variables"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 11,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Assigning Random Value",
+        "script_level.level_keys": [
+          "U3L14 - Assigning Random Value"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 12,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Mini Calculator embed",
+        "script_level.level_keys": [
+          "U3L14 - Mini Calculator embed"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 13,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - User Input Division calculator",
+        "script_level.level_keys": [
+          "U3L14 - User Input Division calculator"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 14,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - test reassignment of two vars",
+        "script_level.level_keys": [
+          "U3L19 - test reassignment of two vars"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 15,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3-Variables-Memory Breakdown",
+        "script_level.level_keys": [
+          "U3-Variables-Memory Breakdown"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 16,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - Variable ReAssignment pt2",
+        "script_level.level_keys": [
+          "U3L14 - Variable ReAssignment pt2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 17,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge1",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 18,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge2",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 19,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge3",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge3"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 20,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge4",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge4"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 21,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge5",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge5"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 22,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - moving memory challenge6",
+        "script_level.level_keys": [
+          "U3L14 - moving memory challenge6"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 23,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - variable reassignment challenge pt2",
+        "script_level.level_keys": [
+          "U3L19 - variable reassignment challenge pt2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 24,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L14 - MC variable reassignment",
+        "script_level.level_keys": [
+          "U3L14 - MC variable reassignment"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 25,
+        "lesson.key": "Controlling Memory with Variables",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 Student Lesson Intro - new",
+        "script_level.level_keys": [
+          "U3L15 Student Lesson Intro - new"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 full clicker demo",
+        "script_level.level_keys": [
+          "U3 full clicker demo"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - practice with setText",
+        "script_level.level_keys": [
+          "U3L15 - practice with setText"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - DEMO up down count practice app",
+        "script_level.level_keys": [
+          "U3L15 - DEMO up down count practice app"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - global var example count up",
+        "script_level.level_keys": [
+          "U3L15 - global var example count up"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - variable scoping problem debugging",
+        "script_level.level_keys": [
+          "U3L15 - variable scoping problem debugging"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 spot the difference variable debugging",
+        "script_level.level_keys": [
+          "U3L15 spot the difference variable debugging"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L19 - variable scope explanation pt2",
+        "script_level.level_keys": [
+          "U3L19 - variable scope explanation pt2"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - add code to make count down work",
+        "script_level.level_keys": [
+          "U3L15 - add code to make count down work"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - count upDown bug forget to set text",
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug forget to set text"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - count upDown bug var not created globally",
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug var not created globally"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 11,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - count upDown bug logic error wrong update",
+        "script_level.level_keys": [
+          "U3L15 - count upDown bug logic error wrong update"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 12,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - mini clicker update score",
+        "script_level.level_keys": [
+          "U3L15 - mini clicker update score"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 13,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 click add lives",
+        "script_level.level_keys": [
+          "U3L15 click add lives"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 14,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - explanation of IF and =v==",
+        "script_level.level_keys": [
+          "U3L15 - explanation of IF and =v=="
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 15,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - Simple If-statements in UpDown App",
+        "script_level.level_keys": [
+          "U3L15 - Simple If-statements in UpDown App"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 16,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - Add reset button to UpDown app",
+        "script_level.level_keys": [
+          "U3L15 - Add reset button to UpDown app"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 17,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - Debugging Simple If-statements =v==",
+        "script_level.level_keys": [
+          "U3L15 - Debugging Simple If-statements =v=="
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 18,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - Debug forget to update var on reset in UpDown app",
+        "script_level.level_keys": [
+          "U3L15 - Debug forget to update var on reset in UpDown app"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 19,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 - Debug if never triggers in UpDown app",
+        "script_level.level_keys": [
+          "U3L15 - Debug if never triggers in UpDown app"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 20,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L15 full clicker app",
+        "script_level.level_keys": [
+          "U3L15 full clicker app"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 21,
+        "lesson.key": "Using Variables in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L26 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L26 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 1,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib Demo",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Demo"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 2,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - introStrings",
+        "script_level.level_keys": [
+          "U3L16 - introStrings"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 3,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - doubleQuotes",
+        "script_level.level_keys": [
+          "U3L16 - doubleQuotes"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 4,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - textInput getText write",
+        "script_level.level_keys": [
+          "U3L16 - textInput getText write"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 5,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - intro getText",
+        "script_level.level_keys": [
+          "U3L16 - intro getText"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 6,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - User Input - Save getText To Variable",
+        "script_level.level_keys": [
+          "U3 - User Input - Save getText To Variable"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 7,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - outputWithTextArea",
+        "script_level.level_keys": [
+          "U3L16 - outputWithTextArea"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 8,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - toUpper",
+        "script_level.level_keys": [
+          "U3L16 - toUpper"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 9,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib Student Setup",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Student Setup"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 10,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib setText",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib setText"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 11,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib getText",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib getText"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 12,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib toUpper",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib toUpper"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 13,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 Mad Lib Clear Input",
+        "script_level.level_keys": [
+          "U3L16 Mad Lib Clear Input"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 14,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 Free Response 3",
+        "script_level.level_keys": [
+          "U3L25 Free Response 3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 15,
+        "lesson.key": "User Input and Strings",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L23 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L23 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L23 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L23 Free Response Getting Started"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Digital Assistant Target",
+        "script_level.level_keys": [
+          "U3 Digital Assistant Target"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L16 - challenge say hi app",
+        "script_level.level_keys": [
+          "U3L16 - challenge say hi app"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Digital Assistant Design",
+        "script_level.level_keys": [
+          "U3 Digital Assistant Design"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Digital Assistant Set Text",
+        "script_level.level_keys": [
+          "U3 Digital Assistant Set Text"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L23 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L23 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Digital Assistants",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L20 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L20 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Boolean Expressions and Operators",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Boolean Expressions and Operators"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L18 comparison operators",
+        "script_level.level_keys": [
+          "U3L18 comparison operators"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 3,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L18 Matching",
+        "script_level.level_keys": [
+          "U3L18 Matching"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 4,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Translating Flowcharts - If Statement",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Translating Flowcharts - If Statement"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 5,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - High Low - If",
+        "script_level.level_keys": [
+          "U3 - High Low - If"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 6,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - High Low - Dropdown",
+        "script_level.level_keys": [
+          "U3 - High Low - Dropdown"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 7,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditional Basics - 6",
+        "script_level.level_keys": [
+          "U3 - Conditional Basics - 6"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 8,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Introducing Else",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Introducing Else"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 9,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - High Low - Else",
+        "script_level.level_keys": [
+          "U3 - High Low - Else"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 10,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Translating Flowcharts - Chained",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Translating Flowcharts - Chained"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 11,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - High Low - Else if",
+        "script_level.level_keys": [
+          "U3 - High Low - Else if"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 12,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - High Low - Debug",
+        "script_level.level_keys": [
+          "U3 - High Low - Debug"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 13,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Dice - If",
+        "script_level.level_keys": [
+          "U3 - Dice - If"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 14,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Dice - Dropdown and Score",
+        "script_level.level_keys": [
+          "U3 - Dice - Dropdown and Score"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 15,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Dice - Dropdown with Strings",
+        "script_level.level_keys": [
+          "U3 - Dice - Dropdown with Strings"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 16,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Dice - Nested",
+        "script_level.level_keys": [
+          "U3 - Dice - Nested"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 17,
+        "lesson.key": "Understanding Program Flow and Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L24 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L24 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L23 Chatbot Conditionals 1",
+        "script_level.level_keys": [
+          "U3L23 Chatbot Conditionals 1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Movie Bot - toLowerCase",
+        "script_level.level_keys": [
+          "U3 - Movie Bot - toLowerCase"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L24 introIncludes",
+        "script_level.level_keys": [
+          "U3L24 introIncludes"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L24 Nested Conditionals 1",
+        "script_level.level_keys": [
+          "U3L24 Nested Conditionals 1"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Movie Bot - Nested Motivation",
+        "script_level.level_keys": [
+          "U3 - Movie Bot - Nested Motivation"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L24 Nested Conditionals 2",
+        "script_level.level_keys": [
+          "U3L24 Nested Conditionals 2"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L25 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 1,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Simple OR",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Simple OR"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 2,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Simple AND",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Simple AND"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 3,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L20 - combining And and Or explanation",
+        "script_level.level_keys": [
+          "U3L20 - combining And and Or explanation"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 4,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Combine AND OR Simple",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Combine AND OR Simple"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 5,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Conditionals - Combine AND OR and NOT",
+        "script_level.level_keys": [
+          "U3 - Conditionals - Combine AND OR and NOT"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 6,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L26 OR operator",
+        "script_level.level_keys": [
+          "U3L26 OR operator"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 7,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Movie Bot - Multiple If Sequences",
+        "script_level.level_keys": [
+          "U3 - Movie Bot - Multiple If Sequences"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 8,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L26 AND operator",
+        "script_level.level_keys": [
+          "U3L26 AND operator"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 9,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Movie Bot - When Multiple If Statements",
+        "script_level.level_keys": [
+          "U3 - Movie Bot - When Multiple If Statements"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 10,
+        "lesson.key": "Compound Conditional Logic",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L21 Student Lesson Introduction v2",
+        "script_level.level_keys": [
+          "U3L21 Student Lesson Introduction v2"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 1,
+        "lesson.key": "Digital Assistant Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L24 Chatbot Basic Conditionals",
+        "script_level.level_keys": [
+          "U3L24 Chatbot Basic Conditionals"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 2,
+        "lesson.key": "Digital Assistant Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L28 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L28 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 1",
+        "script_level.level_keys": [
+          "U3 - Loops - 1"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 2",
+        "script_level.level_keys": [
+          "U3 - Loops - 2"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 3",
+        "script_level.level_keys": [
+          "U3 - Loops - 3"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Typing in Console",
+        "script_level.level_keys": [
+          "U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 4",
+        "script_level.level_keys": [
+          "U3 - Loops - 4"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 5",
+        "script_level.level_keys": [
+          "U3 - Loops - 5"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 8",
+        "script_level.level_keys": [
+          "U3 - Loops - 8"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 6",
+        "script_level.level_keys": [
+          "U3 - Loops - 6"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 7",
+        "script_level.level_keys": [
+          "U3 - Loops - 7"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 9",
+        "script_level.level_keys": [
+          "U3 - Loops - 9"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops -  Complex Condition",
+        "script_level.level_keys": [
+          "U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 10",
+        "script_level.level_keys": [
+          "U3 - Loops - 10"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 11",
+        "script_level.level_keys": [
+          "U3 - Loops - 11"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 12",
+        "script_level.level_keys": [
+          "U3 - Loops - 12"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Plus Plus",
+        "script_level.level_keys": [
+          "U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Minus Minus",
+        "script_level.level_keys": [
+          "U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - plus and minus = operator",
+        "script_level.level_keys": [
+          "U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - minus = operator",
+        "script_level.level_keys": [
+          "U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 14",
+        "script_level.level_keys": [
+          "U3 - Loops - 14"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 15",
+        "script_level.level_keys": [
+          "U3 - Loops - 15"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L29 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L29 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - Intro",
+        "script_level.level_keys": [
+          "U3 - Simulation - Intro"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 1",
+        "script_level.level_keys": [
+          "U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2.1",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2.5",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Simulation Updating Hypotheses",
+        "script_level.level_keys": [
+          "U3 Simulation Updating Hypotheses"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 3",
+        "script_level.level_keys": [
+          "U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 4",
+        "script_level.level_keys": [
+          "U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 5",
+        "script_level.level_keys": [
+          "U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Simulations Hypotheses Reflections",
+        "script_level.level_keys": [
+          "U3 Simulations Hypotheses Reflections"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 6",
+        "script_level.level_keys": [
+          "U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L30 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L30 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - createFirstArray",
+        "script_level.level_keys": [
+          "U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - appendItem",
+        "script_level.level_keys": [
+          "U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - introIndex",
+        "script_level.level_keys": [
+          "U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - indexPractice",
+        "script_level.level_keys": [
+          "U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment2",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment3",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - stringsInArrays",
+        "script_level.level_keys": [
+          "U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - insertingItems",
+        "script_level.level_keys": [
+          "U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - remove",
+        "script_level.level_keys": [
+          "U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - insertionErrors",
+        "script_level.level_keys": [
+          "U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - length",
+        "script_level.level_keys": [
+          "U3 - Arrays - length"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - lengthMinus1",
+        "script_level.level_keys": [
+          "U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - expressionsAsIndexes",
+        "script_level.level_keys": [
+          "U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Demo App",
+        "script_level.level_keys": [
+          "U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings giveIDs",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings createArray",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings firstOutput",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Counting Variable",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Next",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Prev",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings addItem",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings bounds",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings keepPlaying",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Wrap Up 1",
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Wrap Up 2",
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L31 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L31 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Demo App",
+        "script_level.level_keys": [
+          "U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 2,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 - drag out key event",
+        "script_level.level_keys": [
+          "U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 3,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Key Up and Down",
+        "script_level.level_keys": [
+          "U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 4,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 - play sound when up key",
+        "script_level.level_keys": [
+          "U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 5,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Multiple Keys",
+        "script_level.level_keys": [
+          "U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 6,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Buttons and Keys",
+        "script_level.level_keys": [
+          "U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 7,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Functions",
+        "script_level.level_keys": [
+          "U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 8,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Add Image URLs",
+        "script_level.level_keys": [
+          "U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 9,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Final Image Scroller",
+        "script_level.level_keys": [
+          "U3 - Keys - Final Image Scroller"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 10,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3- Keys - Code Refactoring Exit Ticket",
+        "script_level.level_keys": [
+          "U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 11,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L32 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L32 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Intro For Loop",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Print Array",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Add 5",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Divid by 2",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Loop Array If",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Linear Search",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Counting Times",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Printing Single True",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Search with Boolean Var",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Make it a Function",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Make it a Function - add list parameter",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - General Search Param",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Find Min",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L27 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L27 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays and Loops - Explain Functions with Returns",
+        "script_level.level_keys": [
+          "U3 - Arrays and Loops - Explain Functions with Returns"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - useMinVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - writeMaxVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - debuggingMaxVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - debuggingConstrain",
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - constrainTurtle",
+        "script_level.level_keys": [
+          "U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - wrapTurtle",
+        "script_level.level_keys": [
+          "U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L33 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L33 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 1,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - introCanvas",
+        "script_level.level_keys": [
+          "U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 2,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - 200dots",
+        "script_level.level_keys": [
+          "U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 3,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - transparentDots",
+        "script_level.level_keys": [
+          "U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 4,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - clickToAdd",
+        "script_level.level_keys": [
+          "U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 5,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - usingOffsetXY",
+        "script_level.level_keys": [
+          "U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 6,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - draw at click point",
+        "script_level.level_keys": [
+          "U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 7,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - changeToMouseMove",
+        "script_level.level_keys": [
+          "U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 8,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - shiftKey",
+        "script_level.level_keys": [
+          "U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 9,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - appendToArray",
+        "script_level.level_keys": [
+          "U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 10,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - delete",
+        "script_level.level_keys": [
+          "U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 11,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawRandom",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 12,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawRandom2",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 13,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawOriginal",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 14,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - movementFunction",
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 15,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - movementFunction fix Orig",
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 16,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - One Dot sprayPaint",
+        "script_level.level_keys": [
+          "U3 - Canvas - One Dot sprayPaint"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 17,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - sprayPaint",
+        "script_level.level_keys": [
+          "U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 18,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - sketch",
+        "script_level.level_keys": [
+          "U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 19,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - freePlay",
+        "script_level.level_keys": [
+          "U3 - Canvas - freePlay"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 20,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L34 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L34 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Practice Create Performance Task",
+        "script_level.level_keys": [
+          "U3 - Practice Create Performance Task"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit3temp.script_json
+++ b/dashboard/config/scripts_json/cspunit3temp.script_json
@@ -1,0 +1,4171 @@
+{
+  "script": {
+    "name": "cspunit3temp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit3temp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Loops and Simulations",
+      "name": "Loops and Simulations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Introduction to Arrays",
+      "name": "Introduction to Arrays",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Image Scroller with Key Events",
+      "name": "Image Scroller with Key Events",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Processing Arrays",
+      "name": "Processing Arrays",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Functions with Return Values",
+      "name": "Functions with Return Values",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Canvas and Arrays in Apps",
+      "name": "Canvas and Arrays in Apps",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "key": "Practice PT: Create",
+      "name": "Practice PT: Create",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L28 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L28 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - Typing in Console"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops -  Complex Condition"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 10"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 11"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 12"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - Plus Plus"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - Minus Minus"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - plus and minus = operator"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - minus = operator"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 14"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops - 15"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops - 15"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 22,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L28 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L28 Free Response Wrap Up"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L29 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L29 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2.1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 2.5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Simulation Updating Hypotheses"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 Simulation Updating Hypotheses"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 3"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 4"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 5"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Simulations Hypotheses Reflections"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 Simulations Hypotheses Reflections"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Simulation - 6"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L30 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L30 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - createFirstArray"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - appendItem"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - introIndex"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - indexPractice"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment2"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - assignment3"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - stringsInArrays"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - insertingItems"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - remove"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - insertionErrors"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - length"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - length"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - lengthMinus1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - expressionsAsIndexes"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - Demo App"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings giveIDs"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings createArray"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings firstOutput"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Counting Variable"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Next"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings Prev"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings addItem"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings bounds"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - favThings keepPlaying"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 26,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - Wrap Up 1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 27,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays - Wrap Up 2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L31 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L31 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Demo App"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L25 - drag out key event"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Key Up and Down"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L25 - play sound when up key"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Multiple Keys"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Buttons and Keys"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Functions"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Add Image URLs"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Keys - Final Image Scroller"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Keys - Final Image Scroller"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3- Keys - Code Refactoring Exit Ticket"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L32 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L32 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Intro For Loop"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Print Array"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Add 5"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Divid by 2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Loop Array If"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Linear Search"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Counting Times"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Printing Single True"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Search with Boolean Var"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Make it a Function"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Make it a Function - add list parameter"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - General Search Param"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Loops And Arrays - Find Min"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L27 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L27 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Arrays and Loops - Explain Functions with Returns"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Arrays and Loops - Explain Functions with Returns"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - useMinVal"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - writeMaxVal"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - debuggingMaxVal"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - debuggingConstrain"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - constrainTurtle"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Return Values - wrapTurtle"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L33 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L33 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - introCanvas"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - 200dots"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - transparentDots"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - clickToAdd"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - usingOffsetXY"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - draw at click point"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - changeToMouseMove"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - shiftKey"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - appendToArray"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawRandom"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawRandom2"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - redrawOriginal"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - delete"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - movementFunction"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - movementFunction fix Orig"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 17,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - sprayPaint"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 18,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Canvas - sketch"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L33 Free Response Getting Started"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 19,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L33 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L34 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3L34 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Practice Create Performance Task"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      },
+      "level_keys": [
+        "U3 - Practice Create Performance Task"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U3L28 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L28 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 1",
+        "script_level.level_keys": [
+          "U3 - Loops - 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 2",
+        "script_level.level_keys": [
+          "U3 - Loops - 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 3",
+        "script_level.level_keys": [
+          "U3 - Loops - 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Typing in Console",
+        "script_level.level_keys": [
+          "U3 - Loops - Typing in Console"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 4",
+        "script_level.level_keys": [
+          "U3 - Loops - 4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 5",
+        "script_level.level_keys": [
+          "U3 - Loops - 5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 8",
+        "script_level.level_keys": [
+          "U3 - Loops - 8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 6",
+        "script_level.level_keys": [
+          "U3 - Loops - 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 7",
+        "script_level.level_keys": [
+          "U3 - Loops - 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 9",
+        "script_level.level_keys": [
+          "U3 - Loops - 9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops -  Complex Condition",
+        "script_level.level_keys": [
+          "U3 - Loops -  Complex Condition"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 10",
+        "script_level.level_keys": [
+          "U3 - Loops - 10"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 11",
+        "script_level.level_keys": [
+          "U3 - Loops - 11"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 12",
+        "script_level.level_keys": [
+          "U3 - Loops - 12"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Plus Plus",
+        "script_level.level_keys": [
+          "U3 - Loops - Plus Plus"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - Minus Minus",
+        "script_level.level_keys": [
+          "U3 - Loops - Minus Minus"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - plus and minus = operator",
+        "script_level.level_keys": [
+          "U3 - Loops - plus and minus = operator"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - minus = operator",
+        "script_level.level_keys": [
+          "U3 - Loops - minus = operator"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 14",
+        "script_level.level_keys": [
+          "U3 - Loops - 14"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops - 15",
+        "script_level.level_keys": [
+          "U3 - Loops - 15"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L28 Free Response Wrap Up",
+        "script_level.level_keys": [
+          "U3L28 Free Response Wrap Up"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L29 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L29 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - Intro",
+        "script_level.level_keys": [
+          "U3 - Simulation - Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 1",
+        "script_level.level_keys": [
+          "U3 - Simulation - 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2.1",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 2.5",
+        "script_level.level_keys": [
+          "U3 - Simulation - 2.5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Simulation Updating Hypotheses",
+        "script_level.level_keys": [
+          "U3 Simulation Updating Hypotheses"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 3",
+        "script_level.level_keys": [
+          "U3 - Simulation - 3"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 4",
+        "script_level.level_keys": [
+          "U3 - Simulation - 4"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 5",
+        "script_level.level_keys": [
+          "U3 - Simulation - 5"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Simulations Hypotheses Reflections",
+        "script_level.level_keys": [
+          "U3 Simulations Hypotheses Reflections"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simulation - 6",
+        "script_level.level_keys": [
+          "U3 - Simulation - 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Loops and Simulations",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L30 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L30 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - createFirstArray",
+        "script_level.level_keys": [
+          "U3 - Arrays - createFirstArray"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - appendItem",
+        "script_level.level_keys": [
+          "U3 - Arrays - appendItem"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - introIndex",
+        "script_level.level_keys": [
+          "U3 - Arrays - introIndex"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - indexPractice",
+        "script_level.level_keys": [
+          "U3 - Arrays - indexPractice"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment2",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment2"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - assignment3",
+        "script_level.level_keys": [
+          "U3 - Arrays - assignment3"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - stringsInArrays",
+        "script_level.level_keys": [
+          "U3 - Arrays - stringsInArrays"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - insertingItems",
+        "script_level.level_keys": [
+          "U3 - Arrays - insertingItems"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - remove",
+        "script_level.level_keys": [
+          "U3 - Arrays - remove"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - insertionErrors",
+        "script_level.level_keys": [
+          "U3 - Arrays - insertionErrors"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - length",
+        "script_level.level_keys": [
+          "U3 - Arrays - length"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - lengthMinus1",
+        "script_level.level_keys": [
+          "U3 - Arrays - lengthMinus1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - expressionsAsIndexes",
+        "script_level.level_keys": [
+          "U3 - Arrays - expressionsAsIndexes"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 15,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Demo App",
+        "script_level.level_keys": [
+          "U3 - Arrays - Demo App"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 16,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings giveIDs",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings giveIDs"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 17,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings createArray",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings createArray"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 18,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings firstOutput",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings firstOutput"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 19,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Counting Variable",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Counting Variable"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 20,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Next",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Next"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 21,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings Prev",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings Prev"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 22,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings addItem",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings addItem"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 23,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings bounds",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings bounds"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 24,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - favThings keepPlaying",
+        "script_level.level_keys": [
+          "U3 - Arrays - favThings keepPlaying"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 25,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Wrap Up 1",
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 26,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays - Wrap Up 2",
+        "script_level.level_keys": [
+          "U3 - Arrays - Wrap Up 2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 27,
+        "lesson.key": "Introduction to Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L31 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L31 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Demo App",
+        "script_level.level_keys": [
+          "U3 - Keys - Demo App"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 - drag out key event",
+        "script_level.level_keys": [
+          "U3L25 - drag out key event"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Key Up and Down",
+        "script_level.level_keys": [
+          "U3 - Keys - Key Up and Down"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L25 - play sound when up key",
+        "script_level.level_keys": [
+          "U3L25 - play sound when up key"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Multiple Keys",
+        "script_level.level_keys": [
+          "U3 - Keys - Multiple Keys"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Buttons and Keys",
+        "script_level.level_keys": [
+          "U3 - Keys - Buttons and Keys"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Functions",
+        "script_level.level_keys": [
+          "U3 - Keys - Functions"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Add Image URLs",
+        "script_level.level_keys": [
+          "U3 - Keys - Add Image URLs"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Keys - Final Image Scroller",
+        "script_level.level_keys": [
+          "U3 - Keys - Final Image Scroller"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3- Keys - Code Refactoring Exit Ticket",
+        "script_level.level_keys": [
+          "U3- Keys - Code Refactoring Exit Ticket"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "Image Scroller with Key Events",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L32 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L32 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Intro For Loop",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Intro For Loop"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Print Array",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Print Array"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Add 5",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Add 5"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Divid by 2",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Divid by 2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Loop Array If",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Loop Array If"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Linear Search",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Linear Search"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Counting Times",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Counting Times"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Printing Single True",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Printing Single True"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Search with Boolean Var",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Search with Boolean Var"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Make it a Function",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Make it a Function - add list parameter",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Make it a Function - add list parameter"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - General Search Param",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - General Search Param"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 13,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Loops And Arrays - Find Min",
+        "script_level.level_keys": [
+          "U3 - Loops And Arrays - Find Min"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 14,
+        "lesson.key": "Processing Arrays",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L27 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L27 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Arrays and Loops - Explain Functions with Returns",
+        "script_level.level_keys": [
+          "U3 - Arrays and Loops - Explain Functions with Returns"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - useMinVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - useMinVal"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - writeMaxVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - writeMaxVal"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - debuggingMaxVal",
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingMaxVal"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - debuggingConstrain",
+        "script_level.level_keys": [
+          "U3 - Return Values - debuggingConstrain"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - constrainTurtle",
+        "script_level.level_keys": [
+          "U3 - Return Values - constrainTurtle"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Return Values - wrapTurtle",
+        "script_level.level_keys": [
+          "U3 - Return Values - wrapTurtle"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Return Values",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L33 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L33 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - introCanvas",
+        "script_level.level_keys": [
+          "U3 - Canvas - introCanvas"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - 200dots",
+        "script_level.level_keys": [
+          "U3 - Canvas - 200dots"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - transparentDots",
+        "script_level.level_keys": [
+          "U3 - Canvas - transparentDots"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - clickToAdd",
+        "script_level.level_keys": [
+          "U3 - Canvas - clickToAdd"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - usingOffsetXY",
+        "script_level.level_keys": [
+          "U3 - Canvas - usingOffsetXY"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - draw at click point",
+        "script_level.level_keys": [
+          "U3 - Canvas - draw at click point"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - changeToMouseMove",
+        "script_level.level_keys": [
+          "U3 - Canvas - changeToMouseMove"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - shiftKey",
+        "script_level.level_keys": [
+          "U3 - Canvas - shiftKey"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - appendToArray",
+        "script_level.level_keys": [
+          "U3 - Canvas - appendToArray"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawRandom",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawRandom2",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawRandom2"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - redrawOriginal",
+        "script_level.level_keys": [
+          "U3 - Canvas - redrawOriginal"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - delete",
+        "script_level.level_keys": [
+          "U3 - Canvas - delete"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - movementFunction",
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - movementFunction fix Orig",
+        "script_level.level_keys": [
+          "U3 - Canvas - movementFunction fix Orig"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - sprayPaint",
+        "script_level.level_keys": [
+          "U3 - Canvas - sprayPaint"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 17,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Canvas - sketch",
+        "script_level.level_keys": [
+          "U3 - Canvas - sketch"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 18,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L33 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L33 Free Response Getting Started"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 19,
+        "lesson.key": "Canvas and Arrays in Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L34 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L34 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Practice Create Performance Task",
+        "script_level.level_keys": [
+          "U3 - Practice Create Performance Task"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Practice PT: Create",
+        "lesson_group.key": "",
+        "script.name": "cspunit3temp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit4.script_json
+++ b/dashboard/config/scripts_json/cspunit4.script_json
@@ -1,0 +1,1316 @@
+{
+  "script": {
+    "name": "cspunit4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro to Data",
+      "name": "Introduction to Data",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Finding Trends with Visualizations",
+      "name": "Finding Trends with Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Check Your Assumptions",
+      "name": "Check Your Assumptions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Good and Bad Data Visualizations",
+      "name": "Good and Bad Data Visualizations",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Making Data Visualizations",
+      "name": "Making Data Visualizations",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Discover a Data Story",
+      "name": "Discover a Data Story",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Cleaning Data",
+      "name": "Cleaning Data",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Creating Summary Tables",
+      "name": "Creating Summary Tables",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Practice PT - Tell a Data Story",
+      "name": "Practice PT - Tell a Data Story",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "What is Big Data?",
+      "name": "What is Big Data?",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Rapid Research - Data Innovations",
+      "name": "Rapid Research - Data Innovations",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Identifying People with Data",
+      "name": "Identifying People with Data",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "The Cost of Free",
+      "name": "The Cost of Free",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "key": "Practice PT - Propose an Innovation",
+      "name": "Practice PT - Propose an Innovation",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice PT - Propose an Innovation",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02v2 - Finding Trends"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L02v2 - Finding Trends"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03v2 - Student Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L03v2 - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04v2 - Student Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L04v2 - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "GoodBadVisualizations_v1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "GoodBadVisualizations_v2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Student Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Getting Started"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Getting Started"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Scatter Plot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Scatter Plot"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Line Chart"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Line Chart"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Bar Chart"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Bar Chart"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Edit Chart Appearance"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Edit Chart Appearance"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Free Play"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06v2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L06v2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L16 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Cleaning Data - Activity Guide"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Cleaning Data - Activity Guide"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 Cleaning Data Activity Guide Pt2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 Cleaning Data Activity Guide Pt3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Student Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L08v2 Student Intro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 3"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Data and Medicine"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "Video - Data and Medicine"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "Video - CS is Changing Everything"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Privacy Abandoned - Hot On Your Trail Video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4 - Privacy Abandoned - Hot On Your Trail Video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Propose an Innovation",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      },
+      "level_keys": [
+        "U4L14 Student Lesson Introduction"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U4L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02v2 - Finding Trends",
+        "script_level.level_keys": [
+          "U4L02v2 - Finding Trends"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03v2 - Student Introduction",
+        "script_level.level_keys": [
+          "U4L03v2 - Student Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04v2 - Student Introduction",
+        "script_level.level_keys": [
+          "U4L04v2 - Student Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoodBadVisualizations_v1",
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoodBadVisualizations_v2",
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Student Introduction",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Student Introduction"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Getting Started",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Getting Started"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Scatter Plot",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Scatter Plot"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Line Chart",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Line Chart"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Bar Chart",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Bar Chart"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Edit Chart Appearance",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Edit Chart Appearance"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Free Play",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 7,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06v2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L06v2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L16 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Cleaning Data - Activity Guide",
+        "script_level.level_keys": [
+          "U4 - Cleaning Data - Activity Guide"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Cleaning Data Activity Guide Pt2",
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Cleaning Data Activity Guide Pt3",
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Student Intro",
+        "script_level.level_keys": [
+          "U4L08v2 Student Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 2",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 3",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Tell a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "What is Big Data?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Data and Medicine",
+        "script_level.level_keys": [
+          "Video - Data and Medicine"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - CS is Changing Everything",
+        "script_level.level_keys": [
+          "Video - CS is Changing Everything"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Identifying People with Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Privacy Abandoned - Hot On Your Trail Video",
+        "script_level.level_keys": [
+          "U4 - Privacy Abandoned - Hot On Your Trail Video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "The Cost of Free",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L14 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Practice PT - Propose an Innovation",
+        "lesson_group.key": "",
+        "script.name": "cspunit4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit4draft.script_json
+++ b/dashboard/config/scripts_json/cspunit4draft.script_json
@@ -1,0 +1,5886 @@
+{
+  "script": {
+    "name": "cspunit4draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit4draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Finding Trends with Visualizations",
+      "name": "Finding Trends with Visualizations",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Good and Bad Data Visualizations",
+      "name": "Good and Bad Data Visualizations",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Check Your Assumptions",
+      "name": "Check Your Assumptions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Making Data Visualizations",
+      "name": "Making Data Visualizations",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Discover a Data Story",
+      "name": "Discover a Data Story",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Cleaning Data",
+      "name": "Cleaning Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Creating Summary Tables",
+      "name": "Creating Summary Tables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Rapid Research - Data Innovations",
+      "name": "Rapid Research - Data Innovations",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Why Make Apps?",
+      "name": "Why Make Apps?",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Search Terms",
+      "name": "Search Terms",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Unique IDs, Delete and Update Records",
+      "name": "Unique IDs, Delete and Update Records",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Import, Export, and Visualize Data",
+      "name": "Import, Export, and Visualize Data",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Interpreting Data Visualizations",
+      "name": "Interpreting Data Visualizations",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "How is Data Collected?",
+      "name": "How is Data Collected?",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Using Data in the Real World",
+      "name": "Using Data in the Real World",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Web Requests and APIs",
+      "name": "Web Requests and APIs",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Data, Security, and Privacy",
+      "name": "Data, Security, and Privacy",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Privacy vs Utility",
+      "name": "Privacy vs Utility",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Privacy in a Digital World",
+      "name": "Privacy in a Digital World",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Compiling Data",
+      "name": "Compiling Data",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Designing Data Collection",
+      "name": "Designing Data Collection",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Designing for Your User",
+      "name": "Designing for Your User",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Practice Create PT: Data App",
+      "name": "Practice Create PT: Data App",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "What Data Can Tell Us",
+      "name": "What Data Can Tell Us",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "key": "Permanent Data Storage and Clicker Completion",
+      "name": "Permanent Data Storage and Clicker Completion",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02v2 - Finding Trends"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L02v2 - Finding Trends"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04v2 - Student Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L04v2 - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "GoodBadVisualizations_v1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "GoodBadVisualizations_v2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03v2 - Student Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L03v2 - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Student Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Getting Started"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Getting Started"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Scatter Plot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Scatter Plot"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Line Chart"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Line Chart"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Bar Chart"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Bar Chart"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Making Data Visualizations - Free Play"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06v2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L06v2 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L16 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Cleaning Data - Activity Guide"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Cleaning Data - Activity Guide"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 Cleaning Data Activity Guide Pt2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 Cleaning Data Activity Guide Pt3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L16 Free Response"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L16 Free Response"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L16 Choose 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L16 Choose 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L16 Multiple Choice"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L16 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Student Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08v2 Student Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08v2 Making Pivot Tables Part 3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 - Student Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L12 - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L01 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L01 Free Response"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L01 Free Response"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L01 Choose 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L01 Choose 2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L01 Multiple Choice"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L01 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 17,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Free Response"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 17,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L02 Free Response"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 18,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Choose 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 18,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L02 Choose 2"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Multiple Choice"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 19,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L02 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 13,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 14,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 15,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 16,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 17,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 18,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L05 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L05 Free Response"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L05 Free Response"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L05 Choose 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L05 Choose 2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L05 Multiple Choice"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L05 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L06 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Free Response"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L06 Free Response"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Choose 2"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L06 Choose 2"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L06 Multiple Choice"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L06 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L07 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L07 Free Response"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L07 Free Response"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L07 Choose 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L07 Choose 2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L07 Multiple Choice"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L07 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Free Response"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08 Free Response"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Choose 2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08 Choose 2"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L08 Multiple Choice"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L08 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L09 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Free Response"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L09 Free Response"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Choose 2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L09 Choose 2"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L09 Multiple Choice"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L09 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L10 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 Free Response"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L10 Free Response"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 Choose 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L10 Choose 2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L10 Multiple Choice"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L10 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L11 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L11 Free Response"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L11 Free Response"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L11 Choose 2"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L11 Choose 2"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L11 Multiple Choice"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L11 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L12 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 Free Response"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L12 Free Response"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 Choose 2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L12 Choose 2"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L12 Multiple Choice"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L12 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L13 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L13 Free Response"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L13 Free Response"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L13 Choose 2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L13 Choose 2"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L13 Multiple Choice"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L13 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L14 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L14 Free Response"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L14 Free Response"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L14 Choose 2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L14 Choose 2"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L14 Multiple Choice"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L14 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L15 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L15 Free Response"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L15 Free Response"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L15 Choose 2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L15 Choose 2"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L15 Multiple Choice"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L15 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L17 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L17 Free Response"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L17 Free Response"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L17 Choose 2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L17 Choose 2"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L17 Multiple Choice"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L17 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L18 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L18 Free Response"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L18 Free Response"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L18 Choose 2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 3,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L18 Choose 2"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L18 Multiple Choice"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 4,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L18 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L19 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L19 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L19 Free Response"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L19 Free Response"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L19 Choose 2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L19 Choose 2"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L19 Multiple Choice"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U4L19 Multiple Choice"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Data Unit -Counting Records - Hard Way"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "CSP Data Unit -Counting Records - Hard Way"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Data Unit -Counting Records - Easy Way"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "CSP Data Unit -Counting Records - Easy Way"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Data Unit - Counting Multiple Things"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "CSP Data Unit - Counting Multiple Things"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L22 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L22 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L17 - introKeyValue"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L17 - introKeyValue"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L17 - setKeyValue"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L17 - setKeyValue"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L17 - twoSetKeyValue"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L17 - twoSetKeyValue"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L17 - introCallbacks"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L17 - introCallbacks"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L17 - getKeyValue"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L17 - getKeyValue"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L22 Free Response Getting Started"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L22 Free Response Getting Started"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L22 Assessment"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L22 Assessment"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L22 Reflection"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      },
+      "level_keys": [
+        "U3L22 Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U4L02v2 - Finding Trends",
+        "script_level.level_keys": [
+          "U4L02v2 - Finding Trends"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Finding Trends with Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04v2 - Student Introduction",
+        "script_level.level_keys": [
+          "U4L04v2 - Student Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoodBadVisualizations_v1",
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GoodBadVisualizations_v2",
+        "script_level.level_keys": [
+          "GoodBadVisualizations_v2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Good and Bad Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03v2 - Student Introduction",
+        "script_level.level_keys": [
+          "U4L03v2 - Student Introduction"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Check Your Assumptions",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Student Introduction",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Student Introduction"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Getting Started",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Getting Started"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Scatter Plot",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Scatter Plot"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Line Chart",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Line Chart"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Bar Chart",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Bar Chart"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Making Data Visualizations - Free Play",
+        "script_level.level_keys": [
+          "U4 - Making Data Visualizations - Free Play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Making Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06v2 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L06v2 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Discover a Data Story",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L16 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L16 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Cleaning Data - Activity Guide",
+        "script_level.level_keys": [
+          "U4 - Cleaning Data - Activity Guide"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Cleaning Data Activity Guide Pt2",
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Cleaning Data Activity Guide Pt3",
+        "script_level.level_keys": [
+          "U4 Cleaning Data Activity Guide Pt3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L16 Free Response",
+        "script_level.level_keys": [
+          "U4L16 Free Response"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L16 Choose 2",
+        "script_level.level_keys": [
+          "U4L16 Choose 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L16 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L16 Multiple Choice"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Cleaning Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Student Intro",
+        "script_level.level_keys": [
+          "U4L08v2 Student Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 2",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08v2 Making Pivot Tables Part 3",
+        "script_level.level_keys": [
+          "U4L08v2 Making Pivot Tables Part 3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Creating Summary Tables",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 - Student Introduction",
+        "script_level.level_keys": [
+          "U4L12 - Student Introduction"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Rapid Research - Data Innovations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L01 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L01 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L01 Free Response",
+        "script_level.level_keys": [
+          "U4L01 Free Response"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L01 Choose 2",
+        "script_level.level_keys": [
+          "U4L01 Choose 2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L01 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L01 Multiple Choice"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Why Make Apps?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Free Response",
+        "script_level.level_keys": [
+          "U4L02 Free Response"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 17,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Choose 2",
+        "script_level.level_keys": [
+          "U4L02 Choose 2"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 18,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L02 Multiple Choice"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 19,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 13,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 14,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 15,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 16,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 17,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 18,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L05 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L05 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 1,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L05 Free Response",
+        "script_level.level_keys": [
+          "U4L05 Free Response"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 2,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L05 Choose 2",
+        "script_level.level_keys": [
+          "U4L05 Choose 2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 3,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L05 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L05 Multiple Choice"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 4,
+        "lesson.key": "Search Terms",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L06 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Free Response",
+        "script_level.level_keys": [
+          "U4L06 Free Response"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Choose 2",
+        "script_level.level_keys": [
+          "U4L06 Choose 2"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L06 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L06 Multiple Choice"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Unique IDs, Delete and Update Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L07 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L07 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 10,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 11,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L07 Free Response",
+        "script_level.level_keys": [
+          "U4L07 Free Response"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 12,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L07 Choose 2",
+        "script_level.level_keys": [
+          "U4L07 Choose 2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 13,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L07 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L07 Multiple Choice"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 14,
+        "lesson.key": "Import, Export, and Visualize Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L08 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 1,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Free Response",
+        "script_level.level_keys": [
+          "U4L08 Free Response"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 2,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Choose 2",
+        "script_level.level_keys": [
+          "U4L08 Choose 2"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 3,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L08 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L08 Multiple Choice"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 4,
+        "lesson.key": "Interpreting Data Visualizations",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L09 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 1,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Free Response",
+        "script_level.level_keys": [
+          "U4L09 Free Response"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 2,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Choose 2",
+        "script_level.level_keys": [
+          "U4L09 Choose 2"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 3,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L09 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L09 Multiple Choice"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 4,
+        "lesson.key": "How is Data Collected?",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L10 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 Free Response",
+        "script_level.level_keys": [
+          "U4L10 Free Response"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 Choose 2",
+        "script_level.level_keys": [
+          "U4L10 Choose 2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L10 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L10 Multiple Choice"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Using Data in the Real World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L11 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L11 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L11 Free Response",
+        "script_level.level_keys": [
+          "U4L11 Free Response"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L11 Choose 2",
+        "script_level.level_keys": [
+          "U4L11 Choose 2"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L11 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L11 Multiple Choice"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Web Requests and APIs",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L12 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 1,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 Free Response",
+        "script_level.level_keys": [
+          "U4L12 Free Response"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 2,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 Choose 2",
+        "script_level.level_keys": [
+          "U4L12 Choose 2"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 3,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L12 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L12 Multiple Choice"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 4,
+        "lesson.key": "Data, Security, and Privacy",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L13 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L13 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L13 Free Response",
+        "script_level.level_keys": [
+          "U4L13 Free Response"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L13 Choose 2",
+        "script_level.level_keys": [
+          "U4L13 Choose 2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L13 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L13 Multiple Choice"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Privacy vs Utility",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L14 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L14 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L14 Free Response",
+        "script_level.level_keys": [
+          "U4L14 Free Response"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L14 Choose 2",
+        "script_level.level_keys": [
+          "U4L14 Choose 2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L14 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L14 Multiple Choice"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Privacy in a Digital World",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L15 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L15 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L15 Free Response",
+        "script_level.level_keys": [
+          "U4L15 Free Response"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L15 Choose 2",
+        "script_level.level_keys": [
+          "U4L15 Choose 2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L15 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L15 Multiple Choice"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Compiling Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L17 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L17 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L17 Free Response",
+        "script_level.level_keys": [
+          "U4L17 Free Response"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L17 Choose 2",
+        "script_level.level_keys": [
+          "U4L17 Choose 2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L17 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L17 Multiple Choice"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "Designing Data Collection",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L18 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L18 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 1,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L18 Free Response",
+        "script_level.level_keys": [
+          "U4L18 Free Response"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 2,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L18 Choose 2",
+        "script_level.level_keys": [
+          "U4L18 Choose 2"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 3,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L18 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L18 Multiple Choice"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 4,
+        "lesson.key": "Designing for Your User",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L19 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L19 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L19 Free Response",
+        "script_level.level_keys": [
+          "U4L19 Free Response"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L19 Choose 2",
+        "script_level.level_keys": [
+          "U4L19 Choose 2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L19 Multiple Choice",
+        "script_level.level_keys": [
+          "U4L19 Multiple Choice"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Practice Create PT: Data App",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Data Unit -Counting Records - Hard Way",
+        "script_level.level_keys": [
+          "CSP Data Unit -Counting Records - Hard Way"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Data Unit -Counting Records - Easy Way",
+        "script_level.level_keys": [
+          "CSP Data Unit -Counting Records - Easy Way"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Data Unit - Counting Multiple Things",
+        "script_level.level_keys": [
+          "CSP Data Unit - Counting Multiple Things"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "What Data Can Tell Us",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L22 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U3L22 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L17 - introKeyValue",
+        "script_level.level_keys": [
+          "U3L17 - introKeyValue"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L17 - setKeyValue",
+        "script_level.level_keys": [
+          "U3L17 - setKeyValue"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L17 - twoSetKeyValue",
+        "script_level.level_keys": [
+          "U3L17 - twoSetKeyValue"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L17 - introCallbacks",
+        "script_level.level_keys": [
+          "U3L17 - introCallbacks"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L17 - getKeyValue",
+        "script_level.level_keys": [
+          "U3L17 - getKeyValue"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L22 Free Response Getting Started",
+        "script_level.level_keys": [
+          "U3L22 Free Response Getting Started"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L22 Assessment",
+        "script_level.level_keys": [
+          "U3L22 Assessment"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L22 Reflection",
+        "script_level.level_keys": [
+          "U3L22 Reflection"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage and Clicker Completion",
+        "lesson_group.key": "",
+        "script.name": "cspunit4draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit5.script_json
+++ b/dashboard/config/scripts_json/cspunit5.script_json
@@ -1,0 +1,231 @@
+{
+  "script": {
+    "name": "cspunit5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Explore PT Prep",
+      "name": "Explore PT Prep",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "key": "Explore PT",
+      "name": "Explore PT",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "key": "Create PT Prep",
+      "name": "Create PT Prep",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "key": "Create PT",
+      "name": "Create PT",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Create PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 - Explore PT Prep - Student Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      },
+      "level_keys": [
+        "U5 - Explore PT Prep - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 - Explore PT - Student Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      },
+      "level_keys": [
+        "U5 - Explore PT - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 - Create PT Prep - Student Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      },
+      "level_keys": [
+        "U5 - Create PT Prep - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U5 - Create PT - Student Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      },
+      "level_keys": [
+        "U5 - Create PT - Student Introduction"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U5 - Explore PT Prep - Student Introduction",
+        "script_level.level_keys": [
+          "U5 - Explore PT Prep - Student Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 - Explore PT - Student Introduction",
+        "script_level.level_keys": [
+          "U5 - Explore PT - Student Introduction"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Explore PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 - Create PT Prep - Student Introduction",
+        "script_level.level_keys": [
+          "U5 - Create PT Prep - Student Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Create PT Prep",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U5 - Create PT - Student Introduction",
+        "script_level.level_keys": [
+          "U5 - Create PT - Student Introduction"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Create PT",
+        "lesson_group.key": "",
+        "script.name": "cspunit5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit6.script_json
+++ b/dashboard/config/scripts_json/cspunit6.script_json
@@ -1,0 +1,2751 @@
+{
+  "script": {
+    "name": "cspunit6",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit6"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Deleting Records",
+      "name": "Deleting Records",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Updating Records",
+      "name": "Updating Records",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Importing and Exporting Data",
+      "name": "Importing and Exporting Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Visualizing Data",
+      "name": "Visualizing Data",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Sample Apps",
+      "name": "Sample Apps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "key": "Final Project",
+      "name": "Final Project",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - deleteRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Default Block"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Callback Success Parameter"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Update Nonexistent Record"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit UI"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit event handler"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Save edited contact"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - ImportExport - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Charts - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - User Login"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Class Survey"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Clicker Game"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Flashcards"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Final Project - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      },
+      "level_keys": [
+        "U6 - Final Project - Project Level"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - deleteRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Default Block",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Callback Success Parameter",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Update Nonexistent Record",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit UI",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit event handler",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Save edited contact",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - ImportExport - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Charts - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - User Login",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Class Survey",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Clicker Game",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Flashcards",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Project Level",
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/cspunit6draft.script_json
+++ b/dashboard/config/scripts_json/cspunit6draft.script_json
@@ -1,0 +1,2750 @@
+{
+  "script": {
+    "name": "cspunit6draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "cspunit6draft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Creating Javascript Objects",
+      "name": "Creating Javascript Objects",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Permanent Data Storage",
+      "name": "Permanent Data Storage",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Reading Records",
+      "name": "Reading Records",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Deleting Records",
+      "name": "Deleting Records",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Updating Records",
+      "name": "Updating Records",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Importing and Exporting Data",
+      "name": "Importing and Exporting Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Visualizing Data",
+      "name": "Visualizing Data",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Sample Apps",
+      "name": "Sample Apps",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "key": "Final Project",
+      "name": "Final Project",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4L02 Student Lesson Introduction Video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - eventParameter"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - dotNotation"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createDotNotation"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - arraysOfObjects"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - accessingPropertiesInArray"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - exemplarContactsApp"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - readStarterCode"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactsData"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showContact3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - pullValues"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - createContactObject"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - resetIndexAndShow"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Objects - showSampleImage"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4L03 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 2.5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - CreateRecord - 5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Edit Data Table by Hand"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - debug column names are case sensitive"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Add Row By Hand"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - add createRecord to contacts App"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - fix contacts by hand in data table"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - last stage test adding contcts"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4L04 Student Lesson Introduction"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 1.3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 4.1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - 5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 1"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Read Record - Local vs Remote Data External"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - deleteRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Unique Ids Explanation"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 0"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 1"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - deleteRecords 2 delete object"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - ReadRecords - Contacts App 5 make delete work"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Default Block"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Callback Success Parameter"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Update Nonexistent Record"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit UI"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Edit event handler"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - updateRecord - Contacts - Save edited contact"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - ImportExport - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 1"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Import Data 2"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Remixing Apps with Data"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Export Data"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Charts - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords 1"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Scatter Chart"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - Line Chart 2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U4 - Charts - drawChartFromRecords Options 2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - User Login"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Class Survey"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Clicker Game"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Sample Apps - Flashcards"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Final Project - Student Introduction"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      },
+      "level_keys": [
+        "U6 - Final Project - Project Level"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U4L02 Student Lesson Introduction Video",
+        "script_level.level_keys": [
+          "U4L02 Student Lesson Introduction Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - eventParameter",
+        "script_level.level_keys": [
+          "U4 - Objects - eventParameter"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - dotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - dotNotation"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createDotNotation",
+        "script_level.level_keys": [
+          "U4 - Objects - createDotNotation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - arraysOfObjects",
+        "script_level.level_keys": [
+          "U4 - Objects - arraysOfObjects"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - accessingPropertiesInArray",
+        "script_level.level_keys": [
+          "U4 - Objects - accessingPropertiesInArray"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - exemplarContactsApp",
+        "script_level.level_keys": [
+          "U4 - Objects - exemplarContactsApp"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - readStarterCode",
+        "script_level.level_keys": [
+          "U4 - Objects - readStarterCode"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactsData",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactsData"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact1",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact2",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showContact3",
+        "script_level.level_keys": [
+          "U4 - Objects - showContact3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - pullValues",
+        "script_level.level_keys": [
+          "U4 - Objects - pullValues"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - createContactObject",
+        "script_level.level_keys": [
+          "U4 - Objects - createContactObject"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - resetIndexAndShow",
+        "script_level.level_keys": [
+          "U4 - Objects - resetIndexAndShow"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Objects - showSampleImage",
+        "script_level.level_keys": [
+          "U4 - Objects - showSampleImage"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Creating Javascript Objects",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L03 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L03 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 1",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 2.5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 2.5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 3",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 4",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - CreateRecord - 5",
+        "script_level.level_keys": [
+          "U4 - CreateRecord - 5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Edit Data Table by Hand",
+        "script_level.level_keys": [
+          "U4 - Edit Data Table by Hand"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - debug column names are case sensitive",
+        "script_level.level_keys": [
+          "U4 - debug column names are case sensitive"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Add Row By Hand",
+        "script_level.level_keys": [
+          "U4 - Add Row By Hand"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - add createRecord to contacts App",
+        "script_level.level_keys": [
+          "U4 - add createRecord to contacts App"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - fix contacts by hand in data table",
+        "script_level.level_keys": [
+          "U4 - fix contacts by hand in data table"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - last stage test adding contcts",
+        "script_level.level_keys": [
+          "U4 - last stage test adding contcts"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Permanent Data Storage",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4L04 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U4L04 Student Lesson Introduction"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 1.3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 1.3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 2",
+        "script_level.level_keys": [
+          "U4 - Read Record - 2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 3",
+        "script_level.level_keys": [
+          "U4 - Read Record - 3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 4.1",
+        "script_level.level_keys": [
+          "U4 - Read Record - 4.1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - 5",
+        "script_level.level_keys": [
+          "U4 - Read Record - 5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 1",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 1"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Read Record - Local vs Remote Data External",
+        "script_level.level_keys": [
+          "U4 - Read Record - Local vs Remote Data External"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 2",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 3",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Reading Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - deleteRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - deleteRecord - Student Introduction"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Unique Ids Explanation",
+        "script_level.level_keys": [
+          "U4 - Unique Ids Explanation"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 0",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 0"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 1",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 1"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - deleteRecords 2 delete object",
+        "script_level.level_keys": [
+          "U4 - deleteRecords 2 delete object"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 4",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - ReadRecords - Contacts App 5 make delete work",
+        "script_level.level_keys": [
+          "U4 - ReadRecords - Contacts App 5 make delete work"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Deleting Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Student Introduction"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Default Block",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Default Block"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Callback Success Parameter",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Callback Success Parameter"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Update Nonexistent Record",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Update Nonexistent Record"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit UI",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit UI"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Edit event handler",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Edit event handler"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - updateRecord - Contacts - Save edited contact",
+        "script_level.level_keys": [
+          "U6 - updateRecord - Contacts - Save edited contact"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Updating Records",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - ImportExport - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - ImportExport - Student Introduction"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 1"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Import Data 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Import Data 2"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Remixing Apps with Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Remixing Apps with Data"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Export Data",
+        "script_level.level_keys": [
+          "U4 - Charts - Export Data"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Importing and Exporting Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Charts - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Charts - Student Introduction"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords 1"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Scatter Chart",
+        "script_level.level_keys": [
+          "U4 - Charts - Scatter Chart"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 1",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - Line Chart 2",
+        "script_level.level_keys": [
+          "U4 - Charts - Line Chart 2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 1",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 - Charts - drawChartFromRecords Options 2",
+        "script_level.level_keys": [
+          "U4 - Charts - drawChartFromRecords Options 2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Visualizing Data",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Student Introduction"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - User Login",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - User Login"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Class Survey",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Class Survey"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Clicker Game",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Clicker Game"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Sample Apps - Flashcards",
+        "script_level.level_keys": [
+          "U6 - Sample Apps - Flashcards"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Sample Apps",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Student Introduction",
+        "script_level.level_keys": [
+          "U6 - Final Project - Student Introduction"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U6 - Final Project - Project Level",
+        "script_level.level_keys": [
+          "U6 - Final Project - Project Level"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Final Project",
+        "lesson_group.key": "",
+        "script.name": "cspunit6draft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/curriculum-sandbox-levels.script_json
+++ b/dashboard/config/scripts_json/curriculum-sandbox-levels.script_json
@@ -1,0 +1,546 @@
+{
+  "script": {
+    "name": "curriculum-sandbox-levels",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "curriculum-sandbox-levels"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lesson group",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "display name"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Course A",
+      "name": "Course A",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "key": "Course B",
+      "name": "Course B",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "key": "Course E/F",
+      "name": "Course E/F",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course E/F",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "key": "CS Discoveries",
+      "name": "CS Discoveries",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Discoveries",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10_predict1_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseB_maze_seq10_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1_predict1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseB_maze_seq1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops3_predict1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseA_collector_loops3_predict1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops11_predict2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseA_collector_loops11_predict2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11_predict2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseA_artist_loops11_predict2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq2_predict1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseA_maze_seq2_predict1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_predict2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_predict2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_predict1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_predict1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_predict1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "teacherSandboxFish"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Course E/F",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "teacherSandboxFish"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Swimming Fish Teacher Sandbox"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Course E/F",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "Swimming Fish Teacher Sandbox"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search big"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP word search big"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating big"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      },
+      "level_keys": [
+        "csd digital unplugged PSP seating big"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10_predict1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq10_predict1_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1_predict1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq1_predict1_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops3_predict1",
+        "script_level.level_keys": [
+          "courseA_collector_loops3_predict1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops11_predict2",
+        "script_level.level_keys": [
+          "courseA_collector_loops11_predict2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11_predict2",
+        "script_level.level_keys": [
+          "courseA_artist_loops11_predict2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Course A",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq2_predict1",
+        "script_level.level_keys": [
+          "courseA_maze_seq2_predict1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_predict2",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_predict2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_predict1",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_predict1",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_predict1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Course B",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "teacherSandboxFish",
+        "script_level.level_keys": [
+          "teacherSandboxFish"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Course E/F",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Swimming Fish Teacher Sandbox",
+        "script_level.level_keys": [
+          "Swimming Fish Teacher Sandbox"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Course E/F",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP word search big",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP word search big"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "CS Discoveries",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd digital unplugged PSP seating big",
+        "script_level.level_keys": [
+          "csd digital unplugged PSP seating big"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "CS Discoveries",
+        "lesson_group.key": "lesson group",
+        "script.name": "curriculum-sandbox-levels"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dance-2019.script_json
+++ b/dashboard/config/scripts_json/dance-2019.script_json
@@ -1,0 +1,399 @@
+{
+  "script": {
+    "name": "dance-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_01"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_02"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_03"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_04"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_05"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_06"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_07"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_07"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_08"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_08"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_09"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_09"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_2019_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      },
+      "level_keys": [
+        "Dance_2019_10"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_01",
+        "script_level.level_keys": [
+          "Dance_2019_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_02",
+        "script_level.level_keys": [
+          "Dance_2019_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_03",
+        "script_level.level_keys": [
+          "Dance_2019_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_04",
+        "script_level.level_keys": [
+          "Dance_2019_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_05",
+        "script_level.level_keys": [
+          "Dance_2019_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_06",
+        "script_level.level_keys": [
+          "Dance_2019_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_07",
+        "script_level.level_keys": [
+          "Dance_2019_07"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_08",
+        "script_level.level_keys": [
+          "Dance_2019_08"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_09",
+        "script_level.level_keys": [
+          "Dance_2019_09"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_2019_10",
+        "script_level.level_keys": [
+          "Dance_2019_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dance-draft.script_json
+++ b/dashboard/config/scripts_json/dance-draft.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "dance-draft",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-draft"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/dance-extras-2019.script_json
+++ b/dashboard/config/scripts_json/dance-extras-2019.script_json
@@ -1,0 +1,364 @@
+{
+  "script": {
+    "name": "dance-extras-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-extras-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party - Go Further",
+      "name": "Dance Party - Go Further",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_intro_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_intro_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_alternate_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_alternate_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_mixed_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_mixed_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_layout_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_layout_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_visible_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_visible_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_battle_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_battle_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_every_beat_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_every_beat_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_on_beat_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_on_beat_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_speed_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      },
+      "level_keys": [
+        "Dance_Party_extras_speed_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_intro_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_intro_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_alternate_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_alternate_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_mixed_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_mixed_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_layout_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_layout_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_visible_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_visible_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_battle_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_battle_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_every_beat_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_every_beat_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_on_beat_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_on_beat_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_speed_2019",
+        "script_level.level_keys": [
+          "Dance_Party_extras_speed_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dance-extras-gallery.script_json
+++ b/dashboard/config/scripts_json/dance-extras-gallery.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "dance-extras-gallery",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-extras-gallery"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "dance-extras-gallery"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party - Go Further",
+      "name": "Dance Party - Go Further",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-gallery"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_gallery_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-gallery"
+      },
+      "level_keys": [
+        "Dance_Party_extras_gallery_intro"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_gallery_intro",
+        "script_level.level_keys": [
+          "Dance_Party_extras_gallery_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras-gallery"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dance-extras.script_json
+++ b/dashboard/config/scripts_json/dance-extras.script_json
@@ -1,0 +1,294 @@
+{
+  "script": {
+    "name": "dance-extras",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-extras"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party - Go Further",
+      "name": "Dance Party - Go Further",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_layout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_layout"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_visible"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_visible"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_battle"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_battle"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_every_beat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_every_beat"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_on_beat"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_on_beat"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_extras_speed"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      },
+      "level_keys": [
+        "Dance_Party_extras_speed"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_intro",
+        "script_level.level_keys": [
+          "Dance_Party_extras_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_layout",
+        "script_level.level_keys": [
+          "Dance_Party_extras_layout"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_visible",
+        "script_level.level_keys": [
+          "Dance_Party_extras_visible"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_battle",
+        "script_level.level_keys": [
+          "Dance_Party_extras_battle"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_every_beat",
+        "script_level.level_keys": [
+          "Dance_Party_extras_every_beat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_on_beat",
+        "script_level.level_keys": [
+          "Dance_Party_extras_on_beat"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_extras_speed",
+        "script_level.level_keys": [
+          "Dance_Party_extras_speed"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party - Go Further",
+        "lesson_group.key": "",
+        "script.name": "dance-extras"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dance-low.script_json
+++ b/dashboard/config/scripts_json/dance-low.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "dance-low",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance-low"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/dance.script_json
+++ b/dashboard/config/scripts_json/dance.script_json
@@ -1,0 +1,505 @@
+{
+  "script": {
+    "name": "dance",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true,
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dance"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_08"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_09"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_11b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_11_5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance_Party_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      },
+      "level_keys": [
+        "Dance_Party_12"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_01",
+        "script_level.level_keys": [
+          "Dance_Party_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_02",
+        "script_level.level_keys": [
+          "Dance_Party_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_03",
+        "script_level.level_keys": [
+          "Dance_Party_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_04",
+        "script_level.level_keys": [
+          "Dance_Party_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_05",
+        "script_level.level_keys": [
+          "Dance_Party_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_06",
+        "script_level.level_keys": [
+          "Dance_Party_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_08",
+        "script_level.level_keys": [
+          "Dance_Party_08"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_09",
+        "script_level.level_keys": [
+          "Dance_Party_09"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_10",
+        "script_level.level_keys": [
+          "Dance_Party_10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_11",
+        "script_level.level_keys": [
+          "Dance_Party_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_11b",
+        "script_level.level_keys": [
+          "Dance_Party_11b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_11_5",
+        "script_level.level_keys": [
+          "Dance_Party_11_5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance_Party_12",
+        "script_level.level_keys": [
+          "Dance_Party_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "",
+        "script.name": "dance"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dani-june-2020-test.script_json
+++ b/dashboard/config/scripts_json/dani-june-2020-test.script_json
@@ -1,0 +1,267 @@
+{
+  "script": {
+    "name": "dani-june-2020-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dani-june-2020-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lesson group",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "display name"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lesson group",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "lg_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "DISPLAYNAME"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lg_1",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "cspSurvey",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Survey"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cspSurvey",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "cs_lg",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "LG GOOD"
+      },
+      "seeding_key": {
+        "lesson_group.key": "cs_lg",
+        "script.name": "dani-june-2020-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "new lesson",
+      "name": "new lesson",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "new lesson",
+        "lesson_group.key": "lesson group",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "lesson 2",
+      "name": "lesson 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "lesson 2",
+        "lesson_group.key": "lg_1",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "CS Principles Pre-survey",
+      "name": "CS Principles Pre-survey",
+      "absolute_position": 3,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "key": "Buttons and Events",
+      "name": "Buttons and Events",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "cs_lg",
+        "script.name": "dani-june-2020-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_virtual_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new lesson",
+        "lesson_group.key": "lesson group",
+        "script.name": "dani-june-2020-test"
+      },
+      "level_keys": [
+        "CSD U3L12 TFMD_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_virtual_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "lesson 2",
+        "lesson_group.key": "lg_1",
+        "script.name": "dani-june-2020-test"
+      },
+      "level_keys": [
+        "CSD U3 dancing alien_virtual_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "dani-june-2020-test"
+      },
+      "level_keys": [
+        "csp-pre-survey-levelgroup_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "cs_lg",
+        "script.name": "dani-june-2020-test"
+      },
+      "level_keys": [
+        "CSP U5L01 SFLP_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3L12 TFMD_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3L12 TFMD_virtual_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new lesson",
+        "lesson_group.key": "lesson group",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 dancing alien_virtual_2020",
+        "script_level.level_keys": [
+          "CSD U3 dancing alien_virtual_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "lesson 2",
+        "lesson_group.key": "lg_1",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-pre-survey-levelgroup_2019",
+        "script_level.level_keys": [
+          "csp-pre-survey-levelgroup_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "CS Principles Pre-survey",
+        "lesson_group.key": "cspSurvey",
+        "script.name": "dani-june-2020-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP U5L01 SFLP_2019",
+        "script_level.level_keys": [
+          "CSP U5L01 SFLP_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Buttons and Events",
+        "lesson_group.key": "cs_lg",
+        "script.name": "dani-june-2020-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/deepdive-debugging.script_json
+++ b/dashboard/config/scripts_json/deepdive-debugging.script_json
@@ -1,0 +1,272 @@
+{
+  "script": {
+    "name": "deepdive-debugging",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "deepdive-debugging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging for AB Educators",
+      "name": "Debugging for AB Educators",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "key": "Debugging for CDEF Educators",
+      "name": "Debugging for CDEF Educators",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AB_debug_Laurel1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "AB_debug_Laurel1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AB_Debug_Artist1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "AB_Debug_Artist1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AB_Debug_PlayLab3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "AB_Debug_PlayLab3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_debugging_farmer1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "CDEF_debugging_farmer1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_debugging_Artist1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "CDEF_debugging_Artist1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_debugging_flappy2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      },
+      "level_keys": [
+        "CDEF_debugging_flappy2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "AB_debug_Laurel1",
+        "script_level.level_keys": [
+          "AB_debug_Laurel1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AB_Debug_Artist1",
+        "script_level.level_keys": [
+          "AB_Debug_Artist1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AB_Debug_PlayLab3",
+        "script_level.level_keys": [
+          "AB_Debug_PlayLab3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Debugging for AB Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_debugging_farmer1",
+        "script_level.level_keys": [
+          "CDEF_debugging_farmer1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_debugging_Artist1",
+        "script_level.level_keys": [
+          "CDEF_debugging_Artist1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_debugging_flappy2",
+        "script_level.level_keys": [
+          "CDEF_debugging_flappy2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Debugging for CDEF Educators",
+        "lesson_group.key": "",
+        "script.name": "deepdive-debugging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/denny-science-8.script_json
+++ b/dashboard/config/scripts_json/denny-science-8.script_json
@@ -1,0 +1,413 @@
+{
+  "script": {
+    "name": "denny-science-8",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "pilot_experiment": "denny-science-piloters"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "denny-science-8"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Collision Detector: Designing Screens",
+      "name": "Collision Detector: Designing Screens",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "key": "Collision Detector: Processing with Events",
+      "name": "Collision Detector: Processing with Events",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD mini design mode video_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "CSD mini design mode video_copy"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake 1_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science earthquake 1_copy"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake text_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science earthquake text_copy"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake images_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science earthquake images_copy"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake reflect_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science earthquake reflect_copy"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science Circuit Playground Test_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science Circuit Playground Test_copy"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event demo_copy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science event demo_copy"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event accel_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science event accel_copy"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event test_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science event test_copy"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event challenge"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      },
+      "level_keys": [
+        "Science event challenge"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD mini design mode video_copy",
+        "script_level.level_keys": [
+          "CSD mini design mode video_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake 1_copy",
+        "script_level.level_keys": [
+          "Science earthquake 1_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake text_copy",
+        "script_level.level_keys": [
+          "Science earthquake text_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake images_copy",
+        "script_level.level_keys": [
+          "Science earthquake images_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake reflect_copy",
+        "script_level.level_keys": [
+          "Science earthquake reflect_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science Circuit Playground Test_copy",
+        "script_level.level_keys": [
+          "Science Circuit Playground Test_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event demo_copy",
+        "script_level.level_keys": [
+          "Science event demo_copy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event accel_copy",
+        "script_level.level_keys": [
+          "Science event accel_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event test_copy",
+        "script_level.level_keys": [
+          "Science event test_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event challenge",
+        "script_level.level_keys": [
+          "Science event challenge"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-8"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/denny-science-copy.script_json
+++ b/dashboard/config/scripts_json/denny-science-copy.script_json
@@ -1,0 +1,482 @@
+{
+  "script": {
+    "name": "denny-science-copy",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "denny-science-copy"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Collision Detector: Designing Screens",
+      "name": "Collision Detector: Designing Screens",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "key": "Collision Detector: Processing with Events",
+      "name": "Collision Detector: Processing with Events",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD mini design mode video_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "CSD mini design mode video_copy"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design Mode Map_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Design Mode Map_copy"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake 1_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science earthquake 1_copy"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake text_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science earthquake text_copy"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake images_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science earthquake images_copy"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake reflect_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science earthquake reflect_copy"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science change screen map_copy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science change screen map_copy"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science board event map_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science board event map_copy"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science Circuit Playground Test_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science Circuit Playground Test_copy"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event demo_copy"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science event demo_copy"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event accel_copy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science event accel_copy"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event test_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      },
+      "level_keys": [
+        "Science event test_copy"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD mini design mode video_copy",
+        "script_level.level_keys": [
+          "CSD mini design mode video_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design Mode Map_copy",
+        "script_level.level_keys": [
+          "Design Mode Map_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake 1_copy",
+        "script_level.level_keys": [
+          "Science earthquake 1_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake text_copy",
+        "script_level.level_keys": [
+          "Science earthquake text_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake images_copy",
+        "script_level.level_keys": [
+          "Science earthquake images_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake reflect_copy",
+        "script_level.level_keys": [
+          "Science earthquake reflect_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science change screen map_copy",
+        "script_level.level_keys": [
+          "Science change screen map_copy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science board event map_copy",
+        "script_level.level_keys": [
+          "Science board event map_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science Circuit Playground Test_copy",
+        "script_level.level_keys": [
+          "Science Circuit Playground Test_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event demo_copy",
+        "script_level.level_keys": [
+          "Science event demo_copy"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event accel_copy",
+        "script_level.level_keys": [
+          "Science event accel_copy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event test_copy",
+        "script_level.level_keys": [
+          "Science event test_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science-copy"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/denny-science.script_json
+++ b/dashboard/config/scripts_json/denny-science.script_json
@@ -1,0 +1,483 @@
+{
+  "script": {
+    "name": "denny-science",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "pilot_experiment": "denny-science-piloters"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "denny-science"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Earthquake Detector: Designing Screens",
+      "name": "Earthquake Detector: Designing Screens",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "key": "Earthquake Detector: Processing with Events",
+      "name": "Earthquake Detector: Processing with Events",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD mini design mode video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "CSD mini design mode video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design Mode Map"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Design Mode Map"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science earthquake 1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake text"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science earthquake text"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake images"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science earthquake images"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science earthquake reflect"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science earthquake reflect"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science change screen map"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science change screen map"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science board event map"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science board event map"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science Circuit Playground Test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science Circuit Playground Test"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event demo"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science event demo"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event accel"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science event accel"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Science event test"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      },
+      "level_keys": [
+        "Science event test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD mini design mode video",
+        "script_level.level_keys": [
+          "CSD mini design mode video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design Mode Map",
+        "script_level.level_keys": [
+          "Design Mode Map"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake 1",
+        "script_level.level_keys": [
+          "Science earthquake 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake text",
+        "script_level.level_keys": [
+          "Science earthquake text"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake images",
+        "script_level.level_keys": [
+          "Science earthquake images"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science earthquake reflect",
+        "script_level.level_keys": [
+          "Science earthquake reflect"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Earthquake Detector: Designing Screens",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science change screen map",
+        "script_level.level_keys": [
+          "Science change screen map"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science board event map",
+        "script_level.level_keys": [
+          "Science board event map"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science Circuit Playground Test",
+        "script_level.level_keys": [
+          "Science Circuit Playground Test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event demo",
+        "script_level.level_keys": [
+          "Science event demo"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event accel",
+        "script_level.level_keys": [
+          "Science event accel"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Science event test",
+        "script_level.level_keys": [
+          "Science event test"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Earthquake Detector: Processing with Events",
+        "lesson_group.key": "",
+        "script.name": "denny-science"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csd-mod-fit.script_json
+++ b/dashboard/config/scripts_json/dlp19-csd-mod-fit.script_json
@@ -1,0 +1,342 @@
+{
+  "script": {
+    "name": "dlp19-csd-mod-fit",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 2,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csd-mod-fit"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "key": "Understanding the Curriculum",
+      "name": "Understanding the Curriculum",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "key": "Demonstrating Understanding",
+      "name": "Demonstrating Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_csd_prework-fit_content1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_csd_prework-fit_content1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_csd_prework-fit-prompt"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_csd_prework-fit-prompt"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_csd_prework-fit_content1",
+        "script_level.level_keys": [
+          "dlp19_csd_prework-fit_content1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_csd_prework-fit-prompt",
+        "script_level.level_keys": [
+          "dlp19_csd_prework-fit-prompt"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-fit"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csd-mod-w1.script_json
+++ b/dashboard/config/scripts_json/dlp19-csd-mod-w1.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csd-mod-w1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csd-mod-w1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csd-prework-mod1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csd-mod1-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csd-mod1-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csd-mod1-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-prework-mod1",
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod1-q1",
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod1-q2",
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod1-q3",
+        "script_level.level_keys": [
+          "dlp19-csd-mod1-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csd-mod-w2.script_json
+++ b/dashboard/config/scripts_json/dlp19-csd-mod-w2.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csd-mod-w2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csd-mod-w2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csd-prework-mod2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csd-mod2-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csd-mod2-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csd-mod2-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-prework-mod2",
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod2-q1",
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod2-q2",
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod2-q3",
+        "script_level.level_keys": [
+          "dlp19-csd-mod2-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csd-mod-w3.script_json
+++ b/dashboard/config/scripts_json/dlp19-csd-mod-w3.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csd-mod-w3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csd-mod-w3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csd-prework-mod3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csd-mod3-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csd-mod3-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csd-mod3-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-prework-mod3",
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod3-q1",
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod3-q2",
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod3-q3",
+        "script_level.level_keys": [
+          "dlp19-csd-mod3-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csd-mod-w4.script_json
+++ b/dashboard/config/scripts_json/dlp19-csd-mod-w4.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csd-mod-w4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Discoveries Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csd-mod-w4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csd-prework-mod4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csd-mod4-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csd-mod4-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csd-mod4-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-prework-mod4",
+        "script_level.level_keys": [
+          "dlp19-csd-prework-mod4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod4-q1",
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod4-q2",
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csd-mod4-q3",
+        "script_level.level_keys": [
+          "dlp19-csd-mod4-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csd-mod-w4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csp-mod-fit.script_json
+++ b/dashboard/config/scripts_json/dlp19-csp-mod-fit.script_json
@@ -1,0 +1,342 @@
+{
+  "script": {
+    "name": "dlp19-csp-mod-fit",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 2,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csp-mod-fit"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "key": "Understanding the Curriculum",
+      "name": "Understanding the Curriculum",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "key": "Demonstrating Understanding",
+      "name": "Demonstrating Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_csp_prework-fit_content1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_csp_prework-fit_content1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_csp_prework-fit-prompt"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      },
+      "level_keys": [
+        "dlp19_csp_prework-fit-prompt"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_csp_prework-fit_content1",
+        "script_level.level_keys": [
+          "dlp19_csp_prework-fit_content1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Curriculum",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_csp_prework-fit-prompt",
+        "script_level.level_keys": [
+          "dlp19_csp_prework-fit-prompt"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Demonstrating Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-fit"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csp-mod-w1.script_json
+++ b/dashboard/config/scripts_json/dlp19-csp-mod-w1.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csp-mod-w1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csp-mod-w1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csp-prework-mod1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csp-mod1-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csp-mod1-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      },
+      "level_keys": [
+        "dlp19-csp-mod1-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-prework-mod1",
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod1-q1",
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod1-q2",
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod1-q3",
+        "script_level.level_keys": [
+          "dlp19-csp-mod1-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csp-mod-w2.script_json
+++ b/dashboard/config/scripts_json/dlp19-csp-mod-w2.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csp-mod-w2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csp-mod-w2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csp-prework-mod2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csp-mod2-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csp-mod2-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      },
+      "level_keys": [
+        "dlp19-csp-mod2-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-prework-mod2",
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod2-q1",
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod2-q2",
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod2-q3",
+        "script_level.level_keys": [
+          "dlp19-csp-mod2-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csp-mod-w3.script_json
+++ b/dashboard/config/scripts_json/dlp19-csp-mod-w3.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csp-mod-w3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csp-mod-w3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csp-prework-mod3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csp-mod3-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csp-mod3-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      },
+      "level_keys": [
+        "dlp19-csp-mod3-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-prework-mod3",
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod3-q1",
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod3-q2",
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod3-q3",
+        "script_level.level_keys": [
+          "dlp19-csp-mod3-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/dlp19-csp-mod-w4.script_json
+++ b/dashboard/config/scripts_json/dlp19-csp-mod-w4.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "dlp19-csp-mod-w4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS Principles Deeper Learning 2019 - 2020",
+      "peer_reviews_to_complete": 6,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "dlp19-csp-mod-w4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "key": "Step 1: Develop Understanding",
+      "name": "Step 1: Develop Understanding",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "key": "Step 2: Demonstrate Understanding",
+      "name": "Step 2: Demonstrate Understanding",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Process"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Preparation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluation"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Due Dates"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19_overview5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csp-prework-mod4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csp-mod4-q1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csp-mod4-q2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      },
+      "level_keys": [
+        "dlp19-csp-mod4-q3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview1",
+        "script_level.level_keys": [
+          "dlp19_overview1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview2",
+        "script_level.level_keys": [
+          "dlp19_overview2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview3",
+        "script_level.level_keys": [
+          "dlp19_overview3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview4",
+        "script_level.level_keys": [
+          "dlp19_overview4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19_overview5",
+        "script_level.level_keys": [
+          "dlp19_overview5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-prework-mod4",
+        "script_level.level_keys": [
+          "dlp19-csp-prework-mod4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Step 1: Develop Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod4-q1",
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod4-q2",
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp19-csp-mod4-q3",
+        "script_level.level_keys": [
+          "dlp19-csp-mod4-q3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Step 2: Demonstrate Understanding",
+        "lesson_group.key": "content",
+        "script.name": "dlp19-csp-mod-w4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/duino.script_json
+++ b/dashboard/config/scripts_json/duino.script_json
@@ -1,0 +1,370 @@
+{
+  "script": {
+    "name": "duino",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "duino"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Basic Circuits",
+      "name": "Basic Circuits",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Basic Circuits",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "key": "Blinky Lights",
+      "name": "Blinky Lights",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Blinky Lights",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "key": "Making Music",
+      "name": "Making Music",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "key": "JunkBot",
+      "name": "JunkBot",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "JunkBot",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino battery led"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Basic Circuits",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino battery led"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino button led"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Basic Circuits",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino button led"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino multi leds"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Blinky Lights",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino multi leds"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino pov"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Blinky Lights",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino pov"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino music"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino music"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino auduino"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino auduino"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino junkbot build"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "JunkBot",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino junkbot build"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "duino junkbot software"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "JunkBot",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      },
+      "level_keys": [
+        "duino junkbot software"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "duino battery led",
+        "script_level.level_keys": [
+          "duino battery led"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Basic Circuits",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino button led",
+        "script_level.level_keys": [
+          "duino button led"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Basic Circuits",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino multi leds",
+        "script_level.level_keys": [
+          "duino multi leds"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Blinky Lights",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino pov",
+        "script_level.level_keys": [
+          "duino pov"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Blinky Lights",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino music",
+        "script_level.level_keys": [
+          "duino music"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino auduino",
+        "script_level.level_keys": [
+          "duino auduino"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Making Music",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino junkbot build",
+        "script_level.level_keys": [
+          "duino junkbot build"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "JunkBot",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "duino junkbot software",
+        "script_level.level_keys": [
+          "duino junkbot software"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "JunkBot",
+        "lesson_group.key": "",
+        "script.name": "duino"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/e-f-ramp.script_json
+++ b/dashboard/config/scripts_json/e-f-ramp.script_json
@@ -1,0 +1,6815 @@
+{
+  "script": {
+    "name": "e-f-ramp",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "e-f-ramp"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_e_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course E (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "csf_e_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course E Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Algorithms: Dice Race",
+      "name": "Algorithms: Dice Race",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Course E Introduction",
+      "name": "Course E Introduction",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Functions in Farmer",
+      "name": "Functions in Farmer",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Internet",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_unplugged_privateInformation"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions1"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions5"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions8"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions9"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions10"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions11_predict1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions1"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions2"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions3"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions4"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions5"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions6"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions7"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions8"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions9"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions10"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions4b"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions5c"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions6c"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7b"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8b"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9b"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10b"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_concept1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_concept2"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_concept3"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_concept1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_concept4"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_bee_concept5"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_concept4"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold1"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold2"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold3"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold4"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold5"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold6"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseE_playLab_challenge1"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Geometric Sun"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Robot Doodle"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Alien Defender"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Find the Wizard"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Course E: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Course E: Artist Project"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      },
+      "level_keys": [
+        "Crowdsourcing"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_privateInformation",
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions1",
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions2",
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions3",
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions4",
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions5",
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions6",
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions7",
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions8",
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions9",
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions10",
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions11_predict1",
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1",
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2",
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3",
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4",
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5",
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions6",
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7",
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8",
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9",
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10",
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions4b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions5c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions6c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1",
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2",
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3",
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1",
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4",
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5",
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4",
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold1",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold2",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold3",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold4",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold5",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold6",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_challenge1",
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun",
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle",
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Alien Defender",
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Find the Wizard",
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Play Lab Project",
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project",
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing",
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "e-f-ramp"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit1.script_json
+++ b/dashboard/config/scripts_json/ecs-unit1.script_json
@@ -1,0 +1,1785 @@
+{
+  "script": {
+    "name": "ecs-unit1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Days 1-2 What Is a Computer?",
+      "name": "Unit 1, Days 1-2 What Is a Computer?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Days 3-4 Buying a Computer",
+      "name": "Unit 1, Days 3-4 Buying a Computer",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Days 5-7 Searching and Web 2",
+      "name": "Unit 1, Days 5-7 Searching and Web 2",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "name": "Unit 1, Days 8-9 Impact of Computers and Communication",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Day 10 Telling a Story with Data",
+      "name": "Unit 1, Day 10 Telling a Story with Data",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Day 11-14 Data Modeling and Design",
+      "name": "Unit 1, Day 11-14 Data Modeling and Design",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "name": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Unit 1, Day 17-19 What Is Intelligence?",
+      "name": "Unit 1, Day 17-19 What Is Intelligence?",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "key": "Wrap-up",
+      "name": "Wrap-up",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online intro"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online Units"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Resources 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Strategies"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D1-2 Forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D3-4 Resources 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD online U1D3-4 Forum"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Resources 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D5-7 Forum"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Resources 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D8-9 Forum"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Resources"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D10 Forum"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Assessment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Resources"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D11-14 Forum"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Resources"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D15-16 Forum"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Resources"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Assessment 2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Reflection"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1D17-19 Forum"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD Online U1Reflection"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      },
+      "level_keys": [
+        "ECSPD U1Conclusion"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Welcome",
+        "script_level.level_keys": [
+          "ECSPD Online Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online intro",
+        "script_level.level_keys": [
+          "ECSPD Online intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online Units",
+        "script_level.level_keys": [
+          "ECSPD Online Units"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Assessment 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Resources 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Strategies",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Strategies"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D1-2 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D1-2 Forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 1, Days 1-2 What Is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Assessment 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D3-4 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D3-4 Resources 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD online U1D3-4 Forum",
+        "script_level.level_keys": [
+          "ECSPD online U1D3-4 Forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 3-4 Buying a Computer",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Assessment 2"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Resources 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Resources 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D5-7 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D5-7 Forum"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Days 5-7 Searching and Web 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Resources 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Resources 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D8-9 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D8-9 Forum"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Days 8-9 Impact of Computers and Communication",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 1",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Resources"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Assessment 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D10 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D10 Forum"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 10 Telling a Story with Data",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Assessment",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Assessment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Resources"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D11-14 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D11-14 Forum"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 11-14 Data Modeling and Design",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Resources"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D15-16 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D15-16 Forum"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 15-16 Computer Programs and Following Directions",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Resources",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Resources"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Assessment 2",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Assessment 2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Reflection"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1D17-19 Forum",
+        "script_level.level_keys": [
+          "ECSPD Online U1D17-19 Forum"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Unit 1, Day 17-19 What Is Intelligence?",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Online U1Reflection",
+        "script_level.level_keys": [
+          "ECSPD Online U1Reflection"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U1Conclusion",
+        "script_level.level_keys": [
+          "ECSPD U1Conclusion"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-up",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit2.script_json
+++ b/dashboard/config/scripts_json/ecs-unit2.script_json
@@ -1,0 +1,1484 @@
+{
+  "script": {
+    "name": "ecs-unit2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "key": "Intro to Unit 2",
+      "name": "Intro to Unit 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "key": "Lesson Overviews",
+      "name": "Lesson Overviews",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "key": "Unit 2 Challenge",
+      "name": "Unit 2 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECS Phase 3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECS Phase 3 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit2 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit2 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 2-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 2-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Growth"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Unit 2 Growth"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Growth Mindset Student Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Growth Mindset Student Video"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD What Is Problem Solving"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD What Is Problem Solving"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Real Life Problem Solving"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Real Life Problem Solving"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Find Learning Strategy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Find Learning Strategy"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ecs unit 2 introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ecs unit 2 introduction"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 1-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 1-2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 4-6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 4-6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 7-9 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 7-9 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 10-12 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 10-12 Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Binary Odometer"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Binary Odometer"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "U1L5 How the Internet Works - Video"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 13-14 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 13-14 Intro"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Linear vs Binary Search Video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Linear vs Binary Search Video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 15-16 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 15-16 Intro"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2L1516 Sorting Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2L1516 Sorting Video"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 17 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 17 Intro"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 D 18-21 Intro"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 D 18-21 Intro"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD What is the Challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD What is the Challenge"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U2 Challenges"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD U2 Challenges"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 2 Challenge Selection"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECS Unit 2 Challenge Selection"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 2 Challenge Submission"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECS Unit 2 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit2 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit2 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 2",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 2-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 2-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 2 Growth",
+        "script_level.level_keys": [
+          "ECSPD Unit 2 Growth"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 2 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 2 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Growth Mindset Student Video",
+        "script_level.level_keys": [
+          "ECSPD Growth Mindset Student Video"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD What Is Problem Solving",
+        "script_level.level_keys": [
+          "ECSPD What Is Problem Solving"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Real Life Problem Solving",
+        "script_level.level_keys": [
+          "ECSPD Real Life Problem Solving"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Find Learning Strategy",
+        "script_level.level_keys": [
+          "ECSPD Find Learning Strategy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ecs unit 2 introduction",
+        "script_level.level_keys": [
+          "ecs unit 2 introduction"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 1-2",
+        "script_level.level_keys": [
+          "ECSPD U2 D 1-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 3",
+        "script_level.level_keys": [
+          "ECSPD U2 D 3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 4-6",
+        "script_level.level_keys": [
+          "ECSPD U2 D 4-6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 7-9 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 7-9 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 10-12 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 10-12 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Binary Odometer",
+        "script_level.level_keys": [
+          "ECSPD Binary Odometer"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L5 How the Internet Works - Video",
+        "script_level.level_keys": [
+          "U1L5 How the Internet Works - Video"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 13-14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 13-14 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Linear vs Binary Search Video",
+        "script_level.level_keys": [
+          "ECSPD Linear vs Binary Search Video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 15-16 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 15-16 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2L1516 Sorting Video",
+        "script_level.level_keys": [
+          "ECSPD U2L1516 Sorting Video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 17 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 17 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 D 18-21 Intro",
+        "script_level.level_keys": [
+          "ECSPD U2 D 18-21 Intro"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Lesson Overviews",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD What is the Challenge",
+        "script_level.level_keys": [
+          "ECSPD What is the Challenge"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U2 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U2 Challenges"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 2 Challenge Selection",
+        "script_level.level_keys": [
+          "ECS Unit 2 Challenge Selection"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 2 Challenge Submission",
+        "script_level.level_keys": [
+          "ECS Unit 2 Challenge Submission"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Unit 2 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit3.script_json
+++ b/dashboard/config/scripts_json/ecs-unit3.script_json
@@ -1,0 +1,1344 @@
+{
+  "script": {
+    "name": "ecs-unit3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "key": "Intro to Unit 3",
+      "name": "Intro to Unit 3",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "key": "Unit 3 Day-by-Day",
+      "name": "Unit 3 Day-by-Day",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "key": "Unit 3 Challenge",
+      "name": "Unit 3 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit3 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit 3 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PLC- check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "PLC- check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit3 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit3 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 3-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 3-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Expertise"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Expertise"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD jsfiddle"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD jsfiddle"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Strategy Review"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Stage 6 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Unit 3 Stage 6 Overview"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 1-2 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 1-2 Intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 3-4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 3-4 Intro"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 5 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 5 Intro"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 6-7 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 6-7 Intro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 8-10 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 8-10 Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 11-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 11-13 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 14 Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 15-16 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 15-16 Intro"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 17-19 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 17-19 Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 20-21 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 20-21 Intro"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 D 22-25 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 D 22-25 Intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD-unit2 What is the Challenge"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD-unit2 What is the Challenge"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U3 Challenges"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD U3 Challenges"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 3 Challenge Selection"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECS Unit 3 Challenge Selection"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 3 Challenge Submission"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECS Unit 3 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit3 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit3 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit 3 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 3 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PLC- check your progress",
+        "script_level.level_keys": [
+          "PLC- check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit3 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit3 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 3",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 3-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 3-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Expertise",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Expertise"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 3 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 3 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD jsfiddle",
+        "script_level.level_keys": [
+          "ECSPD jsfiddle"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Strategy Review",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 3 Stage 6 Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 3 Stage 6 Overview"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 1-2 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 1-2 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 3-4 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 3-4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 5 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 5 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 6-7 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 6-7 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 8-10 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 8-10 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 11-13 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 11-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 15-16 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 15-16 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 17-19 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 17-19 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 20-21 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 20-21 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 D 22-25 Intro",
+        "script_level.level_keys": [
+          "ECSPD U3 D 22-25 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 3 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD-unit2 What is the Challenge",
+        "script_level.level_keys": [
+          "ECSPD-unit2 What is the Challenge"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U3 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U3 Challenges"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 3 Challenge Selection",
+        "script_level.level_keys": [
+          "ECS Unit 3 Challenge Selection"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 3 Challenge Submission",
+        "script_level.level_keys": [
+          "ECS Unit 3 Challenge Submission"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Unit 3 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit4.script_json
+++ b/dashboard/config/scripts_json/ecs-unit4.script_json
@@ -1,0 +1,1449 @@
+{
+  "script": {
+    "name": "ecs-unit4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "key": "Intro to Unit 4",
+      "name": "Intro to Unit 4",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "key": "Teaching Strategies",
+      "name": "Teaching Strategies",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "key": "Unit 4 Day-by-Day",
+      "name": "Unit 4 Day-by-Day",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "key": "Unit 4 Challenge",
+      "name": "Unit 4 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit4 Welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 4 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECS Phase 3 Unit 4 Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PLC- check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "PLC- check your progress"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Outline"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD P3 Plan"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit4 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit4 Connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 4-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "Forum-ECSPD-Unit 4-Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Manage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Manage"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD scratch"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD scratch"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Unit 4 Strategy Review"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD strategies"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 1 Intro"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 1 Intro"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 2-3 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 2-3 Intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 4 Intro"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 5-6 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 5-6 Intro"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 7-8 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 7-8 Intro"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 9 Intro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 10-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 10-13 Intro"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 14 Intro"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 15 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 15 Intro"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 16-17 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 16-17 Intro"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 18 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 18 Intro"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 19 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 19 Intro"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 20-23 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 20-23 Intro"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 24 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 14,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 24 Intro"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 D 25-30 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 15,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 D 25-30 Intro"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ecspd-unit 4 what is the challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ecspd-unit 4 what is the challenge"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD U4 Challenges"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD U4 Challenges"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 4 Challenge Selection"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECS Unit 4 Challenge Selection"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 4 Challenge Submission"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECS Unit 4 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit4 Welcome",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit4 Welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Phase 3 Unit 4 Overview",
+        "script_level.level_keys": [
+          "ECS Phase 3 Unit 4 Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PLC- check your progress",
+        "script_level.level_keys": [
+          "PLC- check your progress"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Outline",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Outline"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD P3 Plan",
+        "script_level.level_keys": [
+          "ECSPD P3 Plan"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit4 Connections",
+        "script_level.level_keys": [
+          "ECSPD Unit4 Connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Lesson Overview",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Intro to Unit 4",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Forum-ECSPD-Unit 4-Teaching Practice",
+        "script_level.level_keys": [
+          "Forum-ECSPD-Unit 4-Teaching Practice"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Manage",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Manage"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Phase 3 - Unit 4 - Teaching Practice",
+        "script_level.level_keys": [
+          "ECSPD Phase 3 - Unit 4 - Teaching Practice"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD scratch",
+        "script_level.level_keys": [
+          "ECSPD scratch"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Unit 4 Strategy Review",
+        "script_level.level_keys": [
+          "ECSPD Unit 4 Strategy Review"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD strategies",
+        "script_level.level_keys": [
+          "ECSPD strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Teaching Strategies",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 1 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 1 Intro"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 2-3 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 2-3 Intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 4 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 4 Intro"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 5-6 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 5-6 Intro"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 7-8 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 7-8 Intro"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 9 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 9 Intro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 10-13 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 10-13 Intro"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 14 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 14 Intro"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 15 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 15 Intro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 16-17 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 16-17 Intro"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 18 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 18 Intro"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 11,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 19 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 19 Intro"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 12,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 20-23 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 20-23 Intro"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 13,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 24 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 24 Intro"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 14,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 D 25-30 Intro",
+        "script_level.level_keys": [
+          "ECSPD U4 D 25-30 Intro"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 15,
+        "lesson.key": "Unit 4 Day-by-Day",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ecspd-unit 4 what is the challenge",
+        "script_level.level_keys": [
+          "ecspd-unit 4 what is the challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD U4 Challenges",
+        "script_level.level_keys": [
+          "ECSPD U4 Challenges"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 4 Challenge Selection",
+        "script_level.level_keys": [
+          "ECS Unit 4 Challenge Selection"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 4 Challenge Submission",
+        "script_level.level_keys": [
+          "ECS Unit 4 Challenge Submission"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Unit 4 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit5.script_json
+++ b/dashboard/config/scripts_json/ecs-unit5.script_json
@@ -1,0 +1,1260 @@
+{
+  "script": {
+    "name": "ecs-unit5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "key": "Unit 5 Overview",
+      "name": "Unit 5 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "key": "Unit 5 lessons",
+      "name": "Unit 5 lessons",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "key": "Unit 5 Challenge",
+      "name": "Unit 5 Challenge",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3- unit 5- welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3- unit 5- welcome"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 about"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 plan"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 intro to u5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 intro to u5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u5 what is data"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u5 what is data"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 tools"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 tools"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 connections"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 1-3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 1-3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 4-5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 4-5"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 6-7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 6-7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 9-12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 9-12"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 13"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 14-16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 14-16"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 17"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 18-20"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 18-20"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 21"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 22-24"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 22-24"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 25"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 25"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 26-27"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 26-27"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 28-29"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 28-29"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 30"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 day 30"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 what is a challenge"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 what is a challenge"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD3-u5 list of challenges"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 5 Challenge Selection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECS Unit 5 Challenge Selection"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSD3-u5 do the challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 5 Challenge Submission"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECS Unit 5 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3- unit 5- welcome",
+        "script_level.level_keys": [
+          "ECSPD3- unit 5- welcome"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 about",
+        "script_level.level_keys": [
+          "ECSPD3-u5 about"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 plan",
+        "script_level.level_keys": [
+          "ECSPD3-u5 plan"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 intro to u5",
+        "script_level.level_keys": [
+          "ECSPD3-u5 intro to u5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u5 what is data",
+        "script_level.level_keys": [
+          "CSPPD3-u5 what is data"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 tools",
+        "script_level.level_keys": [
+          "ECSPD3-u5 tools"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 connections",
+        "script_level.level_keys": [
+          "ECSPD3-u5 connections"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 1-3",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 1-3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 4-5",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 4-5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 6-7",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 6-7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 8",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 9-12",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 9-12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 13",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 14-16",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 14-16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 17",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 18-20",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 18-20"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 21",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 21"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 22-24",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 22-24"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 25",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 25"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 26-27",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 26-27"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 28-29",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 28-29"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 day 30",
+        "script_level.level_keys": [
+          "ECSPD3-u5 day 30"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Unit 5 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 what is a challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u5 what is a challenge"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u5 list of challenges",
+        "script_level.level_keys": [
+          "ECSPD3-u5 list of challenges"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 5 Challenge Selection",
+        "script_level.level_keys": [
+          "ECS Unit 5 Challenge Selection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSD3-u5 do the challenge",
+        "script_level.level_keys": [
+          "ECSD3-u5 do the challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 5 Challenge Submission",
+        "script_level.level_keys": [
+          "ECS Unit 5 Challenge Submission"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Unit 5 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/ecs-unit6.script_json
+++ b/dashboard/config/scripts_json/ecs-unit6.script_json
@@ -1,0 +1,1204 @@
+{
+  "script": {
+    "name": "ecs-unit6",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "ECS Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "ecs-unit6"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Getting Started",
+      "name": "Getting Started",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "key": "Unit 6 Overview",
+      "name": "Unit 6 Overview",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "key": "Unit 6 lessons",
+      "name": "Unit 6 lessons",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "key": "Alternative Ideas for Unit 6",
+      "name": "Alternative Ideas for Unit 6",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "key": "Unit 6 Challenge",
+      "name": "Unit 6 Challenge",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "key": "Close & Next Steps",
+      "name": "Close & Next Steps",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 about"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 about"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 plan"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 plan"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD course goals"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 intro to u6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 intro to u6"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 why study robotics"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 why study robotics"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 connections"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 2-3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 2-3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 5"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 6-7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 6-7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 8-9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 8-9"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 10-13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 10-13"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 14"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 15"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 16-18"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 10,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 16-18"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 19-23"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 11,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 19-23"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 24-33"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 12,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 day 24-33"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson ideas"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 lesson ideas"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 links to online simulations"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 links to online simulations"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 ideas for culminating projects"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 ideas for culminating projects"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge details"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 challenge details"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 list of challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 list of challenges"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 6 Challenge Selection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECS Unit 6 Challenge Selection"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD3-u6 do the challenge"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD3-u6 do the challenge"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "CSPPD3-u2 create your extension"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "CSPPD3-u2 reflect on challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "CSPPD3-u2 expectations"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECS Unit 6 Challenge Submission"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECS Unit 6 Challenge Submission"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      },
+      "level_keys": [
+        "ECSPD Challenge Reflection"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 about",
+        "script_level.level_keys": [
+          "ECSPD3-u6 about"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 plan",
+        "script_level.level_keys": [
+          "ECSPD3-u6 plan"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD course goals",
+        "script_level.level_keys": [
+          "ECSPD course goals"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Getting Started",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 intro to u6",
+        "script_level.level_keys": [
+          "ECSPD3-u6 intro to u6"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 why study robotics",
+        "script_level.level_keys": [
+          "ECSPD3-u6 why study robotics"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 connections",
+        "script_level.level_keys": [
+          "ECSPD3-u6 connections"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Overview",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 1",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 2-3",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 2-3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 4",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 5",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 5"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 6-7",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 6-7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 8-9",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 8-9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 10-13",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 10-13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 14",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 15",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 15"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 9,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 16-18",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 16-18"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 10,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 19-23",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 19-23"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 11,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 day 24-33",
+        "script_level.level_keys": [
+          "ECSPD3-u6 day 24-33"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 12,
+        "lesson.key": "Unit 6 lessons",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 lesson ideas",
+        "script_level.level_keys": [
+          "ECSPD3-u6 lesson ideas"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 links to online simulations",
+        "script_level.level_keys": [
+          "ECSPD3-u6 links to online simulations"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 ideas for culminating projects",
+        "script_level.level_keys": [
+          "ECSPD3-u6 ideas for culminating projects"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Alternative Ideas for Unit 6",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 challenge details",
+        "script_level.level_keys": [
+          "ECSPD3-u6 challenge details"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 list of challenges",
+        "script_level.level_keys": [
+          "ECSPD3-u6 list of challenges"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 6 Challenge Selection",
+        "script_level.level_keys": [
+          "ECS Unit 6 Challenge Selection"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD3-u6 do the challenge",
+        "script_level.level_keys": [
+          "ECSPD3-u6 do the challenge"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 create your extension",
+        "script_level.level_keys": [
+          "CSPPD3-u2 create your extension"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 reflect on challenge",
+        "script_level.level_keys": [
+          "CSPPD3-u2 reflect on challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD3-u2 expectations",
+        "script_level.level_keys": [
+          "CSPPD3-u2 expectations"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECS Unit 6 Challenge Submission",
+        "script_level.level_keys": [
+          "ECS Unit 6 Challenge Submission"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Unit 6 Challenge",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD Challenge Reflection",
+        "script_level.level_keys": [
+          "ECSPD Challenge Reflection"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Close & Next Steps",
+        "lesson_group.key": "",
+        "script.name": "ecs-unit6"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/edit-code.script_json
+++ b/dashboard/config/scripts_json/edit-code.script_json
@@ -1,0 +1,909 @@
+{
+  "script": {
+    "name": "edit-code",
+    "wrapup_video_id": 13,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "edit-code"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "The Maze",
+      "name": "The Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "key": "Applab",
+      "name": "Applab",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Applab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "key": "The Artist",
+      "name": "The Artist",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "key": "Play Lab",
+      "name": "Play Lab",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "key": "Hoc2015 Blockly",
+      "name": "Hoc2015 Blockly",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:MazeEC:3_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:MazeEC:3_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:MazeEC:3_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:MazeEC:3_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Applab:ec_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Applab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Applab:ec_simple"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:ArtistEC:ec_1_2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:ArtistEC:ec_1_2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:ArtistEC:ec_1_10"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:ArtistEC:ec_1_10"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:ec_sandbox"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:StudioEC:ec_sandbox"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_3"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_4"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_4"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_5"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_6"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_6"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 15,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeEC:3_1",
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeEC:3_2",
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeEC:3_3",
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeEC:3_4",
+        "script_level.level_keys": [
+          "blockly:MazeEC:3_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "The Maze",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Applab:ec_simple",
+        "script_level.level_keys": [
+          "blockly:Applab:ec_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Applab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:ArtistEC:ec_1_2",
+        "script_level.level_keys": [
+          "blockly:ArtistEC:ec_1_2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:ArtistEC:ec_1_10",
+        "script_level.level_keys": [
+          "blockly:ArtistEC:ec_1_10"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Artist",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:ec_sandbox",
+        "script_level.level_keys": [
+          "blockly:StudioEC:ec_sandbox"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_1",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_2",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_3",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_3"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_4",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_4"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_5",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_6",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_6"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 8,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 9,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 10,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 11,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 12,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 13,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 14,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 15,
+        "lesson.key": "Hoc2015 Blockly",
+        "lesson_group.key": "",
+        "script.name": "edit-code"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/equity-pd.script_json
+++ b/dashboard/config/scripts_json/equity-pd.script_json
@@ -1,0 +1,413 @@
+{
+  "script": {
+    "name": "equity-pd",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "Equity Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "equity-pd"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Necessary Background",
+      "name": "Necessary Background",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "key": "Code.org Equity PD",
+      "name": "Code.org Equity PD",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity v equality"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity v equality"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity is more"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity is more"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity in CS"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity in CS"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity lead 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity lead 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity activity"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity activity"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity vids"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity vids"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity expect"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity expect"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity discuss"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "equity discuss"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Equity Resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      },
+      "level_keys": [
+        "Equity Resources"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "equity Intro",
+        "script_level.level_keys": [
+          "equity Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity v equality",
+        "script_level.level_keys": [
+          "equity v equality"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity is more",
+        "script_level.level_keys": [
+          "equity is more"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity in CS",
+        "script_level.level_keys": [
+          "equity in CS"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity lead 1",
+        "script_level.level_keys": [
+          "equity lead 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity activity",
+        "script_level.level_keys": [
+          "equity activity"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity vids",
+        "script_level.level_keys": [
+          "equity vids"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity expect",
+        "script_level.level_keys": [
+          "equity expect"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity discuss",
+        "script_level.level_keys": [
+          "equity discuss"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Equity Resources",
+        "script_level.level_keys": [
+          "Equity Resources"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Code.org Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equity-pd"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/equityPD.script_json
+++ b/dashboard/config/scripts_json/equityPD.script_json
@@ -1,0 +1,308 @@
+{
+  "script": {
+    "name": "equityPD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "Equity Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "equityPD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Necessary Background",
+      "name": "Necessary Background",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "key": "Equity PD",
+      "name": "Equity PD",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity v equality"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity v equality"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity is more"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity is more"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity in CS"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity in CS"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity lead 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity lead 1"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity activity"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity activity"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "equity vids"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      },
+      "level_keys": [
+        "equity vids"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "equity Intro",
+        "script_level.level_keys": [
+          "equity Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity v equality",
+        "script_level.level_keys": [
+          "equity v equality"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity is more",
+        "script_level.level_keys": [
+          "equity is more"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity in CS",
+        "script_level.level_keys": [
+          "equity in CS"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Necessary Background",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity lead 1",
+        "script_level.level_keys": [
+          "equity lead 1"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity activity",
+        "script_level.level_keys": [
+          "equity activity"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "equity vids",
+        "script_level.level_keys": [
+          "equity vids"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Equity PD",
+        "lesson_group.key": "",
+        "script.name": "equityPD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/events.script_json
+++ b/dashboard/config/scripts_json/events.script_json
@@ -1,0 +1,580 @@
+{
+  "script": {
+    "name": "events",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "events"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bounce",
+      "name": "Bounce",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "key": "Studio",
+      "name": "Studio",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "key": "Calc",
+      "name": "Calc",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Calc",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "key": "Eval",
+      "name": "Eval",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Eval",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:full_sandbox"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "blockly:Studio:full_sandbox"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:full_sandbox_infinity"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "blockly:Studio:full_sandbox_infinity"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Calc:example1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Calc",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "blockly:Calc:example1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Eval:eval1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Eval",
+        "lesson_group.key": "",
+        "script.name": "events"
+      },
+      "level_keys": [
+        "blockly:Eval:eval1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Bounce",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:full_sandbox",
+        "script_level.level_keys": [
+          "blockly:Studio:full_sandbox"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:full_sandbox_infinity",
+        "script_level.level_keys": [
+          "blockly:Studio:full_sandbox_infinity"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Studio",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Calc:example1",
+        "script_level.level_keys": [
+          "blockly:Calc:example1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Calc",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Eval:eval1",
+        "script_level.level_keys": [
+          "blockly:Eval:eval1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Eval",
+        "lesson_group.key": "",
+        "script.name": "events"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/express-2017.script_json
+++ b/dashboard/config/scripts_json/express-2017.script_json
@@ -1,0 +1,11040 @@
+{
+  "script": {
+    "name": "express-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/express/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "express-2017",
+    "family_name": "express",
+    "seeding_key": {
+      "script.name": "express-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Programming: Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Introduction to Debugging",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Nested Loops Project in Frozen",
+      "name": "Nested Loops in Frozen",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "How it Works: The Internet",
+      "name": "Beyond Programming: The Internet",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Common Sense Education: Digital Citizenship",
+      "name": "Digital Citizenship: Practicing Digital Citizenship",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Common Sense Education: Screen Out the Mean",
+      "name": "Digital Citizenship: Screen Out the Mean",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Events in Star Wars",
+      "name": "Events in Star Wars",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Events with Flappy",
+      "name": "Events with Flappy",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Conditionals: Conditionals with Cards",
+      "name": "Conditionals: Conditionals with Cards",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft",
+      "name": "Conditionals in Minecraft",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Conditionals & Loops in Harvester",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Variables: Envelope Variables",
+      "name": "Variables: Envelope Variables",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "For Loops: For Loop Fun",
+      "name": "For Loops: For Loop Fun",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Functions: Songwriting with Parameters",
+      "name": "Functions: Songwriting with Parameters",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 30,
+      "lockable": false,
+      "relative_position": 30,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 31,
+      "lockable": false,
+      "relative_position": 31,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 32,
+      "lockable": false,
+      "relative_position": 32,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 33,
+      "lockable": false,
+      "relative_position": 33,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 34,
+      "lockable": false,
+      "relative_position": 34,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 35,
+      "lockable": false,
+      "relative_position": 35,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1",
+        "courseE_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2",
+        "courseE_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3",
+        "courseE_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4",
+        "courseE_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5",
+        "courseE_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1",
+        "courseE_maze_predict1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseCDEF_video_AngryBirdLoops": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops",
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6",
+        "courseE_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp7": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7",
+        "courseE_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true,
+        "variants": {
+          "courseE_artist_ramp8": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8",
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseC_video_angles": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles",
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_artist_ramp9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8_2",
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_artist_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles2",
+        "courseE_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_video_nestedLoopsArtist": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist",
+        "courseE_artist_ramp9_2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_video_debugging": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_video_debugging",
+        "courseD_video_debugging"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1",
+        "courseD_collector_debugging1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2",
+        "courseD_collector_debugging2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3",
+        "courseD_collector_debugging3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4",
+        "courseD_collector_debugging4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5",
+        "courseD_collector_debugging5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6",
+        "courseD_collector_debugging6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true,
+        "variants": {
+          "courseD_collector_debugging8": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7",
+        "courseD_collector_debugging8"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1",
+        "courseD_collector_debugging9"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging10_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9",
+        "courseD_collector_debugging10_predict1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 14,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_collector_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseC_Unplugged_ScreenOutTheMean"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_1"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_2"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_3"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_4"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_5"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_6"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_7"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_10"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_11"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "bounce_12"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while1"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while2"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while3"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while4"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while5"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while6"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while7"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while8"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while9"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while10"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge2"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until1"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until3"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until4"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until5"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until6"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until7"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until8"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until9"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until10"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_maze_until_challenge1"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_until_challenge2"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables2"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables3"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables4"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables5"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables6"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables7"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables8"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables9"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables10"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for1"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for2"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_forBee"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for4"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for6"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for7"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for8"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for5"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for9"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for10"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for11"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_forArtist"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for1"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for2"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for3"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for4"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for5"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for6"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for7"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for8"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for9"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for10"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functionsPre7"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_artistFunctions"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "InspirationalArtwork"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "FoodFight"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Guess The Number"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Course F: Artist Project"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8_2",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles2",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_predict1",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9_2",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging10_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 14,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro2",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 1,
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_Unplugged_ScreenOutTheMean",
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 1,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 2,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 3,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 4,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 5,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 6,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 7,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 8,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 9,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 10,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_3",
+        "script_level.level_keys": [
+          "bounce_3"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_4",
+        "script_level.level_keys": [
+          "bounce_4"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1",
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2",
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3",
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4",
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5",
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6",
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7",
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8",
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9",
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10",
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1",
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3",
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4",
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5",
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6",
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7",
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ifElse",
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until8",
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9",
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10",
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until_challenge1",
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_until_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2",
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3",
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4",
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5",
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6",
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7",
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8",
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9",
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10",
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 1,
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1",
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2",
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee",
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4",
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6",
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7",
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8",
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5",
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9",
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10",
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11",
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist",
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1",
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2",
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3",
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4",
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5",
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6",
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7",
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8",
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9",
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10",
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functionsPre7",
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistFunctions",
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork",
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight",
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number",
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project",
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/express-2018.script_json
+++ b/dashboard/config/scripts_json/express-2018.script_json
@@ -1,0 +1,13000 @@
+{
+  "script": {
+    "name": "express-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/express/{LESSON}",
+      "announcements": [
+        {
+          "notice": "New: Choose Which Lessons to Show or Hide for Your Section",
+          "details": "Click \"Learn More\" to read the help article on showing and hiding lessons.",
+          "link": "https://support.code.org/hc/en-us/articles/115001479372-Hiding-units-and-lessons-in-Code-org-s-CS-Principles-and-CS-Discoveries-courses bullhorn",
+          "type": "bullhorn"
+        }
+      ],
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-18/express/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-18/express/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-18/express/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "express",
+    "seeding_key": {
+      "script.name": "express-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Graph Paper Programming",
+      "name": "Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Coding with Angry Birds",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Relay Programming",
+      "name": "Relay Programming",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Loops: Getting Loopy",
+      "name": "Getting Loopy",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Copyright and Creativity",
+      "name": "Copyright and Creativity",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Concept Practice with Minecraft ",
+      "name": "Looking Ahead with Minecraft",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Bee",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Nested Loops with Anna and Elsa",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops with the Farmer",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Songwriting",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions with Minecraft",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions with the Harvester",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Screen Out the Mean",
+      "name": "Screen Out the Mean",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Variables as Constant in Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Variables that Change in Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 30,
+      "lockable": false,
+      "relative_position": 30,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Variables that Change in Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 31,
+      "lockable": false,
+      "relative_position": 31,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 32,
+      "lockable": false,
+      "relative_position": 32,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 33,
+      "lockable": false,
+      "relative_position": 33,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 34,
+      "lockable": false,
+      "relative_position": 34,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprite Lab",
+      "absolute_position": 35,
+      "lockable": false,
+      "relative_position": 35,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party",
+      "absolute_position": 36,
+      "lockable": false,
+      "relative_position": 36,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Pet Giraffe with Sprite Lab",
+      "name": "Pet Giraffe",
+      "absolute_position": 37,
+      "lockable": false,
+      "relative_position": 37,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 38,
+      "lockable": false,
+      "relative_position": 38,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 39,
+      "lockable": false,
+      "relative_position": 39,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 40,
+      "lockable": false,
+      "relative_position": 40,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 41,
+      "lockable": false,
+      "relative_position": 41,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 42,
+      "lockable": false,
+      "relative_position": 42,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Binary Bracelets",
+      "name": "Binary Bracelets",
+      "absolute_position": 43,
+      "lockable": false,
+      "relative_position": 43,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Binary Images",
+      "absolute_position": 44,
+      "lockable": false,
+      "relative_position": 44,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Binary Images with Artist",
+      "absolute_position": 45,
+      "lockable": false,
+      "relative_position": 45,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "The Internet",
+      "absolute_position": 46,
+      "lockable": false,
+      "relative_position": 46,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 47,
+      "lockable": false,
+      "relative_position": 47,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "GraphPaperProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_video_maze_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "RelayProgramming_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "RelayProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_video_collector_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "grade2_collector_A_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "grade2_collector_10_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "GettingLoopy_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loop1_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_unplugged_CnC_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 13,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 14,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_1_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_1_2018"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_2_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_2_2018"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_3_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_3_2018"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_4_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_4_2018"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_5_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_5_2018"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_6_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_6_2018"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2018"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2018"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2018"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2018"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2018"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2018"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2018"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2018"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2018"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2018"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2018"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2018"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2018"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2018"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2018"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2018"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2018"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2018"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2018"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2018"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Conditionals_2018"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2018"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2018"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2018"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2018"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2018"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2018"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2018"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2018"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2018"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2018"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2018"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "SongwritingParameters_2018"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2018"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2018"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2018"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2018"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2018"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2018"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2018"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2018"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2018"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2018"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2018"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2018"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2018"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2018"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2018"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2018"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2018"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2018"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2018"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2018"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2018"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2018"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2018"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2018"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_Unplugged_ScreenOutTheMean_2018"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_bee_concept5_2018"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "BigEvent_2018"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro_2018"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events1_2018"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events2_2018"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events3_2018"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events4_2018"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events5_2018"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events6_2018"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events7_2018"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events8_2018"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events9_2018"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2018"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseC_flappy_events10_2018"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_unplugged_powerOfWords_2018"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "EnvelopeVariables_2018"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2018"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2018"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_intro"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2018"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2018"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2018"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2018"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2018"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2018"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant_2018"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2018"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2018"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2018"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2018"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2018"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2018"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2018"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2018"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2018"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2018"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2018"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2018"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2018"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_end"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "ForLoopFun_2018"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2018"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2018"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_intro"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2018"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2018"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2018"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2018"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2018"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2018"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2018"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2018"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2018"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_end"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2018"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2018"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2018"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2018"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2018"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2018"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2018"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2018"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2018"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2018"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2018"
+      ]
+    },
+    {
+      "chapter": 299,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 300,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 301,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab"
+      ]
+    },
+    {
+      "chapter": 302,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 303,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 304,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 305,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 306,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite"
+      ]
+    },
+    {
+      "chapter": 307,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 308,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 309,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 310,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 311,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 312,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 313,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 314,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 315,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 316,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 317,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 318,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 319,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 320,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 321,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 322,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 323,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 324,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    },
+    {
+      "chapter": 325,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_video_csMatters_2018"
+      ]
+    },
+    {
+      "chapter": 326,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "InspirationalArtwork_2018"
+      ]
+    },
+    {
+      "chapter": 327,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_project_1"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseF_project_1"
+      ]
+    },
+    {
+      "chapter": 328,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Begin planning your project_2018"
+      ]
+    },
+    {
+      "chapter": 329,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 329,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project_2018"
+      ]
+    },
+    {
+      "chapter": 330,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab"
+        ],
+        "script_level.chapter": 330,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "CourseF_Project_SpriteLab"
+      ]
+    },
+    {
+      "chapter": 331,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 331,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise_2018"
+      ]
+    },
+    {
+      "chapter": 332,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_Revise_SpriteLab"
+        ],
+        "script_level.chapter": 332,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "CourseF_Project_Revise_SpriteLab"
+      ]
+    },
+    {
+      "chapter": 333,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 333,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Prepare for your presentation_2018"
+      ]
+    },
+    {
+      "chapter": 334,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets_2018"
+        ],
+        "script_level.chapter": 334,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "BinaryBracelets_2018"
+      ]
+    },
+    {
+      "chapter": 335,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages_2018"
+        ],
+        "script_level.chapter": 335,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "BinaryImages_2018"
+      ]
+    },
+    {
+      "chapter": 336,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018"
+        ],
+        "script_level.chapter": 336,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_external_binary1_2018"
+      ]
+    },
+    {
+      "chapter": 337,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2018"
+        ],
+        "script_level.chapter": 337,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary1_2018"
+      ]
+    },
+    {
+      "chapter": 338,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2018"
+        ],
+        "script_level.chapter": 338,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary2_2018"
+      ]
+    },
+    {
+      "chapter": 339,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2018"
+        ],
+        "script_level.chapter": 339,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary3_2018"
+      ]
+    },
+    {
+      "chapter": 340,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2018"
+        ],
+        "script_level.chapter": 340,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary4_2018"
+      ]
+    },
+    {
+      "chapter": 341,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2018"
+        ],
+        "script_level.chapter": 341,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary5_2018"
+      ]
+    },
+    {
+      "chapter": 342,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2018"
+        ],
+        "script_level.chapter": 342,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary6_2018"
+      ]
+    },
+    {
+      "chapter": 343,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2018"
+        ],
+        "script_level.chapter": 343,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary7_2018"
+      ]
+    },
+    {
+      "chapter": 344,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2018"
+        ],
+        "script_level.chapter": 344,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_2018"
+      ]
+    },
+    {
+      "chapter": 345,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2018"
+        ],
+        "script_level.chapter": 345,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 346,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2018"
+        ],
+        "script_level.chapter": 346,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP_2018"
+      ]
+    },
+    {
+      "chapter": 347,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2018"
+        ],
+        "script_level.chapter": 347,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 348,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2018"
+        ],
+        "script_level.chapter": 348,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 349,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 349,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Internet_2018"
+      ]
+    },
+    {
+      "chapter": 350,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 350,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      },
+      "level_keys": [
+        "Crowdsourcing_2018"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming_2018",
+        "script_level.level_keys": [
+          "GraphPaperProgramming_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2018",
+        "script_level.level_keys": [
+          "courseC_video_maze_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "RelayProgramming_2018",
+        "script_level.level_keys": [
+          "RelayProgramming_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Relay Programming",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2018",
+        "script_level.level_keys": [
+          "courseC_video_collector_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2018",
+        "script_level.level_keys": [
+          "grade2_collector_A_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2018",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2018",
+        "script_level.level_keys": [
+          "grade2_collector_10_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy_2018",
+        "script_level.level_keys": [
+          "GettingLoopy_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Loops: Getting Loopy",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2018",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2018",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_CnC_2018",
+        "script_level.level_keys": [
+          "courseE_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 13,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 14,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_1_2018"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_2_2018"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_3_2018"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_4_2018"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_5_2018"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_6_2018",
+        "script_level.level_keys": [
+          "courseD_artist_6_2018"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2018"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2018"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2018"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2018",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2018"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2018"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2018"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2018"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2018"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2018"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2018"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2018"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2018"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2018"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2018"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2018"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2018",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2018"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2018"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2018"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2018"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2018"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2018"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2018"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2018"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2018"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2018"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals_2018",
+        "script_level.level_keys": [
+          "Conditionals_2018"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2018"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2018"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2018"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2018"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2018"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2018"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2018"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2018"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2018"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2018"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2018"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2018"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2018"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2018"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2018"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2018"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2018"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2018"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2018"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2018"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2018"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2018"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2018"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2018"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2018"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2018"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2018"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters_2018",
+        "script_level.level_keys": [
+          "SongwritingParameters_2018"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2018"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2018"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2018"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2018"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2018"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2018"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2018",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2018"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2018"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2018"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2018"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2018"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2018"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2018"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2018"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2018"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2018"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2018"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2018"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2018"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2018"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2018"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2018"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2018"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2018"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2018"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2018"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2018"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2018"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_Unplugged_ScreenOutTheMean_2018",
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean_2018"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 1,
+        "lesson.key": "Screen Out the Mean",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2018",
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro_2018",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2018"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2018"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2018"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2018"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2018"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2018"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2018"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2018"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2018"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2018"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10_2018",
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2018"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_unplugged_powerOfWords_2018",
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords_2018"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables_2018",
+        "script_level.level_keys": [
+          "EnvelopeVariables_2018"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2018",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2018"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2018"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2018",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2018"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2018"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2018"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant_2018",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2018"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2018"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2018"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2018"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2018"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2018"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_end",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2018"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2018"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun_2018",
+        "script_level.level_keys": [
+          "ForLoopFun_2018"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2018"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2018"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2018",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2018"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2018"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2018"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2018"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2018"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2018"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2018"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2018"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2018"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2018"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2018"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2018"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2018",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2018"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2018"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2018"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2018"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2018"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2018"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2018"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2018"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2018"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2018"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2018"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2018"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2018"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2018",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2018"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters_2018",
+        "script_level.level_keys": [
+          "courseF_video_csMatters_2018"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork_2018",
+        "script_level.level_keys": [
+          "InspirationalArtwork_2018"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_project_1",
+        "script_level.level_keys": [
+          "courseF_project_1"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project_2018",
+        "script_level.level_keys": [
+          "Begin planning your project_2018"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project_2018"
+        ],
+        "script_level.chapter": 329,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_SpriteLab",
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab"
+        ],
+        "script_level.chapter": 330,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise_2018",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise_2018"
+        ],
+        "script_level.chapter": 331,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_Revise_SpriteLab",
+        "script_level.level_keys": [
+          "CourseF_Project_Revise_SpriteLab"
+        ],
+        "script_level.chapter": 332,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation_2018",
+        "script_level.level_keys": [
+          "Prepare for your presentation_2018"
+        ],
+        "script_level.chapter": 333,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets_2018",
+        "script_level.level_keys": [
+          "BinaryBracelets_2018"
+        ],
+        "script_level.chapter": 334,
+        "script_level.position": 1,
+        "lesson.key": "Binary Bracelets",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages_2018",
+        "script_level.level_keys": [
+          "BinaryImages_2018"
+        ],
+        "script_level.chapter": 335,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1_2018",
+        "script_level.level_keys": [
+          "courseD_external_binary1_2018"
+        ],
+        "script_level.chapter": 336,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary1_2018"
+        ],
+        "script_level.chapter": 337,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary2_2018"
+        ],
+        "script_level.chapter": 338,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary3_2018"
+        ],
+        "script_level.chapter": 339,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary4_2018"
+        ],
+        "script_level.chapter": 340,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary5_2018"
+        ],
+        "script_level.chapter": 341,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary6_2018"
+        ],
+        "script_level.chapter": 342,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary7_2018"
+        ],
+        "script_level.chapter": 343,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_2018"
+        ],
+        "script_level.chapter": 344,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1_2018"
+        ],
+        "script_level.chapter": 345,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP_2018"
+        ],
+        "script_level.chapter": 346,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1_2018"
+        ],
+        "script_level.chapter": 347,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2_2018"
+        ],
+        "script_level.chapter": 348,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet_2018",
+        "script_level.level_keys": [
+          "Internet_2018"
+        ],
+        "script_level.chapter": 349,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing_2018",
+        "script_level.level_keys": [
+          "Crowdsourcing_2018"
+        ],
+        "script_level.chapter": 350,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "",
+        "script.name": "express-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/express-2019.script_json
+++ b/dashboard/config/scripts_json/express-2019.script_json
@@ -1,0 +1,12046 @@
+{
+  "script": {
+    "name": "express-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/express/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "es-MX",
+        "fr-FR",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-19/express/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-19/express/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-19/express/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "express",
+    "seeding_key": {
+      "script.name": "express-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_warmup",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Warm-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_functions",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_variables",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_for_loops",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "For Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 8,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Debugging in Maze",
+      "name": "Debugging with Scrat",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Programming in Collector",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Creating Art with Code",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Snowflakes with Anna and Elsa",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Concept Practice with Minecraft ",
+      "name": "Looking Ahead with Minecraft",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops with the Farmer",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Harvester",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Variables as Constant in Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Variables that Change in Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Variables that Change in Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Swimming Fish in Sprite Lab",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Editing Behaviors",
+      "name": "Behaviors in Sprite Lab",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Virtual Pet with Sprite Lab",
+      "name": "Virtual Pet with Sprite Lab",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "key": "Build A Project",
+      "name": "End of Course Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_01"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_02"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_03"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_04"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_05"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_06"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_08"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_09"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_10"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11b"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_11_5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseD_Dance_Party_12"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_video_maze_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "express_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "express_maze_debugging9_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_video_collector_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "grade2_collector_A_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "grade2_collector_10_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_video_artist_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loop1_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_1_2018_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_1_2018_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_2_2018_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_2_2018_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_3_2018_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_3_2018_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_4_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_4_2018_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_5_2018_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_5_2018_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_6_2018_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_artist_6_2018_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Chop Tree_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Chop Trees_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Place Wall_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Plant Crops_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Underground Mining Coal_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Underground Iron_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Underground If Statements_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2019"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2019"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2019"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2019"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2019"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2019"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2019"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2019"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2019"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2019"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2019"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2019"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2019"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2019"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2019"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2019"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2019"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2019"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2019"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2019"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2019"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2019"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2019"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2019"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2019"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2019"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2019"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2019"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2019"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2019"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2019"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2019"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2019"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2019"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2019"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2019"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2019"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_intro_2019"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2019"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2019"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2019"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2019"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2019"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2019"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant_2018_2019"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2019"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2019"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2019"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2019"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2019"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2019"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2019"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2019"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2019"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2019"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2019"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2019"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2019"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_end_2019"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2019"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2019"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_intro_2019"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2019"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2019"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2019"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2019"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2019"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2019"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2019"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2019"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2019"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end_2019"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_end_2019"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2019"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2019"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2019"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2019"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2019"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2019"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2019"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2019"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2019"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2019"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2019"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2019"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2019"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2019"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2019"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2019"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2019"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2019"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2019"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2019"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2019"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2019"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2019"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2019"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2019"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2019"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2019"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2019"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2019"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2019"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2019"
+      ]
+    },
+    {
+      "chapter": 299,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2019"
+      ]
+    },
+    {
+      "chapter": 300,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2019"
+      ]
+    },
+    {
+      "chapter": 301,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2019"
+      ]
+    },
+    {
+      "chapter": 302,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 2_2019"
+      ]
+    },
+    {
+      "chapter": 303,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 3_2019"
+      ]
+    },
+    {
+      "chapter": 304,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 4_2019"
+      ]
+    },
+    {
+      "chapter": 305,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 5_2019"
+      ]
+    },
+    {
+      "chapter": 306,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 6_2019"
+      ]
+    },
+    {
+      "chapter": 307,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party 7_2019"
+      ]
+    },
+    {
+      "chapter": 308,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2019"
+      ]
+    },
+    {
+      "chapter": 309,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 1"
+      ]
+    },
+    {
+      "chapter": 310,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 2"
+      ]
+    },
+    {
+      "chapter": 311,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 3"
+      ]
+    },
+    {
+      "chapter": 312,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3a"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 3a"
+      ]
+    },
+    {
+      "chapter": 313,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 4"
+      ]
+    },
+    {
+      "chapter": 314,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 5"
+      ]
+    },
+    {
+      "chapter": 315,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors free play"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors free play"
+      ]
+    },
+    {
+      "chapter": 316,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 6"
+      ]
+    },
+    {
+      "chapter": 317,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 7"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "behaviors 7"
+      ]
+    },
+    {
+      "chapter": 318,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_2019"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 1_2019"
+      ]
+    },
+    {
+      "chapter": 319,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_2019"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 2_2019"
+      ]
+    },
+    {
+      "chapter": 320,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_2019"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 3_2019"
+      ]
+    },
+    {
+      "chapter": 321,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_2019"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 4_2019"
+      ]
+    },
+    {
+      "chapter": 322,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_2019"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 5_2019"
+      ]
+    },
+    {
+      "chapter": 323,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_2019"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 6_2019"
+      ]
+    },
+    {
+      "chapter": 324,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 7_2019"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 7_2019"
+      ]
+    },
+    {
+      "chapter": 325,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 8_2019"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Virtual Pet 8_2019"
+      ]
+    },
+    {
+      "chapter": 326,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 1,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "courseF_project_exemplars_2019"
+      ]
+    },
+    {
+      "chapter": 327,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Lab Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 2,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "CourseF_Project_SpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 328,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project_2019"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 3,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      },
+      "level_keys": [
+        "Course F: Artist Project_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_02"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_03"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_04"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_05"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_06"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_08"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_09"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_10"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11b",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_11_5",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_11_5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_Party_12",
+        "script_level.level_keys": [
+          "CourseD_Dance_Party_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2019",
+        "script_level.level_keys": [
+          "courseC_video_maze_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2019",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "express_maze_debugging9_2019",
+        "script_level.level_keys": [
+          "express_maze_debugging9_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 10,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 11,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 12,
+        "lesson.key": "Debugging in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2019",
+        "script_level.level_keys": [
+          "courseC_video_collector_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2019",
+        "script_level.level_keys": [
+          "grade2_collector_A_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2019",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2019",
+        "script_level.level_keys": [
+          "grade2_collector_10_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Collector",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2019",
+        "script_level.level_keys": [
+          "courseC_video_artist_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video_2019",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video_2019",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2019",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2019",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2019",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_1_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_1_2018_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_2_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_2_2018_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_3_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_3_2018_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_4_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_4_2018_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_5_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_5_2018_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_6_2018_2019",
+        "script_level.level_keys": [
+          "courseD_artist_6_2018_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep_2019",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree_2019",
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep_2019",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees_2019",
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall_2019",
+        "script_level.level_keys": [
+          "Overworld Place Wall_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen_2019",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops_2019",
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters_2019",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal_2019",
+        "script_level.level_keys": [
+          "Underground Mining Coal_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron_2019",
+        "script_level.level_keys": [
+          "Underground Iron_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava_2019",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements_2019",
+        "script_level.level_keys": [
+          "Underground If Statements_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart_2019",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20_2019",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Concept Practice with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2019"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2019",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2019"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2019",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2019"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2019"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2019"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2019"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2019"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2019"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2019"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2019"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2019"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2019"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2019"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2019"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2019"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2019"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2019"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2019"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2019"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2019"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2019"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Harvester",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2019",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2019",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_intro_2019",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2019",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant_2018_2019",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Variables as Constant in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2019"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2019"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2019"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2019"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2019"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 1,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2019"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 2,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2019"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 3,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2019"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 4,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2019"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 5,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_end_2019",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end_2019"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 6,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2019"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 7,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2019"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 8,
+        "lesson.key": "Variables that Change in Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2019"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2019"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_intro_2019",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro_2019"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2019",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2019"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2019"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2019"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2019"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2019"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2019"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2019"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2019"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2019"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2019"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_end_2019",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end_2019"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2019"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 15,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2019"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 16,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2019",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2019"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2019"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2019"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2019"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2019"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2019"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2019"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2019"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2019"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2019"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2019"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2019"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2019"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2019",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2019"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2019"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2019"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2019"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2019"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2019"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2019",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2019"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2019"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2019"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2019",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2019"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2019",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2019"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2019",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2019"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2019",
+        "script_level.level_keys": [
+          "Dance Party 2_2019"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2019",
+        "script_level.level_keys": [
+          "Dance Party 3_2019"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2019",
+        "script_level.level_keys": [
+          "Dance Party 4_2019"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2019",
+        "script_level.level_keys": [
+          "Dance Party 5_2019"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2019",
+        "script_level.level_keys": [
+          "Dance Party 6_2019"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2019",
+        "script_level.level_keys": [
+          "Dance Party 7_2019"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2019",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2019"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 1",
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 1,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 2",
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 2,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3",
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 3,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3a",
+        "script_level.level_keys": [
+          "behaviors 3a"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 4,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 4",
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 5,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 5",
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 6,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors free play",
+        "script_level.level_keys": [
+          "behaviors free play"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 7,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 6",
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 8,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 7",
+        "script_level.level_keys": [
+          "behaviors 7"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 9,
+        "lesson.key": "Editing Behaviors",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 1_2019"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 2_2019"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 3_2019"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 4_2019"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 5_2019"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 6_2019"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 7_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 7_2019"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 8_2019",
+        "script_level.level_keys": [
+          "Virtual Pet 8_2019"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_project_exemplars_2019",
+        "script_level.level_keys": [
+          "courseF_project_exemplars_2019"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 1,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_Project_SpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseF_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 2,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project_2019",
+        "script_level.level_keys": [
+          "Course F: Artist Project_2019"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 3,
+        "lesson.key": "Build A Project",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/express-2020.script_json
+++ b/dashboard/config/scripts_json/express-2020.script_json
@@ -1,0 +1,12191 @@
+{
+  "script": {
+    "name": "express-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab",
+        "artist"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/express/{LESSON}",
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/express/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/express/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/express/standards/"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "express",
+    "seeding_key": {
+      "script.name": "express-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_warmup",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Warm-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_functions",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_variables",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Variables"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_for_loops",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "For Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 8,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 9,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Dance Party",
+      "name": "Dance Party",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Programming with Angry Birds",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Collecting Treasure with Laurel",
+      "name": "Collecting Treasure with Laurel",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Creating Art with Code",
+      "name": "Creating Art with Code",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Loops with Rey and BB-8",
+      "name": "Loops with Rey and BB-8",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Sticker Art with Loops",
+      "name": "Sticker Art with Loops",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Nested Loops in Maze",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Snowflakes with Anna and Elsa",
+      "name": "Snowflakes with Anna and Elsa",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Looking Ahead with Minecraft ",
+      "name": "Looking Ahead with Minecraft ",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "If/Else with Bee",
+      "name": "If/Else with Bee",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "While Loops with the Farmer",
+      "name": "While Loops with the Farmer",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Until Loops in Maze",
+      "name": "Until Loops in Maze",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Harvesting with Conditionals",
+      "name": "Harvesting with Conditionals",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Functions with Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Functions with Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Variables with Artist",
+      "name": "Variables with Artist",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Changing Variables with Bee",
+      "name": "Changing Variables with Bee",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Changing Variables with Artist",
+      "name": "Changing Variables with Artist",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "For Loops with Bee",
+      "name": "For Loops with Bee",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "For Loops with Artist",
+      "name": "For Loops with Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Swimming Fish in Sprite Lab",
+      "name": "Swimming Fish in Sprite Lab",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Alien Dance Party",
+      "name": "Alien Dance Party",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Behaviors in Sprite Lab",
+      "name": "Behaviors in Sprite Lab",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "Virtual Pet with Sprite Lab",
+      "name": "Virtual Pet with Sprite Lab",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_01"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_01"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_02"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_02"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_03"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_03"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_04"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_04"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_05"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_05"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_06"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_06"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_07"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_07"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_08"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_08"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_09"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_09"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_vid5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_10"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_bonus1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseD_Dance_2020_bonus3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_maze_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_video_maze_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming1_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming2_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming3_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming4_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming5_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming6_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming7_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming8_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming9_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_programming_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "express_maze_debugging9_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "express_maze_debugging9_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_collector_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_video_collector_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog5_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog6_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog8_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog9_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "grade2_collector_A_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "grade2_collector_A_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade2_collector_10_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "grade2_collector_10_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_prog_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_video_artist_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "bb8_skinOverview_C-F_video_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops1_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "bb8_loops_C-F_video_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_maze_loops_challenge1a_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_collector_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPrePre1a_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loopsPre1a_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loop1_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops5a_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops7a_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_1_2018_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_1_2018_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_2_2018_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_3_2018_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_3_2018_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_4_2018_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_4_2018_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_5_2018_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_5_2018_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_6_2018_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_artist_6_2018_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Chop Tree_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Chop Trees_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Place Wall_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Plant Crops_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Underground Mining Coal_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Underground Iron_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Underground If Statements_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2020"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2020"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2020"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6_2020"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse_2020"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_2020"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8_2020"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9_2020"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10_2020"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while1_2020"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while2_2020"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while3_2020"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_2020"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_2020"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while5_2020"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while6_2020"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while7_2020"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while8_2020"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while9_2020"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_2020"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1_2020"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_2020"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2_2020"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_2020"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3_2020"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4_2020"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_2020"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5_2020"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6_2020"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a_2020"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8_2020"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b_2020"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10_2020"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_2020"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11_2020"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until1_2020"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_2020"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until3_2020"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until4_2020"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5_2020"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until5_2020"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until6_2020"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7_2020"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until7_2020"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until9_2020"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until10_2020"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 1,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2020"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 2,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1_2020"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 3,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2_2020"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2020"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 4,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3_2020"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2020"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 5,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4_2020"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2020"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 6,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5_2020"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2020"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 7,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6_2020"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2020"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 8,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7_2020"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2020"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 9,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8_2020"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2020"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 10,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_2020"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 11,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 12,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 13,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2020"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Function intro Ryan_2020"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2020"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2020"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2020"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2020"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2020"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2020"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2020"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2020"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2020"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2020"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2020"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2020"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2020"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2020"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2020"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2020"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2020"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2020"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2020"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2020"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2020"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2020"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2020"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2020"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2020"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2020"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2020"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2020"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2020"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2020"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2020"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2020"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2020"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2020"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2020"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2020"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2020"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2020"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2020"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2020"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2020"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2020"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2020"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2020"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2020"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2020"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2020"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2020"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2020"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2020"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2020"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2020"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2020"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2020"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2020"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1_2020"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2020"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables2_2020"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro_2019_2020"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_intro_2019_2020"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2020"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables_2020"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2020"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2020"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables3_2020"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2020"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables4_2020"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2020"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables5_2020"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2020"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables6_2020"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2020"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a_2020"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018_2019_2020"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant_2018_2019_2020"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2020"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 1,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_1_2020"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2020"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 2,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_2_2020"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2020"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 3,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_3_2020"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2020"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 4,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_4_2020"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2020"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 5,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_5_2020"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2020"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 6,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_6_2020"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2020"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 7,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_7_2020"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2020"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 8,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_variables_8_2020"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2020"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 1,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables7_2020"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2020"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 2,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables8_2020"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2020"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 3,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables9_2020"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2020"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 4,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables10_2020"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2020"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 5,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP_2020"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end_2019_2020"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 6,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_markdown_variables_end_2019_2020"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2020"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 7,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2020"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 8,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1_2020"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 1,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for1_2020"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2_2020"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 2,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for2_2020"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro_2019_2020"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 3,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_intro_2019_2020"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee_2020"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 4,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_video_forBee_2020"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2020"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 5,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4_2020"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 6,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for4_2020"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6_2020"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 7,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for6_2020"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7_2020"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 8,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for7_2020"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8_2020"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 9,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for8_2020"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5_2020"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 10,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for5_2020"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9_2020"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 11,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for9_2020"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10_2020"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 12,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for10_2020"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11_2020"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 13,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for11_2020"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end_2019_2020"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 14,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_markdown_forloops_end_2019_2020"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2020"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 15,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2020"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 16,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2020"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 1,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_video_forArtist_2020"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1_2020"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 2,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for1_2020"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2_2020"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 3,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for2_2020"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3_2020"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 4,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for3_2020"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4_2020"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 5,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for4_2020"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5_2020"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 6,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for5_2020"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6_2020"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 7,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for6_2020"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7_2020"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 8,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for7_2020"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8_2020"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 9,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for8_2020"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9_2020"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 10,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for9_2020"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2020"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 11,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_2020"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 12,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for10_2020"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2020"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 13,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2020"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 14,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_2020"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 2,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 3,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_2020"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 4,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_2020"
+      ]
+    },
+    {
+      "chapter": 299,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 5,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_2020"
+      ]
+    },
+    {
+      "chapter": 300,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 6,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_2020"
+      ]
+    },
+    {
+      "chapter": 301,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 7,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_2020"
+      ]
+    },
+    {
+      "chapter": 302,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 8,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_2020"
+      ]
+    },
+    {
+      "chapter": 303,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 9,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_2020"
+      ]
+    },
+    {
+      "chapter": 304,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 10,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "spritelab_extras_repeat"
+      ]
+    },
+    {
+      "chapter": 305,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_2020"
+      ]
+    },
+    {
+      "chapter": 306,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_2020"
+      ]
+    },
+    {
+      "chapter": 307,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 2_2020"
+      ]
+    },
+    {
+      "chapter": 308,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 3_2020"
+      ]
+    },
+    {
+      "chapter": 309,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 4_2020"
+      ]
+    },
+    {
+      "chapter": 310,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 5_2020"
+      ]
+    },
+    {
+      "chapter": 311,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 6_2020"
+      ]
+    },
+    {
+      "chapter": 312,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party 7_2020"
+      ]
+    },
+    {
+      "chapter": 313,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_2020"
+      ]
+    },
+    {
+      "chapter": 314,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 1_2020"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 1,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 1_2020"
+      ]
+    },
+    {
+      "chapter": 315,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 2_2020"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 2,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 2_2020"
+      ]
+    },
+    {
+      "chapter": 316,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3_2020"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 3,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 3_2020"
+      ]
+    },
+    {
+      "chapter": 317,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3a_2020"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 4,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 3a_2020"
+      ]
+    },
+    {
+      "chapter": 318,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 4_2020"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 5,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 4_2020"
+      ]
+    },
+    {
+      "chapter": 319,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 5_2020"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 6,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 5_2020"
+      ]
+    },
+    {
+      "chapter": 320,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors free play_2020"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 7,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors free play_2020"
+      ]
+    },
+    {
+      "chapter": 321,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 6_2020"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 8,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 6_2020"
+      ]
+    },
+    {
+      "chapter": 322,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 7_2020"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 9,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "behaviors 7_2020"
+      ]
+    },
+    {
+      "chapter": 323,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_2020"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 1_2020"
+      ]
+    },
+    {
+      "chapter": 324,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_2020"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 2_2020"
+      ]
+    },
+    {
+      "chapter": 325,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_2020"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 3_2020"
+      ]
+    },
+    {
+      "chapter": 326,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_2020"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 4_2020"
+      ]
+    },
+    {
+      "chapter": 327,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_2020"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 5_2020"
+      ]
+    },
+    {
+      "chapter": 328,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_2020"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 6_2020"
+      ]
+    },
+    {
+      "chapter": 329,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 7_2020"
+        ],
+        "script_level.chapter": 329,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 7_2020"
+      ]
+    },
+    {
+      "chapter": 330,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 8_2020"
+        ],
+        "script_level.chapter": 330,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "Virtual Pet 8_2020"
+      ]
+    },
+    {
+      "chapter": 331,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseExpress_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 331,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseExpress_project_exemplars_2019_2020"
+      ]
+    },
+    {
+      "chapter": 332,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Create your project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseExpress_EOC_2020"
+        ],
+        "script_level.chapter": 332,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      },
+      "level_keys": [
+        "courseExpress_EOC_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid1",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_01",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_01"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid2",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_02",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_02"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_03",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_03"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid3",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_04",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_04"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_05",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_05"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_06",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_06"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid4",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_07",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_07"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_08",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_08"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_09",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_09"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_vid5",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_vid5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_10",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_10"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_bonus1",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseD_Dance_2020_bonus3",
+        "script_level.level_keys": [
+          "CourseD_Dance_2020_bonus3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Dance Party",
+        "lesson_group.key": "csf_warmup",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_maze_2020",
+        "script_level.level_keys": [
+          "courseC_video_maze_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming1_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming2_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming3_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming3_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming4_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming4_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming5_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming5_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming6_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming6_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming7_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming7_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming8_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming8_predict1_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming9_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming9_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge1_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_programming_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_programming_challenge2_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Programming with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "express_maze_debugging9_2020",
+        "script_level.level_keys": [
+          "express_maze_debugging9_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_collector_2020",
+        "script_level.level_keys": [
+          "courseC_video_collector_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog1_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog2_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog3_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog4_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog5_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog5_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog6_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog6_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog7_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog8_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog8_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog9_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog9_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_2020",
+        "script_level.level_keys": [
+          "grade2_collector_A_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_A_predict1_2020",
+        "script_level.level_keys": [
+          "grade2_collector_A_predict1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade2_collector_10_2020",
+        "script_level.level_keys": [
+          "grade2_collector_10_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 13,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 14,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_prog_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_prog_challenge2_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 15,
+        "lesson.key": "Collecting Treasure with Laurel",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2020",
+        "script_level.level_keys": [
+          "courseC_video_artist_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 1,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 2,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 3,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 4,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 5,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 6,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 7,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 8,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 9,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 10,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 11,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 12,
+        "lesson.key": "Creating Art with Code",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_C-F_video_2020",
+        "script_level.level_keys": [
+          "bb8_skinOverview_C-F_video_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops1_predict1_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops1_predict1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_loops_C-F_video_2020",
+        "script_level.level_keys": [
+          "bb8_loops_C-F_video_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops9_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops9_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops10_predict2_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops10_predict2_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops11_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops11_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_loops_challenge1a_2020",
+        "script_level.level_keys": [
+          "courseC_maze_loops_challenge1a_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_collector_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseC_collector_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 16,
+        "lesson.key": "Loops with Rey and BB-8",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPrePre1a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPrePre1a_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loopsPre1a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loopsPre1a_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loop1_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loop1_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops5a_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops7a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops7a_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a_2020",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Sticker Art with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2020",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_1_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_1_2018_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 1,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_2_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_2_2018_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 2,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_3_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_3_2018_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 3,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_4_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_4_2018_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 4,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_5_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_5_2018_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 5,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_6_2018_2020",
+        "script_level.level_keys": [
+          "courseD_artist_6_2018_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 6,
+        "lesson.key": "Snowflakes with Anna and Elsa",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep_2020",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree_2020",
+        "script_level.level_keys": [
+          "Overworld Chop Tree_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep_2020",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees_2020",
+        "script_level.level_keys": [
+          "Overworld Chop Trees_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall_2020",
+        "script_level.level_keys": [
+          "Overworld Place Wall_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen_2020",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops_2020",
+        "script_level.level_keys": [
+          "Overworld Plant Crops_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters_2020",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal_2020",
+        "script_level.level_keys": [
+          "Underground Mining Coal_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron_2020",
+        "script_level.level_keys": [
+          "Underground Iron_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava_2020",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements_2020",
+        "script_level.level_keys": [
+          "Underground If Statements_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 12,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart_2020",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 13,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20_2020",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 14,
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 1,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 2,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 3,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 4,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 5,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 6,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6_2020"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 7,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse_2020"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 8,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_2020"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 9,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2_2020"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 10,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8_2020"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 11,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9_2020"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 12,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10_2020"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 13,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1_2020"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 14,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2_2020"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 15,
+        "lesson.key": "If/Else with Bee",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while1_2020"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 1,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while2_2020"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 2,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while3_2020"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 3,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_2020",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_2020"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 4,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_2020"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 5,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_2020"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 6,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while5_2020"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 7,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while6_2020"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 8,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while7_2020"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 9,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while8_2020"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 10,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while9_2020"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 11,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_2020"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 12,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2_2020"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 13,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1_2020"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 14,
+        "lesson.key": "While Loops with the Farmer",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_2020"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_2020"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_2020"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_2020"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_2020"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_2020"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_2020"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_2020"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_2020"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_2020"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11_2020",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_2020"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until1_2020"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_2020",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_2020"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1_2020"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until3_2020"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until4_2020"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until5_2020"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until6_2020"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until7_2020"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until9_2020"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 9,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until10_2020"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 10,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2_2020",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2_2020"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 11,
+        "lesson.key": "Until Loops in Maze",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2020",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 1,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1_2020"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 2,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2_2020"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 3,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3_2020"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 4,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4_2020"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 5,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5_2020"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 6,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6_2020"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 7,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7_2020"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 8,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8_2020"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 9,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_2020"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 10,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1_2020"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 11,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1_2020"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 12,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2_2020"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 13,
+        "lesson.key": "Harvesting with Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2020"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2020"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2020"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2020"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2020"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2020"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2020"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2020",
+        "script_level.level_keys": [
+          "Function intro Ryan_2020"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2020"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2020"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2020"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2020",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2020"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2020",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2020"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2020"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2020"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2020"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2020"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2020"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2020"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2020",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2020"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2020"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2020"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2020"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2020"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2020"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2020",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2020"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2020"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2020"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2020"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2020"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2020"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2020"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2020"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2020"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2020"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2020"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2020"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1_2020",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1_2020"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 1,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables2_2020"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 2,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_intro_2019_2020",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_intro_2019_2020"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 3,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables_2020",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables_2020"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 4,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1_2020"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 5,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables3_2020"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 6,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables4_2020"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 7,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables5_2020"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 8,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables6_2020"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 9,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a_2020"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 10,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant_2018_2019_2020",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant_2018_2019_2020"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 11,
+        "lesson.key": "Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_1_2020"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 1,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_2_2020"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 2,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_3_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_3_2020"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 3,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_4_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_4_2020"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 4,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_5_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_5_2020"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 5,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_6_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_6_2020"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 6,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_7_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_7_2020"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 7,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_variables_8_2020",
+        "script_level.level_keys": [
+          "courseF_bee_variables_8_2020"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 8,
+        "lesson.key": "Changing Variables with Bee",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables7_2020"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 1,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables8_2020"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 2,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables9_2020"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 3,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables10_2020"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 4,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP_2020"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 5,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_variables_end_2019_2020",
+        "script_level.level_keys": [
+          "courseF_markdown_variables_end_2019_2020"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 6,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1_2020"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 7,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2_2020"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 8,
+        "lesson.key": "Changing Variables with Artist",
+        "lesson_group.key": "csf_variables",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for1_2020"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 1,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for2_2020"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 2,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_intro_2019_2020",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_intro_2019_2020"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 3,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee_2020",
+        "script_level.level_keys": [
+          "courseF_video_forBee_2020"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 4,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1_2020"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 5,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for4_2020"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 6,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for6_2020"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 7,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for7_2020"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 8,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for8_2020"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 9,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for5_2020"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 10,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for9_2020"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 11,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for10_2020"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 12,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for11_2020"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 13,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_forloops_end_2019_2020",
+        "script_level.level_keys": [
+          "courseF_markdown_forloops_end_2019_2020"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 14,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1_2020"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 15,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2_2020"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 16,
+        "lesson.key": "For Loops with Bee",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist_2020",
+        "script_level.level_keys": [
+          "courseF_video_forArtist_2020"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 1,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for1_2020"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 2,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for2_2020"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 3,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for3_2020"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 4,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for4_2020"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 5,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for5_2020"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 6,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for6_2020"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 7,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for7_2020"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 8,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for8_2020"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 9,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for9_2020"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 10,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1_2020"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 11,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for10_2020"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 12,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1_2020"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 13,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2_2020",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2_2020"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 14,
+        "lesson.key": "For Loops with Artist",
+        "lesson_group.key": "csf_for_loops",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_2020"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 1,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_2020"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 2,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_2020"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 3,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_2020"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 4,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_2020"
+        ],
+        "script_level.chapter": 299,
+        "script_level.position": 5,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_2020",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_2020"
+        ],
+        "script_level.chapter": 300,
+        "script_level.position": 6,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_2020"
+        ],
+        "script_level.chapter": 301,
+        "script_level.position": 7,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_2020"
+        ],
+        "script_level.chapter": 302,
+        "script_level.position": 8,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_2020",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_2020"
+        ],
+        "script_level.chapter": 303,
+        "script_level.position": 9,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "spritelab_extras_repeat",
+        "script_level.level_keys": [
+          "spritelab_extras_repeat"
+        ],
+        "script_level.chapter": 304,
+        "script_level.position": 10,
+        "lesson.key": "Swimming Fish in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_2020",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_2020"
+        ],
+        "script_level.chapter": 305,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_2020",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_2020"
+        ],
+        "script_level.chapter": 306,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_2020",
+        "script_level.level_keys": [
+          "Dance Party 2_2020"
+        ],
+        "script_level.chapter": 307,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_2020",
+        "script_level.level_keys": [
+          "Dance Party 3_2020"
+        ],
+        "script_level.chapter": 308,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_2020",
+        "script_level.level_keys": [
+          "Dance Party 4_2020"
+        ],
+        "script_level.chapter": 309,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_2020",
+        "script_level.level_keys": [
+          "Dance Party 5_2020"
+        ],
+        "script_level.chapter": 310,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_2020",
+        "script_level.level_keys": [
+          "Dance Party 6_2020"
+        ],
+        "script_level.chapter": 311,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_2020",
+        "script_level.level_keys": [
+          "Dance Party 7_2020"
+        ],
+        "script_level.chapter": 312,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_2020",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_2020"
+        ],
+        "script_level.chapter": 313,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 1_2020",
+        "script_level.level_keys": [
+          "behaviors 1_2020"
+        ],
+        "script_level.chapter": 314,
+        "script_level.position": 1,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 2_2020",
+        "script_level.level_keys": [
+          "behaviors 2_2020"
+        ],
+        "script_level.chapter": 315,
+        "script_level.position": 2,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3_2020",
+        "script_level.level_keys": [
+          "behaviors 3_2020"
+        ],
+        "script_level.chapter": 316,
+        "script_level.position": 3,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3a_2020",
+        "script_level.level_keys": [
+          "behaviors 3a_2020"
+        ],
+        "script_level.chapter": 317,
+        "script_level.position": 4,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 4_2020",
+        "script_level.level_keys": [
+          "behaviors 4_2020"
+        ],
+        "script_level.chapter": 318,
+        "script_level.position": 5,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 5_2020",
+        "script_level.level_keys": [
+          "behaviors 5_2020"
+        ],
+        "script_level.chapter": 319,
+        "script_level.position": 6,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors free play_2020",
+        "script_level.level_keys": [
+          "behaviors free play_2020"
+        ],
+        "script_level.chapter": 320,
+        "script_level.position": 7,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 6_2020",
+        "script_level.level_keys": [
+          "behaviors 6_2020"
+        ],
+        "script_level.chapter": 321,
+        "script_level.position": 8,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 7_2020",
+        "script_level.level_keys": [
+          "behaviors 7_2020"
+        ],
+        "script_level.chapter": 322,
+        "script_level.position": 9,
+        "lesson.key": "Behaviors in Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 1_2020"
+        ],
+        "script_level.chapter": 323,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 2_2020"
+        ],
+        "script_level.chapter": 324,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 3_2020"
+        ],
+        "script_level.chapter": 325,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 4_2020"
+        ],
+        "script_level.chapter": 326,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 5_2020"
+        ],
+        "script_level.chapter": 327,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 6_2020"
+        ],
+        "script_level.chapter": 328,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 7_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 7_2020"
+        ],
+        "script_level.chapter": 329,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 8_2020",
+        "script_level.level_keys": [
+          "Virtual Pet 8_2020"
+        ],
+        "script_level.chapter": 330,
+        "script_level.position": 8,
+        "lesson.key": "Virtual Pet with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseExpress_project_exemplars_2019_2020",
+        "script_level.level_keys": [
+          "courseExpress_project_exemplars_2019_2020"
+        ],
+        "script_level.chapter": 331,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseExpress_EOC_2020",
+        "script_level.level_keys": [
+          "courseExpress_EOC_2020"
+        ],
+        "script_level.chapter": 332,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "express-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/fit-test.script_json
+++ b/dashboard/config/scripts_json/fit-test.script_json
@@ -1,0 +1,292 @@
+{
+  "script": {
+    "name": "fit-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "FIT Weekend In Person",
+      "peer_reviews_to_complete": 2,
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "fit-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Deeper Learning Overview",
+      "name": "Deeper Learning Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "key": "Complete Practice Question",
+      "name": "Complete Practice Question",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complete Practice Question",
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Background"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "Deeper Learning Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Deadlines and Payment"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "csd deeper learning timeline 2018-2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Resource Recommendations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "dlp supports - csd"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Guidelines For Peer Review"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "peer review recommendations 18-19"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "fit-dlp-example"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Practice Question",
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "fit-dlp-example"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "fit-dlp-example-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Practice Question",
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      },
+      "level_keys": [
+        "fit-dlp-example-2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Deeper Learning Overview",
+        "script_level.level_keys": [
+          "Deeper Learning Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd deeper learning timeline 2018-2019",
+        "script_level.level_keys": [
+          "csd deeper learning timeline 2018-2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "dlp supports - csd",
+        "script_level.level_keys": [
+          "dlp supports - csd"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "peer review recommendations 18-19",
+        "script_level.level_keys": [
+          "peer review recommendations 18-19"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Deeper Learning Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "fit-dlp-example",
+        "script_level.level_keys": [
+          "fit-dlp-example"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Complete Practice Question",
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "fit-dlp-example-2",
+        "script_level.level_keys": [
+          "fit-dlp-example-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Complete Practice Question",
+        "lesson_group.key": "content",
+        "script.name": "fit-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/fit2019-apprentice.script_json
+++ b/dashboard/config/scripts_json/fit2019-apprentice.script_json
@@ -1,0 +1,1008 @@
+{
+  "script": {
+    "name": "fit2019-apprentice",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "Facilitators in Training Summer Reflections 2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "fit2019-apprentice"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Apprentice Reflection Overview",
+      "name": "Apprentice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "welcome-apprentice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "morning-prep-monday"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "feel-monday"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "debrief-monday"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "debrief-monday"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "engagement-monday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "engagement-monday"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "novice-monday-2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "morning-prep-tuesday"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "feel-tuesday"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "instructional-strategy-tuesday"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "debrief-tuesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "debrief-tuesday"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "engagement-tuesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "engagement-tuesday"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "novice-tuesday-2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "morning-prep-wednesday"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "feel-wednesday"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "getting-buy-in-wednesday"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "debrief-wednesday"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "debrief-wednesday"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "engagement-wednesday"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "engagement-wednesday"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "novice-wednesday-2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "morning-prep-thursday"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "feel-thursday"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "recruiting-thursday"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "debrief-thursday"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "debrief-thursday"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "engagement-thursday"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "engagement-thursday"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "novice-thursday-2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      },
+      "level_keys": [
+        "apprentice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-apprentice-18",
+        "script_level.level_keys": [
+          "welcome-apprentice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Apprentice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-monday",
+        "script_level.level_keys": [
+          "morning-prep-monday"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-monday",
+        "script_level.level_keys": [
+          "feel-monday"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "debrief-monday",
+        "script_level.level_keys": [
+          "debrief-monday"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "engagement-monday",
+        "script_level.level_keys": [
+          "engagement-monday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-2",
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-tuesday",
+        "script_level.level_keys": [
+          "morning-prep-tuesday"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-tuesday",
+        "script_level.level_keys": [
+          "feel-tuesday"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "instructional-strategy-tuesday",
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "debrief-tuesday",
+        "script_level.level_keys": [
+          "debrief-tuesday"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 4,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "engagement-tuesday",
+        "script_level.level_keys": [
+          "engagement-tuesday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 5,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-2",
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 6,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-wednesday",
+        "script_level.level_keys": [
+          "morning-prep-wednesday"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-wednesday",
+        "script_level.level_keys": [
+          "feel-wednesday"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "getting-buy-in-wednesday",
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "debrief-wednesday",
+        "script_level.level_keys": [
+          "debrief-wednesday"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "engagement-wednesday",
+        "script_level.level_keys": [
+          "engagement-wednesday"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-2",
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "morning-prep-thursday",
+        "script_level.level_keys": [
+          "morning-prep-thursday"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "feel-thursday",
+        "script_level.level_keys": [
+          "feel-thursday"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "recruiting-thursday",
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "debrief-thursday",
+        "script_level.level_keys": [
+          "debrief-thursday"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "engagement-thursday",
+        "script_level.level_keys": [
+          "engagement-thursday"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 5,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-2",
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 6,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "apprentice-congrats",
+        "script_level.level_keys": [
+          "apprentice-congrats"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-apprentice"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/fit2019-novice.script_json
+++ b/dashboard/config/scripts_json/fit2019-novice.script_json
@@ -1,0 +1,588 @@
+{
+  "script": {
+    "name": "fit2019-novice",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "Facilitators in Training Summer 2019",
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "fit2019-novice"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Novice Reflection Overview",
+      "name": "Novice Reflection Overview",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "Day 1",
+      "name": "Day 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "Day 2",
+      "name": "Day 2",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "Day 3",
+      "name": "Day 3",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "Day 4",
+      "name": "Day 4",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "key": "Wrap Up",
+      "name": "Wrap Up",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "welcome-novice-18"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-monday-1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-monday-2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-tuesday-1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "instructional-strategy-tuesday"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-tuesday-2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-wednesday-1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "getting-buy-in-wednesday"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-wednesday-2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-thursday-1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "recruiting-thursday"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-thursday-2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      },
+      "level_keys": [
+        "novice-congrats"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "welcome-novice-18",
+        "script_level.level_keys": [
+          "welcome-novice-18"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Novice Reflection Overview",
+        "lesson_group.key": "required",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-1",
+        "script_level.level_keys": [
+          "novice-monday-1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-monday-2",
+        "script_level.level_keys": [
+          "novice-monday-2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Day 1",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-1",
+        "script_level.level_keys": [
+          "novice-tuesday-1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "instructional-strategy-tuesday",
+        "script_level.level_keys": [
+          "instructional-strategy-tuesday"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-tuesday-2",
+        "script_level.level_keys": [
+          "novice-tuesday-2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Day 2",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-1",
+        "script_level.level_keys": [
+          "novice-wednesday-1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "getting-buy-in-wednesday",
+        "script_level.level_keys": [
+          "getting-buy-in-wednesday"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-wednesday-2",
+        "script_level.level_keys": [
+          "novice-wednesday-2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "Day 3",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-1",
+        "script_level.level_keys": [
+          "novice-thursday-1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "recruiting-thursday",
+        "script_level.level_keys": [
+          "recruiting-thursday"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-thursday-2",
+        "script_level.level_keys": [
+          "novice-thursday-2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Day 4",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "novice-congrats",
+        "script_level.level_keys": [
+          "novice-congrats"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Wrap Up",
+        "lesson_group.key": "content",
+        "script.name": "fit2019-novice"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/flappy-impact-study.script_json
+++ b/dashboard/config/scripts_json/flappy-impact-study.script_json
@@ -1,0 +1,496 @@
+{
+  "script": {
+    "name": "flappy-impact-study",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "flappy-impact-study"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Pre Hour of Code Survey",
+      "name": "Pre Hour of Code Survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "key": "Flappy Code",
+      "name": "Flappy Code",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "key": "Post Hour of Code Survey",
+      "name": "Post Hour of Code Survey",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC pre-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "HOC pre-survey 2016 levelgroup"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC post-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      },
+      "level_keys": [
+        "HOC post-survey 2016 levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "HOC pre-survey 2016 levelgroup",
+        "script_level.level_keys": [
+          "HOC pre-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC post-survey 2016 levelgroup",
+        "script_level.level_keys": [
+          "HOC post-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "flappy-impact-study"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/flappy.script_json
+++ b/dashboard/config/scripts_json/flappy.script_json
@@ -1,0 +1,398 @@
+{
+  "script": {
+    "name": "flappy",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "flappy"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Flappy Code",
+      "name": "Flappy Code",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      },
+      "level_keys": [
+        "flappy_11"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "flappy_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "flappy_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "flappy_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "flappy_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "flappy_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "flappy_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "flappy_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "flappy_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "flappy_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "flappy_11"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Flappy Code",
+        "lesson_group.key": "",
+        "script.name": "flappy"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/fmscsd3preview.script_json
+++ b/dashboard/config/scripts_json/fmscsd3preview.script_json
@@ -1,0 +1,833 @@
+{
+  "script": {
+    "name": "fmscsd3preview",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "student_detail_progress_view": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "fmscsd3preview"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Plotting Shapes",
+      "name": "Plotting Shapes",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "key": "Drawing in Game Lab",
+      "name": "Drawing in Game Lab",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "CSD U3 Lesson Overview 2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Describe the Picture"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "CSD U3 Describe the Picture"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Simple Drawing"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "CSD-U3-SFLP Simple Drawing"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Rectangle"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Rectangle Width and Height"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - X and Y values"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - X and Y values"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Order of Blocks"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Fill"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Oval"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Oval"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Simple Shape Drawing"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Simple Shape Drawing"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Ellipse and No Fill"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Ellipse and No Fill"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Stroke and Stroke Weight"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Stroke and Stroke Weight"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - No Fill"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - No Fill"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Comments"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Comments"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Rects and Color"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 15,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Road Rects and Color"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Ellipse"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 16,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Road Ellipse"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - regular polygon"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 17,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - regular polygon"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - text"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 18,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - text"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Plan Personal Drawing"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 19,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Plan Personal Drawing"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Personal Drawing"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 20,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Personal Drawing"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Lesson Overview 2",
+        "script_level.level_keys": [
+          "CSD U3 Lesson Overview 2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Describe the Picture",
+        "script_level.level_keys": [
+          "CSD U3 Describe the Picture"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Plotting Shapes",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD-U3-SFLP Simple Drawing",
+        "script_level.level_keys": [
+          "CSD-U3-SFLP Simple Drawing"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Rectangle",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Rectangle Width and Height",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle Width and Height"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - X and Y values",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - X and Y values"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Order of Blocks",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 2",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Oval",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Oval"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Simple Shape Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Simple Shape Drawing"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Ellipse and No Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Ellipse and No Fill"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Stroke and Stroke Weight",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Stroke and Stroke Weight"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - No Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - No Fill"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Comments",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Comments"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Road Rects and Color",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Rects and Color"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 15,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Road Ellipse",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Road Ellipse"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 16,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - regular polygon",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - regular polygon"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 17,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - text",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - text"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 18,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Plan Personal Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Plan Personal Drawing"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 19,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Personal Drawing",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Personal Drawing"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 20,
+        "lesson.key": "Drawing in Game Lab",
+        "lesson_group.key": "",
+        "script.name": "fmscsd3preview"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/frequency_analysis.script_json
+++ b/dashboard/config/scripts_json/frequency_analysis.script_json
@@ -1,0 +1,84 @@
+{
+  "script": {
+    "name": "frequency_analysis",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "frequency_analysis"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "frequency_analysis"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Frequency Analysis",
+      "name": "Frequency Analysis",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Frequency Analysis",
+        "lesson_group.key": "",
+        "script.name": "frequency_analysis"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Frequency Analysis"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Frequency Analysis",
+        "lesson_group.key": "",
+        "script.name": "frequency_analysis"
+      },
+      "level_keys": [
+        "Frequency Analysis"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Frequency Analysis",
+        "script_level.level_keys": [
+          "Frequency Analysis"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Frequency Analysis",
+        "lesson_group.key": "",
+        "script.name": "frequency_analysis"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/frozen-2018-test-b.script_json
+++ b/dashboard/config/scripts_json/frozen-2018-test-b.script_json
@@ -1,0 +1,678 @@
+{
+  "script": {
+    "name": "frozen-2018-test-b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "frozen-2018-test-b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen line_b"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen line_b"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen perpendicular_b"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen perpendicular_b"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen_video_loops_b"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen_video_loops_b"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square iterative_b"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen square iterative_b"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop_b"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen square loop_b"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop 3x_b"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen square loop 3x_b"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square snowflake_b"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen square snowflake_b"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross_b"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen cross_b"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate_b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen cross rotate_b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate dense_b"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen cross rotate dense_b"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond_b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen diamond_b"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake_b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen diamond mini snowflake_b"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond snowflake_b"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen diamond snowflake_b"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen_variables_functions_b"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen_variables_functions_b"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake branch_b"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen snowflake branch_b"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake full_b"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen snowflake full_b"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake fuller_b"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen snowflake fuller_b"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen freeplay_b"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      },
+      "level_keys": [
+        "frozen freeplay_b"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "frozen line_b",
+        "script_level.level_keys": [
+          "frozen line_b"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen perpendicular_b",
+        "script_level.level_keys": [
+          "frozen perpendicular_b"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen_video_loops_b",
+        "script_level.level_keys": [
+          "frozen_video_loops_b"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square iterative_b",
+        "script_level.level_keys": [
+          "frozen square iterative_b"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop_b",
+        "script_level.level_keys": [
+          "frozen square loop_b"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop 3x_b",
+        "script_level.level_keys": [
+          "frozen square loop 3x_b"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square snowflake_b",
+        "script_level.level_keys": [
+          "frozen square snowflake_b"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross_b",
+        "script_level.level_keys": [
+          "frozen cross_b"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate_b",
+        "script_level.level_keys": [
+          "frozen cross rotate_b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate dense_b",
+        "script_level.level_keys": [
+          "frozen cross rotate dense_b"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond_b",
+        "script_level.level_keys": [
+          "frozen diamond_b"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond mini snowflake_b",
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake_b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond snowflake_b",
+        "script_level.level_keys": [
+          "frozen diamond snowflake_b"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen_variables_functions_b",
+        "script_level.level_keys": [
+          "frozen_variables_functions_b"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake branch_b",
+        "script_level.level_keys": [
+          "frozen snowflake branch_b"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake full_b",
+        "script_level.level_keys": [
+          "frozen snowflake full_b"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake fuller_b",
+        "script_level.level_keys": [
+          "frozen snowflake fuller_b"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen freeplay_b",
+        "script_level.level_keys": [
+          "frozen freeplay_b"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test-b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/frozen-2018-test.script_json
+++ b/dashboard/config/scripts_json/frozen-2018-test.script_json
@@ -1,0 +1,818 @@
+{
+  "script": {
+    "name": "frozen-2018-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "frozen-2018-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen line_test"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen line_test"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen perpendicular_test"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen perpendicular_test"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen_video_loops"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen_video_loops"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square iterative_test"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen square iterative_test"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop_test"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen square loop_test"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop 3x_test"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen square loop 3x_test"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square snowflake_test"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen square snowflake_test"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross_test"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen cross_test"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate_test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen cross rotate_test"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate dense_test"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen cross rotate dense_test"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond_test"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen diamond_test"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake_test"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen diamond mini snowflake_test"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond snowflake_test"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen diamond snowflake_test"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle_test"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen circle_test"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen_variables_functions"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen_variables_functions"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function_test"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen circle function_test"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function in circle_test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen circle function in circle_test"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function with parameter_test"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen circle function with parameter_test"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflower_test"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen snowflower_test"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake branch_test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen snowflake branch_test"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake full_test"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen snowflake full_test"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen freeplay_test"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      },
+      "level_keys": [
+        "frozen freeplay_test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "frozen line_test",
+        "script_level.level_keys": [
+          "frozen line_test"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen perpendicular_test",
+        "script_level.level_keys": [
+          "frozen perpendicular_test"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen_video_loops",
+        "script_level.level_keys": [
+          "frozen_video_loops"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square iterative_test",
+        "script_level.level_keys": [
+          "frozen square iterative_test"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop_test",
+        "script_level.level_keys": [
+          "frozen square loop_test"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop 3x_test",
+        "script_level.level_keys": [
+          "frozen square loop 3x_test"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square snowflake_test",
+        "script_level.level_keys": [
+          "frozen square snowflake_test"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross_test",
+        "script_level.level_keys": [
+          "frozen cross_test"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate_test",
+        "script_level.level_keys": [
+          "frozen cross rotate_test"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate dense_test",
+        "script_level.level_keys": [
+          "frozen cross rotate dense_test"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond_test",
+        "script_level.level_keys": [
+          "frozen diamond_test"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond mini snowflake_test",
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake_test"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond snowflake_test",
+        "script_level.level_keys": [
+          "frozen diamond snowflake_test"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle_test",
+        "script_level.level_keys": [
+          "frozen circle_test"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen_variables_functions",
+        "script_level.level_keys": [
+          "frozen_variables_functions"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function_test",
+        "script_level.level_keys": [
+          "frozen circle function_test"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function in circle_test",
+        "script_level.level_keys": [
+          "frozen circle function in circle_test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function with parameter_test",
+        "script_level.level_keys": [
+          "frozen circle function with parameter_test"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflower_test",
+        "script_level.level_keys": [
+          "frozen snowflower_test"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake branch_test",
+        "script_level.level_keys": [
+          "frozen snowflake branch_test"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake full_test",
+        "script_level.level_keys": [
+          "frozen snowflake full_test"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 21,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen freeplay_test",
+        "script_level.level_keys": [
+          "frozen freeplay_test"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 22,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/frozen-2018.script_json
+++ b/dashboard/config/scripts_json/frozen-2018.script_json
@@ -1,0 +1,748 @@
+{
+  "script": {
+    "name": "frozen-2018",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "frozen-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen line"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen line"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen perpendicular"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen perpendicular"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square iterative"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen square iterative"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen square loop"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop 3x"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen square loop 3x"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square snowflake"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen square snowflake"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen cross"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen cross rotate"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate dense"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen cross rotate dense"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen diamond"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen diamond mini snowflake"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond snowflake"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen diamond snowflake"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen circle"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen circle function"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function in circle"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen circle function in circle"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function with parameter"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen circle function with parameter"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflower"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen snowflower"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake branch"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen snowflake branch"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake full"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen snowflake full"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen freeplay"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      },
+      "level_keys": [
+        "frozen freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "frozen line",
+        "script_level.level_keys": [
+          "frozen line"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen perpendicular",
+        "script_level.level_keys": [
+          "frozen perpendicular"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square iterative",
+        "script_level.level_keys": [
+          "frozen square iterative"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop",
+        "script_level.level_keys": [
+          "frozen square loop"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop 3x",
+        "script_level.level_keys": [
+          "frozen square loop 3x"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square snowflake",
+        "script_level.level_keys": [
+          "frozen square snowflake"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross",
+        "script_level.level_keys": [
+          "frozen cross"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate",
+        "script_level.level_keys": [
+          "frozen cross rotate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate dense",
+        "script_level.level_keys": [
+          "frozen cross rotate dense"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond",
+        "script_level.level_keys": [
+          "frozen diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond mini snowflake",
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond snowflake",
+        "script_level.level_keys": [
+          "frozen diamond snowflake"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle",
+        "script_level.level_keys": [
+          "frozen circle"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function",
+        "script_level.level_keys": [
+          "frozen circle function"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function in circle",
+        "script_level.level_keys": [
+          "frozen circle function in circle"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function with parameter",
+        "script_level.level_keys": [
+          "frozen circle function with parameter"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflower",
+        "script_level.level_keys": [
+          "frozen snowflower"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake branch",
+        "script_level.level_keys": [
+          "frozen snowflake branch"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake full",
+        "script_level.level_keys": [
+          "frozen snowflake full"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen freeplay",
+        "script_level.level_keys": [
+          "frozen freeplay"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/frozen.script_json
+++ b/dashboard/config/scripts_json/frozen.script_json
@@ -1,0 +1,748 @@
+{
+  "script": {
+    "name": "frozen",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "frozen"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Artist",
+      "name": "Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen line"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen line"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen perpendicular"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen perpendicular"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square iterative"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen square iterative"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen square loop"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square loop 3x"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen square loop 3x"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen square snowflake"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen square snowflake"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen cross"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen cross rotate"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen cross rotate dense"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen cross rotate dense"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen diamond"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen diamond mini snowflake"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen diamond snowflake"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen diamond snowflake"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen circle"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen circle function"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function in circle"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen circle function in circle"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen circle function with parameter"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen circle function with parameter"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflower"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen snowflower"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake branch"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen snowflake branch"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen snowflake full"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen snowflake full"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "frozen freeplay"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      },
+      "level_keys": [
+        "frozen freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "frozen line",
+        "script_level.level_keys": [
+          "frozen line"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen perpendicular",
+        "script_level.level_keys": [
+          "frozen perpendicular"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square iterative",
+        "script_level.level_keys": [
+          "frozen square iterative"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop",
+        "script_level.level_keys": [
+          "frozen square loop"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square loop 3x",
+        "script_level.level_keys": [
+          "frozen square loop 3x"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen square snowflake",
+        "script_level.level_keys": [
+          "frozen square snowflake"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross",
+        "script_level.level_keys": [
+          "frozen cross"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate",
+        "script_level.level_keys": [
+          "frozen cross rotate"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen cross rotate dense",
+        "script_level.level_keys": [
+          "frozen cross rotate dense"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond",
+        "script_level.level_keys": [
+          "frozen diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond mini snowflake",
+        "script_level.level_keys": [
+          "frozen diamond mini snowflake"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen diamond snowflake",
+        "script_level.level_keys": [
+          "frozen diamond snowflake"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle",
+        "script_level.level_keys": [
+          "frozen circle"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function",
+        "script_level.level_keys": [
+          "frozen circle function"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function in circle",
+        "script_level.level_keys": [
+          "frozen circle function in circle"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen circle function with parameter",
+        "script_level.level_keys": [
+          "frozen circle function with parameter"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflower",
+        "script_level.level_keys": [
+          "frozen snowflower"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake branch",
+        "script_level.level_keys": [
+          "frozen snowflake branch"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen snowflake full",
+        "script_level.level_keys": [
+          "frozen snowflake full"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "frozen freeplay",
+        "script_level.level_keys": [
+          "frozen freeplay"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Artist",
+        "lesson_group.key": "",
+        "script.name": "frozen"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/gamelab-demo.script_json
+++ b/dashboard/config/scripts_json/gamelab-demo.script_json
@@ -1,0 +1,188 @@
+{
+  "script": {
+    "name": "gamelab-demo",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "gamelab-demo"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Simple Sprite Movement",
+      "name": "Simple Sprite Movement",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      },
+      "level_keys": [
+        "GameLab Livecode Demo 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      },
+      "level_keys": [
+        "GameLab Livecode Demo 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      },
+      "level_keys": [
+        "GameLab Livecode Demo 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      },
+      "level_keys": [
+        "GameLab Livecode Demo 4"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GameLab Livecode Demo 1",
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GameLab Livecode Demo 2",
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GameLab Livecode Demo 3",
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GameLab Livecode Demo 4",
+        "script_level.level_keys": [
+          "GameLab Livecode Demo 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Simple Sprite Movement",
+        "lesson_group.key": "",
+        "script.name": "gamelab-demo"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/gamelab-hackathon.script_json
+++ b/dashboard/config/scripts_json/gamelab-hackathon.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "gamelab-hackathon",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "gamelab-hackathon"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Middle_School_Hackathon",
+      "name": "Middle_School_Hackathon",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Middle_School_Hackathon",
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Middle School Hackathon Pt 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Middle_School_Hackathon",
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      },
+      "level_keys": [
+        "Middle School Hackathon Pt 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Middle School Hackathon Pt 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Middle_School_Hackathon",
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      },
+      "level_keys": [
+        "Middle School Hackathon Pt 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Middle School Hackathon Pt 1",
+        "script_level.level_keys": [
+          "Middle School Hackathon Pt 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Middle_School_Hackathon",
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Middle School Hackathon Pt 2",
+        "script_level.level_keys": [
+          "Middle School Hackathon Pt 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Middle_School_Hackathon",
+        "lesson_group.key": "",
+        "script.name": "gamelab-hackathon"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/gamelab.script_json
+++ b/dashboard/config/scripts_json/gamelab.script_json
@@ -1,0 +1,412 @@
+{
+  "script": {
+    "name": "gamelab",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "gamelab"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Start and End Screens",
+      "name": "Start and End Screens",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "key": "Start and End Screens2",
+      "name": "Start and End Screens2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Start and End Screens2",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen base code"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen base code"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen State"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen State"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Check State"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Check State"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Check States"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Check States"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Change State"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Change State"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen End Game"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen End Game"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Restart Game"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Restart Game"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Hide Sprites"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Hide Sprites"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Gamelab StartScreen Intro"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Start and End Screens2",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      },
+      "level_keys": [
+        "Gamelab StartScreen Intro"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Intro",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen base code",
+        "script_level.level_keys": [
+          "Gamelab StartScreen base code"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen State",
+        "script_level.level_keys": [
+          "Gamelab StartScreen State"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Check State",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Check State"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Check States",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Check States"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Change State",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Change State"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen End Game",
+        "script_level.level_keys": [
+          "Gamelab StartScreen End Game"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Restart Game",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Restart Game"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Hide Sprites",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Hide Sprites"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Start and End Screens",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Gamelab StartScreen Intro",
+        "script_level.level_keys": [
+          "Gamelab StartScreen Intro"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Start and End Screens2",
+        "lesson_group.key": "",
+        "script.name": "gamelab"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/gamelabprojects.script_json
+++ b/dashboard/config/scripts_json/gamelabprojects.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "gamelabprojects",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "gamelabprojects"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/glj-behavior-test.script_json
+++ b/dashboard/config/scripts_json/glj-behavior-test.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "glj-behavior-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "glj-behavior-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Cats and Dogs",
+      "name": "Cats and Dogs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Cats and Dogs",
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "KIKI GLJ Test 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Cats and Dogs",
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      },
+      "level_keys": [
+        "KIKI GLJ Test 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "KIKI GLJ Test 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Cats and Dogs",
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      },
+      "level_keys": [
+        "KIKI GLJ Test 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "KIKI GLJ Test 1",
+        "script_level.level_keys": [
+          "KIKI GLJ Test 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Cats and Dogs",
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "KIKI GLJ Test 2",
+        "script_level.level_keys": [
+          "KIKI GLJ Test 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Cats and Dogs",
+        "lesson_group.key": "",
+        "script.name": "glj-behavior-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/grade5.script_json
+++ b/dashboard/config/scripts_json/grade5.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "grade5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "grade5"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/gumball.script_json
+++ b/dashboard/config/scripts_json/gumball.script_json
@@ -1,0 +1,433 @@
+{
+  "script": {
+    "name": "gumball",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "gumball"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Gumball Play Lab",
+      "name": "Gumball Play Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_hello1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_hello1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_hello2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_hello2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_to_flag"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_to_actor"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_repeat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_repeat"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_click_hello"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_click_hello"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_move_events"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_sound_and_points"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_warn_food_fight"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_warn_food_fight"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_join_food_fight"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_join_food_fight"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_free_play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      },
+      "level_keys": [
+        "blockly:Studio:gumball_free_play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_hello1",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_hello1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_hello2",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_hello2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_move_to_flag",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_to_flag"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_move_to_actor",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_to_actor"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_repeat",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_repeat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_click_hello",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_click_hello"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_move_events",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_move_events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_sound_and_points",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_sound_and_points"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_warn_food_fight",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_warn_food_fight"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_join_food_fight",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_join_food_fight"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:gumball_free_play",
+        "script_level.level_keys": [
+          "blockly:Studio:gumball_free_play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Gumball Play Lab",
+        "lesson_group.key": "",
+        "script.name": "gumball"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/halloween.script_json
+++ b/dashboard/config/scripts_json/halloween.script_json
@@ -1,0 +1,153 @@
+{
+  "script": {
+    "name": "halloween",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "halloween"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Halloween Artist",
+      "name": "Halloween Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      },
+      "level_keys": [
+        "October15 ghost 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      },
+      "level_keys": [
+        "October15 stars 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      },
+      "level_keys": [
+        "October15 JoL 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "October15 ghost 1",
+        "script_level.level_keys": [
+          "October15 ghost 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 stars 1",
+        "script_level.level_keys": [
+          "October15 stars 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "October15 JoL 1",
+        "script_level.level_keys": [
+          "October15 JoL 1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Halloween Artist",
+        "lesson_group.key": "",
+        "script.name": "halloween"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/hero.script_json
+++ b/dashboard/config/scripts_json/hero.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "hero",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "hero"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Minecraft Hour of Code",
+      "name": "Minecraft Hour of Code",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "Function intro Ryan"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan",
+        "script_level.level_keys": [
+          "Function intro Ryan"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Minecraft Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "hero"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/hoc-encryption.script_json
+++ b/dashboard/config/scripts_json/hoc-encryption.script_json
@@ -1,0 +1,258 @@
+{
+  "script": {
+    "name": "hoc-encryption",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "hoc-encryption"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Simple Encryption",
+      "name": "Simple Encryption",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "Terminology Recap"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "New Challenge Introduction"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "Crack Random Substitution"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap",
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction",
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution",
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "hoc-encryption"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/hoc-impact-study.script_json
+++ b/dashboard/config/scripts_json/hoc-impact-study.script_json
@@ -1,0 +1,846 @@
+{
+  "script": {
+    "name": "hoc-impact-study",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "hoc-impact-study"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Pre Hour of Code Survey",
+      "name": "Pre Hour of Code Survey",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "key": "Hour of Code 2013",
+      "name": "Hour of Code 2013",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "key": "Post Hour of Code Survey",
+      "name": "Post Hour of Code Survey",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC pre-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "HOC pre-survey 2016 levelgroup"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2_5"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_10"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_11"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_12"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_13"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_14"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_15"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_16"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_17"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_18"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "blockly:Maze:2_19"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "HOC post-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      },
+      "level_keys": [
+        "HOC post-survey 2016 levelgroup"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "HOC pre-survey 2016 levelgroup",
+        "script_level.level_keys": [
+          "HOC pre-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pre Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_1",
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_3",
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_4",
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_6",
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_7",
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_8",
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_9",
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_10",
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_11",
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_12",
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_13",
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_14",
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_15",
+        "script_level.level_keys": [
+          "blockly:Maze:2_15"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 16,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_16",
+        "script_level.level_keys": [
+          "blockly:Maze:2_16"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 17,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_17",
+        "script_level.level_keys": [
+          "blockly:Maze:2_17"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 18,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_18",
+        "script_level.level_keys": [
+          "blockly:Maze:2_18"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 19,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_19",
+        "script_level.level_keys": [
+          "blockly:Maze:2_19"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 20,
+        "lesson.key": "Hour of Code 2013",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "HOC post-survey 2016 levelgroup",
+        "script_level.level_keys": [
+          "HOC post-survey 2016 levelgroup"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Post Hour of Code Survey",
+        "lesson_group.key": "",
+        "script.name": "hoc-impact-study"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/hourofcode.script_json
+++ b/dashboard/config/scripts_json/hourofcode.script_json
@@ -1,0 +1,748 @@
+{
+  "script": {
+    "name": "hourofcode",
+    "wrapup_video_id": 13,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "hourofcode"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Maze",
+      "name": "Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_2_5"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_8"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_9"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_10"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_11"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_12"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_13"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "blockly:Maze:2_14"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat 16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "scrat 16"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat 17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "scrat 17"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat 18"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "scrat 18"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat 19"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "scrat 19"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "scrat 20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      },
+      "level_keys": [
+        "scrat 20"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_1",
+        "script_level.level_keys": [
+          "blockly:Maze:2_1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_2_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_3",
+        "script_level.level_keys": [
+          "blockly:Maze:2_3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_4",
+        "script_level.level_keys": [
+          "blockly:Maze:2_4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_5",
+        "script_level.level_keys": [
+          "blockly:Maze:2_5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_6",
+        "script_level.level_keys": [
+          "blockly:Maze:2_6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_7",
+        "script_level.level_keys": [
+          "blockly:Maze:2_7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_8",
+        "script_level.level_keys": [
+          "blockly:Maze:2_8"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_9",
+        "script_level.level_keys": [
+          "blockly:Maze:2_9"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_10",
+        "script_level.level_keys": [
+          "blockly:Maze:2_10"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_11",
+        "script_level.level_keys": [
+          "blockly:Maze:2_11"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_12",
+        "script_level.level_keys": [
+          "blockly:Maze:2_12"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_13",
+        "script_level.level_keys": [
+          "blockly:Maze:2_13"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Maze:2_14",
+        "script_level.level_keys": [
+          "blockly:Maze:2_14"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat 16",
+        "script_level.level_keys": [
+          "scrat 16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat 17",
+        "script_level.level_keys": [
+          "scrat 17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat 18",
+        "script_level.level_keys": [
+          "scrat 18"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat 19",
+        "script_level.level_keys": [
+          "scrat 19"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "scrat 20",
+        "script_level.level_keys": [
+          "scrat 20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "Maze",
+        "lesson_group.key": "",
+        "script.name": "hourofcode"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/iceage.script_json
+++ b/dashboard/config/scripts_json/iceage.script_json
@@ -1,0 +1,433 @@
+{
+  "script": {
+    "name": "iceage",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "iceage"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_hello1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_hello2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_repeat"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_click_hello"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_throw_hearts"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      },
+      "level_keys": [
+        "iceage_free_play"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1",
+        "script_level.level_keys": [
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2",
+        "script_level.level_keys": [
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag",
+        "script_level.level_keys": [
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor",
+        "script_level.level_keys": [
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat",
+        "script_level.level_keys": [
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello",
+        "script_level.level_keys": [
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts",
+        "script_level.level_keys": [
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play",
+        "script_level.level_keys": [
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "",
+        "script.name": "iceage"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/infinity.script_json
+++ b/dashboard/config/scripts_json/infinity.script_json
@@ -1,0 +1,398 @@
+{
+  "script": {
+    "name": "infinity",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "infinity"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Infinity",
+      "name": "Infinity",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_move_right"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_move_right"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_say"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_say"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_move_directions"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_move_directions"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_move_collide"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_move_collide"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_touch_score"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_touch_score"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_shoot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_shoot"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_shoot_directions"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_shoot_directions"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_repeat"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_repeat"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_catch"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_catch"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Infinity_finale"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      },
+      "level_keys": [
+        "Infinity_finale"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Infinity_move_right",
+        "script_level.level_keys": [
+          "Infinity_move_right"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_say",
+        "script_level.level_keys": [
+          "Infinity_say"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_move_directions",
+        "script_level.level_keys": [
+          "Infinity_move_directions"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_move_collide",
+        "script_level.level_keys": [
+          "Infinity_move_collide"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_touch_score",
+        "script_level.level_keys": [
+          "Infinity_touch_score"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_shoot",
+        "script_level.level_keys": [
+          "Infinity_shoot"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_shoot_directions",
+        "script_level.level_keys": [
+          "Infinity_shoot_directions"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_repeat",
+        "script_level.level_keys": [
+          "Infinity_repeat"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_catch",
+        "script_level.level_keys": [
+          "Infinity_catch"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Infinity_finale",
+        "script_level.level_keys": [
+          "Infinity_finale"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Infinity",
+        "lesson_group.key": "",
+        "script.name": "infinity"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/jess-test-script.script_json
+++ b/dashboard/config/scripts_json/jess-test-script.script_json
@@ -1,0 +1,3584 @@
+{
+  "script": {
+    "name": "jess-test-script",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1-O6o5yQ4I1dk0n4Qzh86quXGBtzDDtyJ3Skr6RpcpO4/preview"
+        ],
+        [
+          "professionalLearning",
+          "https://studio.code.org/my-professional-learning"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "jess-test-script"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Module 1",
+      "name": "Module 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 2",
+      "name": "Module 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 3",
+      "name": "Module 3",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 4",
+      "name": "Module 4",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 5",
+      "name": "Module 5",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 6",
+      "name": "Module 6",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 7",
+      "name": "Module 7",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "key": "Module 8",
+      "name": "Module 8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPL - CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "OPL - CSD-PL AYWS1 Debugging Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Summer Workshop Review (~ 10 - 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Summer Review Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 Summer Review Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Summer Workshop Review (~ 10 - 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 Summer Review"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 Summer Review"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Variables Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Variables Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module Variable Video with Reflection"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module Variable Video with Reflection"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Variables Predict Where XY_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Variable Resources"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Variable Resources"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Variables naming rules v2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Random Numbers Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Random Numbers Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Random random ellipse2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 New Content Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 New Content Reflection"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 Debugging Reflection 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD Games variables practice_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 Debugging Reflection 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Asynchronous Wrap Up (~ 10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 Overview"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 - CI"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 - CI"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD: Introduction to the Draw Loop_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI The Draw Loop Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI The Draw Loop Reflection"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD: Animating Sprite Movement_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Sprite Movement Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI Sprite Movement Reflection"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U3 - Booleans Video_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Conditionals"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Conditionals"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Conditionals Reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI Conditionals Reflection"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Conclusions and Connections"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Conclusions and Connections"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 Chapter 1 Project"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U3 Chapter 1 Project"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD: Sprite Velocity_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U3 collisions car intro_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Asynchronous Wrap Up (~ 10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 2 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Overview"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check In (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD M3 Check-in"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD M3 Check-in"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Theme Introduction (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD M3 Theme Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD M3 Theme Introduction"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Curriculum Investigation Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Curriculum Investigation Overview"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L1 Investigation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - U4L1 Investigation"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - Problem Solving Process Guide"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Problem Solving Process"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Problem Solving Process"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L2 Investigation"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - U4L2 Investigation"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Reflection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 U4L2 Reflection"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Group Dynamics (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Asynchronous Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 Overview"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - CI"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - CI2"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L4 Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L4 Reflection"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L8 CI"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L8 CI"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L8 Reflection"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L8 Reflection"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L12 GoalsTasks"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - L12 GoalsTasks"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Video Reflection"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 Video Reflection"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module - U4L12Level3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module - U4L12Level3"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level6"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L12 Reflection"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L12 Reflection"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 14,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - Conclusions and Connections"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 1 Project"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 15,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U4 Chapter 1 Project"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L13 LInkingScreens"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 16,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - L13 LInkingScreens"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 2 Project"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 17,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U4 Chapter 2 Project"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Asynchronous Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 18,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 5 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 Overview"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 5 Overview"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Theme Introduction (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD M5 Theme Introduction"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD M5 Theme Introduction"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L3"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L4"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L4_1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L4_2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L4_3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD -  Module 5 - CI - L4_4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD -  Module 5 - CI - L4_4"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~65 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 - CI - L4_5"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 Reflection"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 5 Reflection"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Supporting Equity (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 - Supporting Equity"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 5 - Supporting Equity"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 6 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 Overview"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 Overview"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - CI"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L6"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - CI - U5L6"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L6 Reflection"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 U5L6 Reflection"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - Problem Solving Process Guide"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 PSP Reflection"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 PSP Reflection"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - CI - U5L9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L9 Reflection"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 U5L9 Reflection"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L13"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - CI - U5L13"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L13 Reflection"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 U5L13 Reflection"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 Unit Reflection"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 6 Unit Reflection"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 6 - Conclusions and Connections"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U5 Chapter 1 Project"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U5 Chapter 1 Project"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U5 Chapter 2 Project"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 14,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD U5 Chapter 2 Project"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Differentiation (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 - Differentiation"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 15,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD Module 5 - Differentiation"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 16,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 5 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VirtualPLOverview"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      },
+      "level_keys": [
+        "VirtualPLOverview"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "OPL - CSD-PL AYWS1 Debugging Intro",
+        "script_level.level_keys": [
+          "OPL - CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 Summer Review Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Summer Review Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 Summer Review",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 Summer Review"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Variables Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Variables Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module Variable Video with Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module Variable Video with Reflection"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Variables Predict Where XY_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Variable Resources",
+        "script_level.level_keys": [
+          "VPL - CSD - Variable Resources"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Variables naming rules v2_2018_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Random Numbers Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Random Numbers Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Random random ellipse2_2018_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 New Content Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 New Content Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy",
+        "script_level.level_keys": [
+          "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 Debugging Reflection 1",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD Games variables practice_2020",
+        "script_level.level_keys": [
+          "VPL-CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 Debugging Reflection 2",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 - CI"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Introduction to the Draw Loop_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Draw Loop",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI The Draw Loop Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI The Draw Loop Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Animating Sprite Movement_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Sprite Movement",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI Sprite Movement Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Sprite Movement Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 - Booleans Video_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Conditionals",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Conditionals"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI Conditionals Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Conditionals Reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Conclusions and Connections",
+        "script_level.level_keys": [
+          "VPL - CSD - Conclusions and Connections"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 Chapter 1 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U3 Chapter 1 Project"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Sprite Velocity_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 collisions car intro_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 game intro_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 2 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD M3 Check-in",
+        "script_level.level_keys": [
+          "VPL - CSD M3 Check-in"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD M3 Theme Introduction",
+        "script_level.level_keys": [
+          "VPL - CSD M3 Theme Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Curriculum Investigation Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Curriculum Investigation Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - U4L1 Investigation",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L1 Investigation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - Problem Solving Process Guide",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Problem Solving Process",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Problem Solving Process"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - U4L2 Investigation",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L2 Investigation"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 U4L2 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Reflection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 U4L2 Intro Group Dynamics",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - CI2",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L4 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L4 Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L8 CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L8 CI"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L8 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L8 Reflection"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - L12 GoalsTasks",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L12 GoalsTasks"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 Video Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Video Reflection"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module - U4L12Level3",
+        "script_level.level_keys": [
+          "VPL - CSD - Module - U4L12Level3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level4",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level5",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level6",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L12 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L12 Reflection"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - Conclusions and Connections",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 14,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U4 Chapter 1 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 1 Project"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 15,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - L13 LInkingScreens",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L13 LInkingScreens"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 16,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U4 Chapter 2 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 2 Project"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 17,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 18,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 5 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 Overview"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD M5 Theme Introduction",
+        "script_level.level_keys": [
+          "VPL - CSD M5 Theme Introduction"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L1",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L2",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L3",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L3"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L4",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L4_1",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L4_2",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L4_3",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD -  Module 5 - CI - L4_4",
+        "script_level.level_keys": [
+          "VPL - CSD -  Module 5 - CI - L4_4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 - CI - L4_5",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 - CI - L4_5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 5 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 Reflection"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 5 - Supporting Equity",
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 - Supporting Equity"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 15,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 Overview"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - CI - U5L6",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L6"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 U5L6 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L6 Reflection"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - Problem Solving Process Guide",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 PSP Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 PSP Reflection"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - CI - U5L9",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 U5L9 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L9 Reflection"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - CI - U5L13",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - CI - U5L13"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 U5L13 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 U5L13 Reflection"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 6 Unit Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 6 Unit Reflection"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 6 - Conclusions and Connections",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 6 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U5 Chapter 1 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U5 Chapter 1 Project"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U5 Chapter 2 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U5 Chapter 2 Project"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 14,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 5 - Differentiation",
+        "script_level.level_keys": [
+          "VPL - CSD Module 5 - Differentiation"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 15,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 5 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 16,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLOverview",
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLOverview",
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "jess-test-script"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/jigsaw.script_json
+++ b/dashboard/config/scripts_json/jigsaw.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "jigsaw",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "jigsaw"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Jigsaw",
+      "name": "Jigsaw",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:1",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Jigsaw",
+        "lesson_group.key": "",
+        "script.name": "jigsaw"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/jr-test.script_json
+++ b/dashboard/config/scripts_json/jr-test.script_json
@@ -1,0 +1,1637 @@
+{
+  "script": {
+    "name": "jr-test",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "jr-test"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Using Behaviors",
+      "name": "Using Behaviors",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Using Forever Loops",
+      "name": "Using Forever Loops",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Virtual Pet - Behaviors",
+      "name": "Virtual Pet - Behaviors",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Virtual Pet - Forever",
+      "name": "Virtual Pet - Forever",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Fish Tank",
+      "name": "Fish Tank",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Alien Dance Party - Input",
+      "name": "Alien Dance Party - Input",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "key": "Virtual Pet - Interactions",
+      "name": "Virtual Pet - Interactions",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_5"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_6"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_6"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_7"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_7"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_8"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_8"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Behavior_9"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Behavior_9"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_5"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_6"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_7"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_8"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GLJr_Forever_9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "GLJr_Forever_9"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors pet test"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "behaviors pet test"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors pet test 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "behaviors pet test 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors pet test 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "behaviors pet test 3"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "loop pet test"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "loop pet test"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "loop pet test 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "loop pet test 2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "loop pet test 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "loop pet test 3"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "loop pet test 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "loop pet test 4"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 3"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 4"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 6"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Fish Tank 7"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_1",
+        "script_level.level_keys": [
+          "GLJr_Behavior_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_2",
+        "script_level.level_keys": [
+          "GLJr_Behavior_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_5",
+        "script_level.level_keys": [
+          "GLJr_Behavior_5"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_6",
+        "script_level.level_keys": [
+          "GLJr_Behavior_6"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_7",
+        "script_level.level_keys": [
+          "GLJr_Behavior_7"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_8",
+        "script_level.level_keys": [
+          "GLJr_Behavior_8"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Behavior_9",
+        "script_level.level_keys": [
+          "GLJr_Behavior_9"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Using Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_1",
+        "script_level.level_keys": [
+          "GLJr_Forever_1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_2",
+        "script_level.level_keys": [
+          "GLJr_Forever_2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_5",
+        "script_level.level_keys": [
+          "GLJr_Forever_5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_6",
+        "script_level.level_keys": [
+          "GLJr_Forever_6"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_7",
+        "script_level.level_keys": [
+          "GLJr_Forever_7"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_8",
+        "script_level.level_keys": [
+          "GLJr_Forever_8"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GLJr_Forever_9",
+        "script_level.level_keys": [
+          "GLJr_Forever_9"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Using Forever Loops",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors pet test",
+        "script_level.level_keys": [
+          "behaviors pet test"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors pet test 2",
+        "script_level.level_keys": [
+          "behaviors pet test 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors pet test 3",
+        "script_level.level_keys": [
+          "behaviors pet test 3"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Behaviors",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "loop pet test",
+        "script_level.level_keys": [
+          "loop pet test"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "loop pet test 2",
+        "script_level.level_keys": [
+          "loop pet test 2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "loop pet test 3",
+        "script_level.level_keys": [
+          "loop pet test 3"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "loop pet test 4",
+        "script_level.level_keys": [
+          "loop pet test 4"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Forever",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1",
+        "script_level.level_keys": [
+          "Fish Tank 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2",
+        "script_level.level_keys": [
+          "Fish Tank 2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3",
+        "script_level.level_keys": [
+          "Fish Tank 3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4",
+        "script_level.level_keys": [
+          "Fish Tank 4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5",
+        "script_level.level_keys": [
+          "Fish Tank 5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6",
+        "script_level.level_keys": [
+          "Fish Tank 6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7",
+        "script_level.level_keys": [
+          "Fish Tank 7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1",
+        "script_level.level_keys": [
+          "Dance Party 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "jr-test"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/k1hoc2017.script_json
+++ b/dashboard/config/scripts_json/k1hoc2017.script_json
@@ -1,0 +1,678 @@
+{
+  "script": {
+    "name": "k1hoc2017",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "k1hoc2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Collector Hour of Code 2017",
+      "name": "Collector Hour of Code 2017",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops6"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_preLoops7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_preLoops7"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops12"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      },
+      "level_keys": [
+        "courseA_collector_loops_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops1",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops2",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops3",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops4",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops5",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops6",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops6"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_preLoops7",
+        "script_level.level_keys": [
+          "courseA_collector_preLoops7"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops3",
+        "script_level.level_keys": [
+          "courseA_collector_loops3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops4",
+        "script_level.level_keys": [
+          "courseA_collector_loops4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops5",
+        "script_level.level_keys": [
+          "courseA_collector_loops5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops6",
+        "script_level.level_keys": [
+          "courseA_collector_loops6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops7",
+        "script_level.level_keys": [
+          "courseA_collector_loops7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops8",
+        "script_level.level_keys": [
+          "courseA_collector_loops8"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops12",
+        "script_level.level_keys": [
+          "courseA_collector_loops12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseA_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "Collector Hour of Code 2017",
+        "lesson_group.key": "",
+        "script.name": "k1hoc2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/k5-onlinepd-2019.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2019.script_json
@@ -1,0 +1,5016 @@
+{
+  "script": {
+    "name": "k5-onlinepd-2019",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "k5-onlinepd-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "k5_getting_started",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Getting Started"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "k5_basic_concepts",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Basic Coding Concepts and Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "k5_diving_deeper",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Diving Deeper: Courses E and F"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "k5_next_steps",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Next Steps"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+      "name": "Welcome to \"Teaching Computer Science Fundamentals\"",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Understanding the Computer Science Fundamentals Courses",
+      "name": "Understanding the Computer Science Fundamentals Courses",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Sequencing",
+      "name": "Sequencing",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Loops",
+      "name": "Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Events",
+      "name": "Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "End of Course projects",
+      "name": "End of Course projects",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "For Loops",
+      "name": "For Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Sprite Lab",
+      "name": "Sprite Lab",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Reviewing your reflections",
+      "name": "Reviewing your reflections",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "key": "Next steps",
+      "name": "Next steps",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 About_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 About_copy"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 WhatIsCS_copy"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Why teach CS_copy"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Outline_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Outline_copy"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 CS Tips_copy"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Participation_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Participation_copy"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 whats your plan"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Video_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 CS Video_copy"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Welcome 2_copy"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 role_of_teacher"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 role_of_teacher"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 types of lessons"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 types of lessons"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 lesson plans"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 lesson plans"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video_copy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Unplugged Video_copy"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery_copy"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 What is Mastery_copy"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go_copy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage2Go_copy"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start_copy"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3Start_copy"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing introduced"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing introduced"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo_copy"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3aGo_copy"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram_copy"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 FirstProgram_copy"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_copy"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_copy"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_copy"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_copy"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq7_copy"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq7_copy"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_copy"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_copy"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_copy"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_copy"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 using lesson plans"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 using lesson plans"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 lesson implementation planning"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 lesson implementation planning"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing free response"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start_copy"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Start_copy"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops introduced"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 loops introduced"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go_copy"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Go_copy"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock_copy"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 RepeatBlock_copy"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_copy"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_copy"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_copy"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_copy"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_copy"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_copy"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_copy"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_copy"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_copy"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_copy"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_copy"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_copy"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Pair_copy"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops free response"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 loops free response"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start_copy"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Start_copy"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events introduced"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 events introduced"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go_copy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Go_copy"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-1-video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-1-video"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-events-6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 debugging"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 debugging"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events free response"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 events free response"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start_copy"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Start_copy"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals introduced"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals introduced"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go_copy"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Go_copy"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_copy"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_copy"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_copy"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_copy"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_copy"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_copy"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_copy"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_copy"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_copy"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_copy"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_copy"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_copy"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 journaling"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 journaling"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals free response"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 project"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 project"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects introduction"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 projects introduction"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-3"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-4"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-5"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-6"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-projects-7"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects free response"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 projects free response"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 where to next"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 where to next"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 diving deeper intro"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 diving deeper intro"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start_copy"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Start_copy"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions introduced"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 functions introduced"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go_copy"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Go_copy"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1_copy"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions1_copy"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_copy"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_copy"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_copy"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist_copy"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_copy"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_copy"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_copy"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_copy"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4_copy"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions4_copy"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_copy"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_copy"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions free response"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 functions free response"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 variables"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 variables introduction"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables unplugged"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 variables unplugged"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-1"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-2"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-3-video"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-3-video"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-4"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-5"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-6"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-variables-7"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables free response"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 variables free response"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops intro"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 for loops intro"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops introduction"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 for loops introduction"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 for loops"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-2"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-3-video"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-3-video"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-4"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-4"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-5"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-6"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-7"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 for loops free response"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab introduction"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab introduction"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab unplugged"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab unplugged"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab video"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-1"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-2"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-2"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-3"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-3"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-4"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-5-video"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-5-video"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-6"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-7"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab free response"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Reviewing Reflections"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Reviewing Reflections"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 whats your plan"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing free response"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops free response"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 loops free response"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events free response"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 events free response"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals free response"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions free response"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 functions free response"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables free response"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 variables free response"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 for loops free response"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab free response"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects free response"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 projects free response"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start_copy"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage10Start_copy"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start_copy"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Stage9Start_copy"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses_copy"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 CS Courses_copy"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Assessment_copy"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Assessment_copy"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan_copy"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Your Plan_copy"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Connect_copy"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Connect_copy"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Closing_copy"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      },
+      "level_keys": [
+        "OPD-K5 Closing_copy"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 About_copy",
+        "script_level.level_keys": [
+          "OPD-K5 About_copy"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 WhatIsCS_copy",
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS_copy"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Why teach CS_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS_copy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Outline_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Outline_copy"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Tips_copy",
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips_copy"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Participation_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Participation_copy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 whats your plan",
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Video_copy",
+        "script_level.level_keys": [
+          "OPD-K5 CS Video_copy"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Welcome 2_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2_copy"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 role_of_teacher",
+        "script_level.level_keys": [
+          "OPD-K5 role_of_teacher"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 types of lessons",
+        "script_level.level_keys": [
+          "OPD-K5 types of lessons"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 lesson plans",
+        "script_level.level_keys": [
+          "OPD-K5 lesson plans"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Unplugged Video_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video_copy"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 What is Mastery_copy",
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery_copy"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage2Go_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go_copy"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start_copy"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing introduced",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing introduced"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3aGo_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo_copy"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 FirstProgram_copy",
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram_copy"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_copy",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_copy"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_copy",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_copy"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq7_copy",
+        "script_level.level_keys": [
+          "courseA_maze_seq7_copy"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_copy",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_copy"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_copy",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_copy"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 using lesson plans",
+        "script_level.level_keys": [
+          "OPD-K5 using lesson plans"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 lesson implementation planning",
+        "script_level.level_keys": [
+          "OPD-K5 lesson implementation planning"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing free response",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start_copy"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops introduced",
+        "script_level.level_keys": [
+          "OPD-K5 loops introduced"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Go_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go_copy"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 RepeatBlock_copy",
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock_copy"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_copy"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_copy"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_copy"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_copy"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_copy"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_copy",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_copy"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Pair_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops free response",
+        "script_level.level_keys": [
+          "OPD-K5 loops free response"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start_copy"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events introduced",
+        "script_level.level_keys": [
+          "OPD-K5 events introduced"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Go_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go_copy"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-1-video",
+        "script_level.level_keys": [
+          "OPD-K5-events-1-video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-2",
+        "script_level.level_keys": [
+          "OPD-K5-events-2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-3",
+        "script_level.level_keys": [
+          "OPD-K5-events-3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-4",
+        "script_level.level_keys": [
+          "OPD-K5-events-4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-5",
+        "script_level.level_keys": [
+          "OPD-K5-events-5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-6",
+        "script_level.level_keys": [
+          "OPD-K5-events-6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 debugging",
+        "script_level.level_keys": [
+          "OPD-K5 debugging"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events free response",
+        "script_level.level_keys": [
+          "OPD-K5 events free response"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start_copy"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals introduced",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals introduced"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Go_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go_copy"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_copy"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_copy"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_copy"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_copy"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_copy"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_copy",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_copy"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 journaling",
+        "script_level.level_keys": [
+          "OPD-K5 journaling"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals free response",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 project",
+        "script_level.level_keys": [
+          "OPD-K5 project"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects introduction",
+        "script_level.level_keys": [
+          "OPD-K5 projects introduction"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-1",
+        "script_level.level_keys": [
+          "OPD-K5-projects-1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-2",
+        "script_level.level_keys": [
+          "OPD-K5-projects-2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-3",
+        "script_level.level_keys": [
+          "OPD-K5-projects-3"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-4",
+        "script_level.level_keys": [
+          "OPD-K5-projects-4"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-5",
+        "script_level.level_keys": [
+          "OPD-K5-projects-5"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-6",
+        "script_level.level_keys": [
+          "OPD-K5-projects-6"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-7",
+        "script_level.level_keys": [
+          "OPD-K5-projects-7"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects free response",
+        "script_level.level_keys": [
+          "OPD-K5 projects free response"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 where to next",
+        "script_level.level_keys": [
+          "OPD-K5 where to next"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 diving deeper intro",
+        "script_level.level_keys": [
+          "OPD-K5 diving deeper intro"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start_copy"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions introduced",
+        "script_level.level_keys": [
+          "OPD-K5 functions introduced"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Go_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go_copy"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions1_copy"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_copy"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist_copy",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_copy"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_copy"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_copy"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions4_copy"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_copy",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_copy"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions free response",
+        "script_level.level_keys": [
+          "OPD-K5 functions free response"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables",
+        "script_level.level_keys": [
+          "OPD-K5 variables"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables introduction",
+        "script_level.level_keys": [
+          "OPD-K5 variables introduction"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables unplugged",
+        "script_level.level_keys": [
+          "OPD-K5 variables unplugged"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-1",
+        "script_level.level_keys": [
+          "OPD-K5-variables-1"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-2",
+        "script_level.level_keys": [
+          "OPD-K5-variables-2"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-3-video",
+        "script_level.level_keys": [
+          "OPD-K5-variables-3-video"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-4",
+        "script_level.level_keys": [
+          "OPD-K5-variables-4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-5",
+        "script_level.level_keys": [
+          "OPD-K5-variables-5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-6",
+        "script_level.level_keys": [
+          "OPD-K5-variables-6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-7",
+        "script_level.level_keys": [
+          "OPD-K5-variables-7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables free response",
+        "script_level.level_keys": [
+          "OPD-K5 variables free response"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops intro",
+        "script_level.level_keys": [
+          "OPD-K5 for loops intro"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops introduction",
+        "script_level.level_keys": [
+          "OPD-K5 for loops introduction"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops",
+        "script_level.level_keys": [
+          "OPD-K5 for loops"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-1",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-2",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-2"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-3-video",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-3-video"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-4",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-4"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-5",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-5"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-6",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-6"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-7",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-7"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops free response",
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab introduction",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab introduction"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab unplugged",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab unplugged"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab video",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab video"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-1",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-1"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-2",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-2"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-3",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-3"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-4",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-4"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-5-video",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-5-video"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-6",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-7",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab free response",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Reviewing Reflections",
+        "script_level.level_keys": [
+          "OPD-K5 Reviewing Reflections"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 whats your plan",
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing free response",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops free response",
+        "script_level.level_keys": [
+          "OPD-K5 loops free response"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events free response",
+        "script_level.level_keys": [
+          "OPD-K5 events free response"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals free response",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions free response",
+        "script_level.level_keys": [
+          "OPD-K5 functions free response"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables free response",
+        "script_level.level_keys": [
+          "OPD-K5 variables free response"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops free response",
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab free response",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects free response",
+        "script_level.level_keys": [
+          "OPD-K5 projects free response"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage10Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start_copy"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage9Start_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start_copy"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Courses_copy",
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses_copy"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Assessment_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Assessment_copy"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Your Plan_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan_copy"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Connect_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Connect_copy"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Closing_copy",
+        "script_level.level_keys": [
+          "OPD-K5 Closing_copy"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps",
+        "script.name": "k5-onlinepd-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/k5-onlinepd-2020.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2020.script_json
@@ -1,0 +1,5017 @@
+{
+  "script": {
+    "name": "k5-onlinepd-2020",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "version_year": "2020"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "k5-onlinepd-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "k5_getting_started_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Getting Started"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "k5_basic_concepts_1",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Basic Coding Concepts and Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "k5_diving_deeper_1",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Diving Deeper: Courses E and F"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "k5_next_steps_1",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Next Steps"
+      },
+      "seeding_key": {
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+      "name": "Welcome to \"Teaching Computer Science Fundamentals\"",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Understanding the Computer Science Fundamentals Courses",
+      "name": "Understanding the Computer Science Fundamentals Courses",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Sequencing",
+      "name": "Sequencing",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Loops",
+      "name": "Loops",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Events",
+      "name": "Events",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "End of Course projects",
+      "name": "End of Course projects",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "For Loops",
+      "name": "For Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Sprite Lab",
+      "name": "Sprite Lab",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Reviewing your reflections",
+      "name": "Reviewing your reflections",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "key": "Next steps",
+      "name": "Next steps",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 About_copy_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 About_copy_2020"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 WhatIsCS_2020"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS_copy_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Why teach CS_copy_2020"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Outline_copy_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Outline_copy_2020"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips_copy_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 CS Tips_copy_2020"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Participation_copy_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Participation_copy_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 whats your plan_2020"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Video_copy_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 CS Video_copy_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2_copy_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Welcome 2_copy_2020"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 role_of_teacher_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 role_of_teacher_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 types of lessons_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 types of lessons_2020"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 lesson plans_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 lesson plans_2020"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video_copy_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Unplugged Video_copy_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery_copy_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 What is Mastery_copy_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go_copy_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage2Go_copy_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start_copy_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing introduced_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing introduced_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo_copy_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage3aGo_copy_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 FirstProgram_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq7_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq7_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 using lesson plans_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 using lesson plans_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 lesson implementation planning_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 lesson implementation planning_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing free response_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start_copy_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops introduced_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 loops introduced_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go_copy_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage4Go_copy_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 RepeatBlock_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseC_starWars_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Pair_copy_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Pair_copy_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops free response_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 loops free response_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start_copy_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events introduced_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 events introduced_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go_copy_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage7Go_copy_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-1-video_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-1-video_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-2_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-2_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-3_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-3_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-4_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-4_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-5_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-5_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-events-6_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-events-6_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 debugging_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 debugging_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events free response_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 events free response_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start_copy_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals introduced_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals introduced_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go_copy_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage5Go_copy_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 journaling_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 journaling_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals free response_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 project_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 project_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects introduction_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 projects introduction_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-1_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-1_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-2_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-2_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-3_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-3_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-4_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-4_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-5_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-5_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-6_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-6_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-projects-7_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-projects-7_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects free response_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 projects free response_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 where to next_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 where to next_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 diving deeper intro_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 diving deeper intro_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start_copy_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions introduced_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 functions introduced_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go_copy_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage6Go_copy_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions1_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions4_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions free response_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 functions free response_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 variables_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables introduction_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 variables introduction_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables unplugged_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 variables unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-1_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-1_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-2_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-2_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-3-video_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-3-video_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-4_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-4_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-5_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-5_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-6_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-6_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-variables-7_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-variables-7_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables free response_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 variables free response_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops intro_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 for loops intro_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops introduction_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 for loops introduction_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 for loops_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-1_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-2_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-2_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-3-video_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-3-video_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-4_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-4_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-5_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-5_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-6_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-6_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-forloops-7_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-forloops-7_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 for loops free response_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab introduction_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab introduction_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab unplugged_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab unplugged_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab video_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab video_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-1_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-2_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-3_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-4_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-4_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-5-video_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-5-video_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-6_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-6_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-7_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5-spritelab-7_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab free response_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Reviewing Reflections_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Reviewing Reflections_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 whats your plan_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sequencing free response_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 loops free response_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 loops free response_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 events free response_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 events free response_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 conditionals free response_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 functions free response_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 functions free response_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 variables free response_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 variables free response_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 for loops free response_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 sprite lab free response_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 projects free response_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 projects free response_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start_copy_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage10Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start_copy_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Stage9Start_copy_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses_copy_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 CS Courses_copy_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Assessment_copy_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Assessment_copy_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan_copy_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Your Plan_copy_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Connect_copy_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Connect_copy_2020"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPD-K5 Closing_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      },
+      "level_keys": [
+        "OPD-K5 Closing_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 About_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 About_copy_2020"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 WhatIsCS_2020",
+        "script_level.level_keys": [
+          "OPD-K5 WhatIsCS_2020"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Why teach CS_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Why teach CS_copy_2020"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Outline_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Outline_copy_2020"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Tips_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 CS Tips_copy_2020"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Participation_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Participation_copy_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 whats your plan_2020",
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan_2020"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Welcome to \"Teaching Computer Science Fundamentals\"",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Video_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 CS Video_copy_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Welcome 2_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Welcome 2_copy_2020"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 role_of_teacher_2020",
+        "script_level.level_keys": [
+          "OPD-K5 role_of_teacher_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 types of lessons_2020",
+        "script_level.level_keys": [
+          "OPD-K5 types of lessons_2020"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 lesson plans_2020",
+        "script_level.level_keys": [
+          "OPD-K5 lesson plans_2020"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Unplugged Video_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Unplugged Video_copy_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 What is Mastery_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 What is Mastery_copy_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage2Go_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage2Go_copy_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Understanding the Computer Science Fundamentals Courses",
+        "lesson_group.key": "k5_getting_started_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3Start_copy_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing introduced_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing introduced_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage3aGo_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage3aGo_copy_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 FirstProgram_2020",
+        "script_level.level_keys": [
+          "OPD-K5 FirstProgram_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq7_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq7_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 using lesson plans_2020",
+        "script_level.level_keys": [
+          "OPD-K5 using lesson plans_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 lesson implementation planning_2020",
+        "script_level.level_keys": [
+          "OPD-K5 lesson implementation planning_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Start_copy_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops introduced_2020",
+        "script_level.level_keys": [
+          "OPD-K5 loops introduced_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage4Go_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage4Go_copy_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 RepeatBlock_2020",
+        "script_level.level_keys": [
+          "OPD-K5 RepeatBlock_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops2_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops2_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops4_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops4_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops5_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops5_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops6_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops6_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops7_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops7_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_starWars_loops8_2020",
+        "script_level.level_keys": [
+          "courseC_starWars_loops8_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Pair_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Pair_copy_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 loops free response_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Loops",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Start_copy_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events introduced_2020",
+        "script_level.level_keys": [
+          "OPD-K5 events introduced_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage7Go_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage7Go_copy_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 3,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-1-video_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-1-video_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 4,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-2_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-2_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 5,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-3_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-3_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 6,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-4_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-4_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 7,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-5_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-5_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 8,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-events-6_2020",
+        "script_level.level_keys": [
+          "OPD-K5-events-6_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 9,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 debugging_2020",
+        "script_level.level_keys": [
+          "OPD-K5 debugging_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 10,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 events free response_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 11,
+        "lesson.key": "Events",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Start_copy_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals introduced_2020",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals introduced_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage5Go_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage5Go_copy_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5_2020",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 journaling_2020",
+        "script_level.level_keys": [
+          "OPD-K5 journaling_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 project_2020",
+        "script_level.level_keys": [
+          "OPD-K5 project_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 1,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects introduction_2020",
+        "script_level.level_keys": [
+          "OPD-K5 projects introduction_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 2,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-1_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-1_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 3,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-2_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-2_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 4,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-3_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-3_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 5,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-4_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-4_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 6,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-5_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-5_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 7,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-6_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-6_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 8,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-projects-7_2020",
+        "script_level.level_keys": [
+          "OPD-K5-projects-7_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 9,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 projects free response_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 10,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 where to next_2020",
+        "script_level.level_keys": [
+          "OPD-K5 where to next_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 11,
+        "lesson.key": "End of Course projects",
+        "lesson_group.key": "k5_basic_concepts_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 diving deeper intro_2020",
+        "script_level.level_keys": [
+          "OPD-K5 diving deeper intro_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Start_copy_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions introduced_2020",
+        "script_level.level_keys": [
+          "OPD-K5 functions introduced_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage6Go_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage6Go_copy_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions1_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist_2020",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions4_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2020",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 functions free response_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables_2020",
+        "script_level.level_keys": [
+          "OPD-K5 variables_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables introduction_2020",
+        "script_level.level_keys": [
+          "OPD-K5 variables introduction_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables unplugged_2020",
+        "script_level.level_keys": [
+          "OPD-K5 variables unplugged_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-1_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-1_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-2_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-2_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-3-video_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-3-video_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-4_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-4_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-5_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-5_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-6_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-6_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-variables-7_2020",
+        "script_level.level_keys": [
+          "OPD-K5-variables-7_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 variables free response_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Variables",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops intro_2020",
+        "script_level.level_keys": [
+          "OPD-K5 for loops intro_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops introduction_2020",
+        "script_level.level_keys": [
+          "OPD-K5 for loops introduction_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops_2020",
+        "script_level.level_keys": [
+          "OPD-K5 for loops_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-1_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-1_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-2_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-2_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-3-video_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-3-video_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-4_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-4_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-5_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-5_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 8,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-6_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-6_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 9,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-forloops-7_2020",
+        "script_level.level_keys": [
+          "OPD-K5-forloops-7_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 10,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 11,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 1,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab introduction_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab introduction_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 2,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab unplugged_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab unplugged_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 3,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab video_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab video_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 4,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-1_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-1_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 5,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-2_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-2_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 6,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-3_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-3_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 7,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-4_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-4_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 8,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-5-video_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-5-video_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 9,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-6_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-6_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 10,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5-spritelab-7_2020",
+        "script_level.level_keys": [
+          "OPD-K5-spritelab-7_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 11,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 12,
+        "lesson.key": "Sprite Lab",
+        "lesson_group.key": "k5_diving_deeper_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Reviewing Reflections_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Reviewing Reflections_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 whats your plan_2020",
+        "script_level.level_keys": [
+          "OPD-K5 whats your plan_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sequencing free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sequencing free response_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 loops free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 loops free response_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 events free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 events free response_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 conditionals free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 conditionals free response_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 functions free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 functions free response_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 variables free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 variables free response_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 8,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 for loops free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 for loops free response_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 9,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 sprite lab free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 sprite lab free response_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 10,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 projects free response_2020",
+        "script_level.level_keys": [
+          "OPD-K5 projects free response_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 11,
+        "lesson.key": "Reviewing your reflections",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage10Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage10Start_copy_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 1,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Stage9Start_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Stage9Start_copy_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 2,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 CS Courses_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 CS Courses_copy_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 3,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Assessment_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Assessment_copy_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 4,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Your Plan_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Your Plan_copy_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 5,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Connect_copy_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Connect_copy_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 6,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "OPD-K5 Closing_2020",
+        "script_level.level_keys": [
+          "OPD-K5 Closing_2020"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 7,
+        "lesson.key": "Next steps",
+        "lesson_group.key": "k5_next_steps_1",
+        "script.name": "k5-onlinepd-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/k5concepts.script_json
+++ b/dashboard/config/scripts_json/k5concepts.script_json
@@ -1,0 +1,1259 @@
+{
+  "script": {
+    "name": "k5concepts",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "k5concepts"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Events",
+      "name": "Events",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Loops",
+      "name": "Loops",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "While Loops",
+      "name": "While Loops",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "For Loops",
+      "name": "For Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Functions with Parameters",
+      "name": "Functions with Parameters",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "key": "Binary",
+      "name": "Binary",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Big Event Match 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "2-3 Big Event Match 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "GettingLoopy"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "2-3 Getting Loopy Multi 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comingSoon"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "comingSoon"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Conditionals Multi 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "2-3 Conditionals Multi 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comingSoon"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "comingSoon"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "4-5 Songwriting Multi 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "4-5 Songwriting Multi 1"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MadGlibs"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "MadGlibs"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_bee_for_loops3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_bee_for_loops3"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_bee_for_loops5"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_bee_for_loops5"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_bee_for_loops9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_bee_for_loops9"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_parameters_triangles3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_parameters_triangles3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_parameters_squares2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_parameters_squares2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_functionparameters8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_functionparameters8"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_playlab_variables12"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_playlab_variables12"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_functionparameters11"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_functionparameters11"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "BinaryBracelets"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3 Binary Match 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "2-3 Binary Match 1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "BinaryImages"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_pixelation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_pixelation"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_binary5"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_binary5"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_binary4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_binary4"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_binary8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_binary8"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_binary9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_binary9"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_binary11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      },
+      "level_keys": [
+        "grade5_artist_binary11"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Events",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Big Event Match 1",
+        "script_level.level_keys": [
+          "2-3 Big Event Match 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Events",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GettingLoopy",
+        "script_level.level_keys": [
+          "GettingLoopy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Getting Loopy Multi 1",
+        "script_level.level_keys": [
+          "2-3 Getting Loopy Multi 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comingSoon",
+        "script_level.level_keys": [
+          "comingSoon"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Conditionals Multi 1",
+        "script_level.level_keys": [
+          "2-3 Conditionals Multi 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comingSoon",
+        "script_level.level_keys": [
+          "comingSoon"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "While Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "4-5 Songwriting Multi 1",
+        "script_level.level_keys": [
+          "4-5 Songwriting Multi 1"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MadGlibs",
+        "script_level.level_keys": [
+          "MadGlibs"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_bee_for_loops3",
+        "script_level.level_keys": [
+          "grade5_bee_for_loops3"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_bee_for_loops5",
+        "script_level.level_keys": [
+          "grade5_bee_for_loops5"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_bee_for_loops9",
+        "script_level.level_keys": [
+          "grade5_bee_for_loops9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_parameters_triangles3",
+        "script_level.level_keys": [
+          "grade5_artist_parameters_triangles3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_parameters_squares2",
+        "script_level.level_keys": [
+          "grade5_artist_parameters_squares2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_functionparameters8",
+        "script_level.level_keys": [
+          "grade5_artist_functionparameters8"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_playlab_variables12",
+        "script_level.level_keys": [
+          "grade5_playlab_variables12"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_functionparameters11",
+        "script_level.level_keys": [
+          "grade5_artist_functionparameters11"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryBracelets",
+        "script_level.level_keys": [
+          "BinaryBracelets"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3 Binary Match 1",
+        "script_level.level_keys": [
+          "2-3 Binary Match 1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages",
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_pixelation",
+        "script_level.level_keys": [
+          "grade5_pixelation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_binary5",
+        "script_level.level_keys": [
+          "grade5_artist_binary5"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_binary4",
+        "script_level.level_keys": [
+          "grade5_artist_binary4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_binary8",
+        "script_level.level_keys": [
+          "grade5_artist_binary8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_binary9",
+        "script_level.level_keys": [
+          "grade5_artist_binary9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_binary11",
+        "script_level.level_keys": [
+          "grade5_artist_binary11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "k5concepts"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/kaitie-test-script.script_json
+++ b/dashboard/config/scripts_json/kaitie-test-script.script_json
@@ -1,0 +1,2628 @@
+{
+  "script": {
+    "name": "kaitie-test-script",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "kaitie-test-script"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Module 1",
+      "name": "Module 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 2",
+      "name": "Module 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 3",
+      "name": "Module 3",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 4",
+      "name": "Module 4",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 5",
+      "name": "Module 5",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 6",
+      "name": "Module 6",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 7",
+      "name": "Module 7",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "key": "Module 8",
+      "name": "Module 8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS1 Workshop Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL AYWS1 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Wrapping up Unit 3 (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 3 Context"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP Module 1 Unit 3 Context"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Unit 4 tasks overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Unit 4 tasks overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL - U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 4 Reflection"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP Module 1 Unit 4 Reflection"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing EIPM (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM Reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP Module 1 EIPM Reflection"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing EIPM (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM goes virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP Module 1 EIPM goes virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Asynchronous wrap-up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 1 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS2 Workshop Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL AYWS2 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Variables Practice overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Variables Practice overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL - U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL8 - U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL8 - U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Practice Reflection"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - Practice Reflection"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Variables Make overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Variables Make overview"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL U4 L04 Variables Make Project_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Make Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - Make Reflection"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Collaborative and Independent Work (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - Unit 4 Wrap-up"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL - Unit 4 Wrap-up"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Collaborative and Independent Work (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Collaboration Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - PL - Collaboration Reflection"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Asynchronous wrap-up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 18,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 2 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS3 Workshop Overview"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL AYWS3 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Understanding the context for the Model Lesson overview"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Understanding the context for the Model Lesson overview"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Synch3 - Reflection 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Synch3 - Reflection 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Intro to CI"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Intro to CI"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Broadening the def"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Broadening the def"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Feedback in CI"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Feedback in CI"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Practice feedback"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Practice feedback"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Asynchronous wrap-up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 3 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWA4 Workshop Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL AYWA4 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Content of the Lists EIPM sequence (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Understanding the content of the Lists EIPM sequence"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Understanding the content of the Lists EIPM sequence"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "The Lists EIPM sequence (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Lists EIPM reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Lists EIPM reflection"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mental models in Unit 5 (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP AYW4 - Mental Models in Unit 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP AYW4 - Mental Models in Unit 5"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 - Intro to Traversals"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch4 - Intro to Traversals"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 - U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch4 - U5L10 Traversals Investigate"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP AYW4 - Reflection on datasets"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP AYW4 - Reflection on datasets"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Asynchronous wrap-up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 4 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 5 overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL Module 5 - Workshop Overview"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL Module 5 - Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding Unit 7 (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M5 - Intro to Unit 7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M5 - Intro to Unit 7"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Explore\" lesson (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Explore"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M5 - Param Explore"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Prac 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M5 - Param Prac 1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Return Practice Part 1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Return Practice Part 2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Return Practice Part 4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Return Practice Part 3"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Return Practice Part 5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Investigate Calculator App"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PL U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "PL U7 Param Practice App 2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the \"Parameters and Return Practice\" lesson (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Prac 10"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M5 - Param Prac 10"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Creating inclusive classrooms (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M5 - Inclusive Classrooms"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M5 - Inclusive Classrooms"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 5 Asynchronous wrap-up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 5 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 6 overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL Module 6 - Workshop Overview"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL Module 6 - Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Requirements of the Create Performance Task (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M6 - Create PT Reqs"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M6 - Create PT Reqs"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Digging into the Create PT Survival Guide (~40 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M6 - Survival Guide"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M6 - Survival Guide"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Role of the teacher during the Create PT (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL M6 - Role of teacher"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP-PL M6 - Role of teacher"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 6 Asynchronous Wrap-Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 6 Wrap Up"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 6 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "VirtualPLOverview"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 7 Asynchronous Wrap-Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 3 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "VirtualPLOverview"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 8 Asynchronous Wrap-Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      },
+      "level_keys": [
+        "CSP - Module 3 Wrap Up"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS1 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS1 Workshop Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 Unit 3 Context",
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 3 Context"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Unit 4 tasks overview",
+        "script_level.level_keys": [
+          "CSP - Unit 4 tasks overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "CSP-PL - U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "CSP-PL U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 Unit 4 Reflection",
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 4 Reflection"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 EIPM Reflection",
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM Reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 EIPM goes virtual",
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM goes virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 1 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS2 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS2 Workshop Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Variables Practice overview",
+        "script_level.level_keys": [
+          "CSP - Variables Practice overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "CSP-PL - U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL8 - U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "CSP - PL8 - U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Practice Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Practice Reflection"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Variables Make overview",
+        "script_level.level_keys": [
+          "CSP - Variables Make overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL U4 L04 Variables Make Project_2020",
+        "script_level.level_keys": [
+          "CSP - PL U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L04 Variables Make Project Submit_2020",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Make Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Make Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - Unit 4 Wrap-up",
+        "script_level.level_keys": [
+          "CSP-PL - Unit 4 Wrap-up"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Collaboration Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Collaboration Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 2 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 18,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS3 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS3 Workshop Overview"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Understanding the context for the Model Lesson overview",
+        "script_level.level_keys": [
+          "CSP - Understanding the context for the Model Lesson overview"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Synch3 - Reflection 1",
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Synch3 - Reflection 2",
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Intro to CI",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Intro to CI"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Broadening the def",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Broadening the def"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Feedback in CI",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Feedback in CI"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Practice feedback",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Practice feedback"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWA4 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWA4 Workshop Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Understanding the content of the Lists EIPM sequence",
+        "script_level.level_keys": [
+          "CSP - Understanding the content of the Lists EIPM sequence"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Lists EIPM reflection",
+        "script_level.level_keys": [
+          "CSP - Lists EIPM reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP AYW4 - Mental Models in Unit 5",
+        "script_level.level_keys": [
+          "CSP AYW4 - Mental Models in Unit 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 - Intro to Traversals",
+        "script_level.level_keys": [
+          "CSP - Asynch4 - Intro to Traversals"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify",
+        "script_level.level_keys": [
+          "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 - U5L10 Traversals Investigate",
+        "script_level.level_keys": [
+          "CSP - Asynch4 - U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify",
+        "script_level.level_keys": [
+          "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP AYW4 - Reflection on datasets",
+        "script_level.level_keys": [
+          "CSP AYW4 - Reflection on datasets"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 4 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL Module 5 - Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL Module 5 - Workshop Overview"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M5 - Intro to Unit 7",
+        "script_level.level_keys": [
+          "CSP-PL M5 - Intro to Unit 7"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M5 - Param Explore",
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Explore"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M5 - Param Prac 1",
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Prac 1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Return Practice Part 1",
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Return Practice Part 2",
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Return Practice Part 4",
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Return Practice Part 3",
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 3"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Return Practice Part 5",
+        "script_level.level_keys": [
+          "PL U7 Param Return Practice Part 5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Investigate Calculator App",
+        "script_level.level_keys": [
+          "PL U7 Param Investigate Calculator App"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PL U7 Param Practice App 2",
+        "script_level.level_keys": [
+          "PL U7 Param Practice App 2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M5 - Param Prac 10",
+        "script_level.level_keys": [
+          "CSP-PL M5 - Param Prac 10"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M5 - Inclusive Classrooms",
+        "script_level.level_keys": [
+          "CSP-PL M5 - Inclusive Classrooms"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 5 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 5 Wrap Up"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 14,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL Module 6 - Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL Module 6 - Workshop Overview"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M6 - Create PT Reqs",
+        "script_level.level_keys": [
+          "CSP-PL M6 - Create PT Reqs"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M6 - Survival Guide",
+        "script_level.level_keys": [
+          "CSP-PL M6 - Survival Guide"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL M6 - Role of teacher",
+        "script_level.level_keys": [
+          "CSP-PL M6 - Role of teacher"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 6 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 6 Wrap Up"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLOverview",
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 2,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLOverview",
+        "script_level.level_keys": [
+          "VirtualPLOverview"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "kaitie-test-script"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/kinderTest.script_json
+++ b/dashboard/config/scripts_json/kinderTest.script_json
@@ -1,0 +1,692 @@
+{
+  "script": {
+    "name": "kinderTest",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "kinderTest"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Bee: Conditionals",
+      "name": "Bee: Conditionals",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "key": "Kindergarten Stage 1",
+      "name": "Kindergarten Stage 1",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_ifvid"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_ifvid"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_quantum1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_quantum2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new1a"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new1a"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new2a"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new2a"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_quantum3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_ifelsevid"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_ifelsevid"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_quantum4"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_quantum5"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new3a"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new3b"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3c"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "grade4_bee_conditionals_new3c"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "KTest1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "KTest1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "KTest2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "KTest2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "testArtistForTestK"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "testArtistForTestK"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "testBeeFarmer"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "testBeeFarmer"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "testPlaylabLevel"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      },
+      "level_keys": [
+        "testPlaylabLevel"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_ifvid",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_ifvid"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_quantum1",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_quantum2",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new1a",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new1a"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new2a",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new2a"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new2",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_quantum3",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_ifelsevid",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_ifelsevid"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_quantum4",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_quantum5",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_quantum5"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new3a",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new3b",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade4_bee_conditionals_new3c",
+        "script_level.level_keys": [
+          "grade4_bee_conditionals_new3c"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Bee: Conditionals",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "KTest1",
+        "script_level.level_keys": [
+          "KTest1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "KTest2",
+        "script_level.level_keys": [
+          "KTest2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "testArtistForTestK",
+        "script_level.level_keys": [
+          "testArtistForTestK"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "testBeeFarmer",
+        "script_level.level_keys": [
+          "testBeeFarmer"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "testPlaylabLevel",
+        "script_level.level_keys": [
+          "testPlaylabLevel"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Kindergarten Stage 1",
+        "lesson_group.key": "",
+        "script.name": "kinderTest"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/mc.script_json
+++ b/dashboard/config/scripts_json/mc.script_json
@@ -1,0 +1,538 @@
+{
+  "script": {
+    "name": "mc",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "mc"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Hour of Code 2015",
+      "name": "Hour of Code 2015",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "mc"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/minecraft.script_json
+++ b/dashboard/config/scripts_json/minecraft.script_json
@@ -1,0 +1,468 @@
+{
+  "script": {
+    "name": "minecraft",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "minecraft"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Minecraft Hour of Code Designer",
+      "name": "Minecraft Hour of Code Designer",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 2-2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 2-2"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 3"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 4"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 New Walk"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 New Walk"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 New Drop"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 New Drop"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 8"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Village Test"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Village Test"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 New Spawn"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 New Spawn"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 SCORE LEVEL"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 SCORE LEVEL"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      },
+      "level_keys": [
+        "MC HOC 2016 Level 10"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 2-2",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 2-2"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 3",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 4",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 4"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 New Walk",
+        "script_level.level_keys": [
+          "MC HOC 2016 New Walk"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 New Drop",
+        "script_level.level_keys": [
+          "MC HOC 2016 New Drop"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 5",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 8",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Village Test",
+        "script_level.level_keys": [
+          "MC HOC 2016 Village Test"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 New Spawn",
+        "script_level.level_keys": [
+          "MC HOC 2016 New Spawn"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 6",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 SCORE LEVEL",
+        "script_level.level_keys": [
+          "MC HOC 2016 SCORE LEVEL"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC HOC 2016 Level 10",
+        "script_level.level_keys": [
+          "MC HOC 2016 Level 10"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Minecraft Hour of Code Designer",
+        "lesson_group.key": "",
+        "script.name": "minecraft"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/moneppo-1.script_json
+++ b/dashboard/config/scripts_json/moneppo-1.script_json
@@ -1,0 +1,27 @@
+{
+  "script": {
+    "name": "moneppo-1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "moneppo-1"
+    }
+  },
+  "lesson_groups": [
+
+  ],
+  "lessons": [
+
+  ],
+  "script_levels": [
+
+  ],
+  "levels_script_levels": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/netsim.script_json
+++ b/dashboard/config/scripts_json/netsim.script_json
@@ -1,0 +1,595 @@
+{
+  "script": {
+    "name": "netsim",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "netsim"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Overview and Setup Instructions",
+      "name": "Overview and Setup Instructions",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Peer to Peer - Sending Bits on a Shared Wire",
+      "name": "Peer to Peer - Sending Bits on a Shared Wire",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer to Peer - Sending Bits on a Shared Wire",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Peer to Peer - Sending Numbers",
+      "name": "Peer to Peer - Sending Numbers",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer to Peer - Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Peer to Peer - Sending Ascii",
+      "name": "Peer to Peer - Sending Ascii",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Peer to Peer - Sending Ascii",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Broadcasting messages",
+      "name": "Broadcasting messages",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Broadcasting messages",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Routers and addresses",
+      "name": "Routers and addresses",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Routers and addresses",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Packets and Reliability",
+      "name": "Packets and Reliability",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Packets and Reliability",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Manual DNS",
+      "name": "Manual DNS",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Manual DNS",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Automatic DNS node",
+      "name": "Automatic DNS node",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Automatic DNS node",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "key": "Internet Simulator Freeplay",
+      "name": "Internet Simulator Freeplay",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet Simulator Freeplay",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator Setup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "Internet Simulator Setup"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator Setup 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "Internet Simulator Setup 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet Simulator Setup 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "Internet Simulator Setup 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone SendAB"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Bits on a Shared Wire",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone SendAB"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Sending Numbers"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Sending Numbers"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Sending Numbers Ascii"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Ascii",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Sending Numbers Ascii"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Broadcasting messages",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Broadcast"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Classroom Routers"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Routers and addresses",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Classroom Routers"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Packets TCP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Reliability",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Packets TCP"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Manual DNS"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Manual DNS",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Manual DNS"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Automatic DNS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Automatic DNS node",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Automatic DNS"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "NetSim Standalone Freeplay"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Internet Simulator Freeplay",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      },
+      "level_keys": [
+        "NetSim Standalone Freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator Setup",
+        "script_level.level_keys": [
+          "Internet Simulator Setup"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator Setup 2",
+        "script_level.level_keys": [
+          "Internet Simulator Setup 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet Simulator Setup 3",
+        "script_level.level_keys": [
+          "Internet Simulator Setup 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Overview and Setup Instructions",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone SendAB",
+        "script_level.level_keys": [
+          "NetSim Standalone SendAB"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Bits on a Shared Wire",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Sending Numbers",
+        "script_level.level_keys": [
+          "NetSim Standalone Sending Numbers"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Numbers",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Sending Numbers Ascii",
+        "script_level.level_keys": [
+          "NetSim Standalone Sending Numbers Ascii"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Peer to Peer - Sending Ascii",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Broadcast",
+        "script_level.level_keys": [
+          "NetSim Standalone Broadcast"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Broadcasting messages",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Classroom Routers",
+        "script_level.level_keys": [
+          "NetSim Standalone Classroom Routers"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Routers and addresses",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Packets TCP",
+        "script_level.level_keys": [
+          "NetSim Standalone Packets TCP"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Packets and Reliability",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Manual DNS",
+        "script_level.level_keys": [
+          "NetSim Standalone Manual DNS"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Manual DNS",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Automatic DNS",
+        "script_level.level_keys": [
+          "NetSim Standalone Automatic DNS"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Automatic DNS node",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "NetSim Standalone Freeplay",
+        "script_level.level_keys": [
+          "NetSim Standalone Freeplay"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Internet Simulator Freeplay",
+        "lesson_group.key": "",
+        "script.name": "netsim"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/new-d.script_json
+++ b/dashboard/config/scripts_json/new-d.script_json
@@ -1,0 +1,6172 @@
+{
+  "script": {
+    "name": "new-d",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "new-d"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Algorithms: Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Debugging in Collector",
+      "name": "Debugging in Collector",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops in Ice Age",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Bee",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Nested Loops in Artist",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Conditionals in Bee",
+      "name": "Conditionals in Bee",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Maze",
+      "name": "Conditionals & Loops in Maze",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Farmer",
+      "name": "Conditionals & Loops in Farmer",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Digital Citizenship",
+      "name": "Digital Citizenship",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Unplugged: Binary",
+      "name": "Unplugged: Binary",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "key": "Artist Binary",
+      "name": "Artist Binary",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging1a"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging2a"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging3a"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging4a"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging5a"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging6a"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging8a"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_debugging9a"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_1",
+        "courseD_bounce_events1s"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_2",
+        "courseD_bounce_events2s"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_5",
+        "courseD_bounce_events5s"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_6",
+        "courseD_bounce_events6s"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_7",
+        "courseD_bounce_events7s"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_10",
+        "courseD_bounce_events10s"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_11",
+        "courseD_bounce_events11s"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "bounce_12",
+        "courseD_bounce_events12s"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops_video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops_video"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops3"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops4"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops6"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops7"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops8"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops9"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops10"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops11"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops11"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_iceage_loops12"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_iceage_loops12"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while1"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while2"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while3"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while4"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while5"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while6"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while7"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while8"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while9"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while10"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge2"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals6"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals9"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge1"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_bee_conditionals_challenge2"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until1"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until3"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until4"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until5"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until6"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until7"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until8"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until9"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until10"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_maze_until_challenge1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_until_challenge2"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond1"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond2"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond3a"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond4"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond5"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_cond6a"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_playLab_condFP"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "BinaryImages"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_external_binary1"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary2"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary3"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary4"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary5"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary6"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary7"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary8"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary8_predict1"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binaryFP"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge1"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      },
+      "level_keys": [
+        "courseD_artist_binary_challenge2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging",
+        "script_level.level_keys": [
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging1a"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging2a"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging3a"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging4a"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging5a"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging6a"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging8a"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9a",
+        "script_level.level_keys": [
+          "courseD_collector_debugging9a"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging in Collector",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s",
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s",
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s",
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s",
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s",
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s",
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s",
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s",
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops1",
+        "script_level.level_keys": [
+          "courseD_iceage_loops1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops2",
+        "script_level.level_keys": [
+          "courseD_iceage_loops2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops_video",
+        "script_level.level_keys": [
+          "courseD_iceage_loops_video"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops3",
+        "script_level.level_keys": [
+          "courseD_iceage_loops3"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops4",
+        "script_level.level_keys": [
+          "courseD_iceage_loops4"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops6",
+        "script_level.level_keys": [
+          "courseD_iceage_loops6"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops7",
+        "script_level.level_keys": [
+          "courseD_iceage_loops7"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops8",
+        "script_level.level_keys": [
+          "courseD_iceage_loops8"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops9",
+        "script_level.level_keys": [
+          "courseD_iceage_loops9"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops10",
+        "script_level.level_keys": [
+          "courseD_iceage_loops10"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops11",
+        "script_level.level_keys": [
+          "courseD_iceage_loops11"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_iceage_loops12",
+        "script_level.level_keys": [
+          "courseD_iceage_loops12"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1",
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2",
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3",
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4",
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5",
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6",
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7",
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8",
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9",
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10",
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals2"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals3"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals4"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals5"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals6",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals6"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals8"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals9",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals9"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals10"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge1"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionals_challenge2",
+        "script_level.level_keys": [
+          "courseD_bee_conditionals_challenge2"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals in Bee",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1",
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3",
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4",
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5",
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6",
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7",
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ifElse",
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until8",
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9",
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10",
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until_challenge1",
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_until_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 15,
+        "lesson.key": "Conditionals & Loops in Maze",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Digital Citizenship",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond1",
+        "script_level.level_keys": [
+          "courseD_playLab_cond1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond2",
+        "script_level.level_keys": [
+          "courseD_playLab_cond2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond3a",
+        "script_level.level_keys": [
+          "courseD_playLab_cond3a"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond4",
+        "script_level.level_keys": [
+          "courseD_playLab_cond4"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond5",
+        "script_level.level_keys": [
+          "courseD_playLab_cond5"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_cond6a",
+        "script_level.level_keys": [
+          "courseD_playLab_cond6a"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 8,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_playLab_condFP",
+        "script_level.level_keys": [
+          "courseD_playLab_condFP"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 9,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BinaryImages",
+        "script_level.level_keys": [
+          "BinaryImages"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 1,
+        "lesson.key": "Unplugged: Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_external_binary1",
+        "script_level.level_keys": [
+          "courseD_external_binary1"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 1,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary1",
+        "script_level.level_keys": [
+          "courseD_artist_binary1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 2,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary2",
+        "script_level.level_keys": [
+          "courseD_artist_binary2"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 3,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary3",
+        "script_level.level_keys": [
+          "courseD_artist_binary3"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 4,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary4",
+        "script_level.level_keys": [
+          "courseD_artist_binary4"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 5,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary5",
+        "script_level.level_keys": [
+          "courseD_artist_binary5"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 6,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary6",
+        "script_level.level_keys": [
+          "courseD_artist_binary6"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 7,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary7",
+        "script_level.level_keys": [
+          "courseD_artist_binary7"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 8,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8",
+        "script_level.level_keys": [
+          "courseD_artist_binary8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 9,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary8_predict1",
+        "script_level.level_keys": [
+          "courseD_artist_binary8_predict1"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 10,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binaryFP",
+        "script_level.level_keys": [
+          "courseD_artist_binaryFP"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 11,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge1",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 12,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_binary_challenge2",
+        "script_level.level_keys": [
+          "courseD_artist_binary_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 13,
+        "lesson.key": "Artist Binary",
+        "lesson_group.key": "",
+        "script.name": "new-d"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/new-e.script_json
+++ b/dashboard/config/scripts_json/new-e.script_json
@@ -1,0 +1,6814 @@
+{
+  "script": {
+    "name": "new-e",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "new-e"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_e_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course E (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "csf_e_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course E Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "extra_course_content",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Extra Course Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Algorithms: Dice Race",
+      "name": "Algorithms: Dice Race",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Course E Introduction",
+      "name": "Course E Introduction",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Functions in Farmer",
+      "name": "Functions in Farmer",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Build a Play Lab Game",
+      "name": "Build a Play Lab Game",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Internet",
+      "name": "Internet",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "DiceRace"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_unplugged_privateInformation"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "SongwritingParameters"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions1"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions5"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions8"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions9"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions10"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions11_predict1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions1"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_functionsArtist"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions2"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions3"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions4"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions5"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions6"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions7"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions8"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions9"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions10"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions4b"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions5c"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions6c"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7b"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8b"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9b"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10b"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_concept1"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_concept2"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_concept3"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_concept1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_concept4"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_bee_concept5"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_concept4"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold1"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold2"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold3"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold4"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold5"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_scaffold6"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseE_playLab_challenge1"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Geometric Sun"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Robot Doodle"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Alien Defender"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Find the Wizard"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Course E: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Course E: Artist Project"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      },
+      "level_keys": [
+        "Crowdsourcing"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_e_1",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DiceRace",
+        "script_level.level_keys": [
+          "DiceRace"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Dice Race",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_unplugged_privateInformation",
+        "script_level.level_keys": [
+          "courseE_unplugged_privateInformation"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters",
+        "script_level.level_keys": [
+          "SongwritingParameters"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions1",
+        "script_level.level_keys": [
+          "courseE_bee_functions1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions2",
+        "script_level.level_keys": [
+          "courseE_bee_functions2"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions3",
+        "script_level.level_keys": [
+          "courseE_bee_functions3"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions4",
+        "script_level.level_keys": [
+          "courseE_bee_functions4"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions5",
+        "script_level.level_keys": [
+          "courseE_bee_functions5"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions6",
+        "script_level.level_keys": [
+          "courseE_bee_functions6"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions7",
+        "script_level.level_keys": [
+          "courseE_bee_functions7"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions8",
+        "script_level.level_keys": [
+          "courseE_bee_functions8"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions9",
+        "script_level.level_keys": [
+          "courseE_bee_functions9"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions10",
+        "script_level.level_keys": [
+          "courseE_bee_functions10"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions11_predict1",
+        "script_level.level_keys": [
+          "courseE_bee_functions11_predict1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions1",
+        "script_level.level_keys": [
+          "courseE_artist_functions1"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsArtist",
+        "script_level.level_keys": [
+          "courseE_video_functionsArtist"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2",
+        "script_level.level_keys": [
+          "courseE_artist_functions2"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3",
+        "script_level.level_keys": [
+          "courseE_artist_functions3"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions4",
+        "script_level.level_keys": [
+          "courseE_artist_functions4"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5",
+        "script_level.level_keys": [
+          "courseE_artist_functions5"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions6",
+        "script_level.level_keys": [
+          "courseE_artist_functions6"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7",
+        "script_level.level_keys": [
+          "courseE_artist_functions7"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8",
+        "script_level.level_keys": [
+          "courseE_artist_functions8"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9",
+        "script_level.level_keys": [
+          "courseE_artist_functions9"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10",
+        "script_level.level_keys": [
+          "courseE_artist_functions10"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions4b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions4b"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions5c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions5c"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions6c",
+        "script_level.level_keys": [
+          "courseE_farmer_functions6c"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7b"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8b"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9b"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10b",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10b"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Farmer",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1",
+        "script_level.level_keys": [
+          "courseE_bee_concept1"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2",
+        "script_level.level_keys": [
+          "courseE_bee_concept2"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3",
+        "script_level.level_keys": [
+          "courseE_bee_concept3"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1",
+        "script_level.level_keys": [
+          "courseE_artist_concept1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4",
+        "script_level.level_keys": [
+          "courseE_bee_concept4"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5",
+        "script_level.level_keys": [
+          "courseE_bee_concept5"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4",
+        "script_level.level_keys": [
+          "courseE_artist_concept4"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold1",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold1"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 1,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold2",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold2"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 2,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold3",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold3"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 3,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold4",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold4"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 4,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold5",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold5"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 5,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_scaffold6",
+        "script_level.level_keys": [
+          "courseE_playLab_scaffold6"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 6,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_playLab_challenge1",
+        "script_level.level_keys": [
+          "courseE_playLab_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 7,
+        "lesson.key": "Build a Play Lab Game",
+        "lesson_group.key": "csf_e_2",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Geometric Sun",
+        "script_level.level_keys": [
+          "Geometric Sun"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Robot Doodle",
+        "script_level.level_keys": [
+          "Robot Doodle"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Alien Defender",
+        "script_level.level_keys": [
+          "Alien Defender"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Find the Wizard",
+        "script_level.level_keys": [
+          "Find the Wizard"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Play Lab Project",
+        "script_level.level_keys": [
+          "Course E: Play Lab Project"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project",
+        "script_level.level_keys": [
+          "Course E: Artist Project"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 1,
+        "lesson.key": "Internet",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing",
+        "script_level.level_keys": [
+          "Crowdsourcing"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "extra_course_content",
+        "script.name": "new-e"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/new-express.script_json
+++ b/dashboard/config/scripts_json/new-express.script_json
@@ -1,0 +1,11300 @@
+{
+  "script": {
+    "name": "new-express",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "new-express"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Algorithms: Graph Paper Programming",
+      "name": "Algorithms: Graph Paper Programming",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Loops in Artist (UPDATED!)",
+      "name": "Loops in Artist (UPDATED!)",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Nested Loops Project in Frozen",
+      "name": "Nested Loops Project in Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "How it Works: The Internet",
+      "name": "How it Works: The Internet",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Common Sense Education: Digital Citizenship",
+      "name": "Common Sense Education: Digital Citizenship",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Common Sense Education: Screen Out the Mean",
+      "name": "Common Sense Education: Screen Out the Mean",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Events in Star Wars",
+      "name": "Events in Star Wars",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Events with Flappy",
+      "name": "Events with Flappy",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Events in Bounce",
+      "name": "Events in Bounce",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Conditionals: Conditionals with Cards",
+      "name": "Conditionals: Conditionals with Cards",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "While Loops in Farmer",
+      "name": "While Loops in Farmer",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Conditional Loops in Maze",
+      "name": "Conditional Loops in Maze",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft",
+      "name": "Conditionals in Minecraft",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Conditionals & Loops in Farmer",
+      "name": "Conditionals & Loops in Farmer",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Variables: Envelope Variables",
+      "name": "Variables: Envelope Variables",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "For Loops: For Loop Fun",
+      "name": "For Loops: For Loop Fun",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Functions: Songwriting with Parameters",
+      "name": "Functions: Songwriting with Parameters",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 30,
+      "lockable": false,
+      "relative_position": 30,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 31,
+      "lockable": false,
+      "relative_position": 31,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 32,
+      "lockable": false,
+      "relative_position": 32,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 33,
+      "lockable": false,
+      "relative_position": 33,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 34,
+      "lockable": false,
+      "relative_position": 34,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 35,
+      "lockable": false,
+      "relative_position": 35,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 36,
+      "lockable": false,
+      "relative_position": 36,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "GraphPaperProgramming"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Internet"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_unplugged_digitalCitizenship"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_Unplugged_ScreenOutTheMean"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1",
+          "flappy_1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events1",
+        "flappy_1"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2",
+          "flappy_2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events2",
+        "flappy_2"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3",
+          "flappy_3"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events3",
+        "flappy_3"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4",
+          "flappy_4"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events4",
+        "flappy_4"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5",
+          "flappy_5"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events5",
+        "flappy_5"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6",
+          "flappy_6"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events6",
+        "flappy_6"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7",
+          "flappy_7"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events7",
+        "flappy_7"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8",
+          "flappy_8"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events8",
+        "flappy_8"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9",
+          "flappy_9"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events9",
+        "flappy_9"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10",
+          "flappy_11"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseC_flappy_events10",
+        "flappy_11"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_1",
+        "courseD_bounce_events1s"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_2",
+        "courseD_bounce_events2s"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_5",
+        "courseD_bounce_events5s"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_6",
+        "courseD_bounce_events6s"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_7",
+        "courseD_bounce_events7s"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_10",
+        "courseD_bounce_events10s"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_11",
+        "courseD_bounce_events11s"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "bounce_12",
+        "courseD_bounce_events12s"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Conditionals"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while1"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while2"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while3"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while4"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while5"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while6"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while7"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while8"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while9"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while10"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while10_predict2"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge1"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_while_challenge2"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until1"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until2_predict1"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until3"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until4"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until5"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until6"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until7"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_video_ifElse"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until8"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until9"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until10"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until10_predict2"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_maze_until_challenge1"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_until_challenge2"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops1"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops2"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops3"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops4"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops5"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops6"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops7"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops8"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops9_predict1"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge1"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_farmer_condLoops_challenge2"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables2"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables3"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables4"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables5"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables6"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables7"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables8"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables9"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables10"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for1"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for2"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_forBee"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for4"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for6"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for7"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for8"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for5"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for9"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for10"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for11"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_forArtist"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for1"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for2"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for3"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for4"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for5"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for6"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for7"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for8"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for9"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for10"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functionsPre7"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_artistFunctions"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6"
+      ]
+    },
+    {
+      "chapter": 272,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7"
+      ]
+    },
+    {
+      "chapter": 273,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8"
+      ]
+    },
+    {
+      "chapter": 274,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9"
+      ]
+    },
+    {
+      "chapter": 275,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 276,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 277,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1"
+      ]
+    },
+    {
+      "chapter": 278,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2"
+      ]
+    },
+    {
+      "chapter": 279,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3"
+      ]
+    },
+    {
+      "chapter": 280,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4"
+      ]
+    },
+    {
+      "chapter": 281,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5"
+      ]
+    },
+    {
+      "chapter": 282,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6"
+      ]
+    },
+    {
+      "chapter": 283,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7"
+      ]
+    },
+    {
+      "chapter": 284,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8"
+      ]
+    },
+    {
+      "chapter": 285,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1"
+      ]
+    },
+    {
+      "chapter": 286,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 287,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 288,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 289,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "InspirationalArtwork"
+      ]
+    },
+    {
+      "chapter": 290,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "FoodFight"
+      ]
+    },
+    {
+      "chapter": 291,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Guess The Number"
+      ]
+    },
+    {
+      "chapter": 292,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 293,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 294,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Course F: Artist Project"
+      ]
+    },
+    {
+      "chapter": 295,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 296,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise"
+      ]
+    },
+    {
+      "chapter": 297,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise"
+      ]
+    },
+    {
+      "chapter": 298,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "GraphPaperProgramming",
+        "script_level.level_keys": [
+          "GraphPaperProgramming"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Graph Paper Programming",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist (UPDATED!)",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops Project in Frozen",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Internet",
+        "script_level.level_keys": [
+          "Internet"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "How it Works: The Internet",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_unplugged_digitalCitizenship",
+        "script_level.level_keys": [
+          "courseD_unplugged_digitalCitizenship"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Digital Citizenship",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_Unplugged_ScreenOutTheMean",
+        "script_level.level_keys": [
+          "courseC_Unplugged_ScreenOutTheMean"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 1,
+        "lesson.key": "Common Sense Education: Screen Out the Mean",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1",
+        "script_level.level_keys": [
+          "courseC_flappy_events1",
+          "flappy_1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_1",
+        "script_level.level_keys": [
+          "courseC_flappy_events1",
+          "flappy_1"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2",
+        "script_level.level_keys": [
+          "courseC_flappy_events2",
+          "flappy_2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_2",
+        "script_level.level_keys": [
+          "courseC_flappy_events2",
+          "flappy_2"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3",
+        "script_level.level_keys": [
+          "courseC_flappy_events3",
+          "flappy_3"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_3",
+        "script_level.level_keys": [
+          "courseC_flappy_events3",
+          "flappy_3"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4",
+        "script_level.level_keys": [
+          "courseC_flappy_events4",
+          "flappy_4"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_4",
+        "script_level.level_keys": [
+          "courseC_flappy_events4",
+          "flappy_4"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5",
+        "script_level.level_keys": [
+          "courseC_flappy_events5",
+          "flappy_5"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_5",
+        "script_level.level_keys": [
+          "courseC_flappy_events5",
+          "flappy_5"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 6,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6",
+        "script_level.level_keys": [
+          "courseC_flappy_events6",
+          "flappy_6"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_6",
+        "script_level.level_keys": [
+          "courseC_flappy_events6",
+          "flappy_6"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 7,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7",
+        "script_level.level_keys": [
+          "courseC_flappy_events7",
+          "flappy_7"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_7",
+        "script_level.level_keys": [
+          "courseC_flappy_events7",
+          "flappy_7"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 8,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8",
+        "script_level.level_keys": [
+          "courseC_flappy_events8",
+          "flappy_8"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_8",
+        "script_level.level_keys": [
+          "courseC_flappy_events8",
+          "flappy_8"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 9,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9",
+        "script_level.level_keys": [
+          "courseC_flappy_events9",
+          "flappy_9"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_9",
+        "script_level.level_keys": [
+          "courseC_flappy_events9",
+          "flappy_9"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 10,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10",
+        "script_level.level_keys": [
+          "courseC_flappy_events10",
+          "flappy_11"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "flappy_11",
+        "script_level.level_keys": [
+          "courseC_flappy_events10",
+          "flappy_11"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 11,
+        "lesson.key": "Events with Flappy",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_1",
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events1s",
+        "script_level.level_keys": [
+          "bounce_1",
+          "courseD_bounce_events1s"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2",
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events2s",
+        "script_level.level_keys": [
+          "bounce_2",
+          "courseD_bounce_events2s"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events5s",
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5",
+        "script_level.level_keys": [
+          "bounce_5",
+          "courseD_bounce_events5s"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6",
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events6s",
+        "script_level.level_keys": [
+          "bounce_6",
+          "courseD_bounce_events6s"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7",
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events7s",
+        "script_level.level_keys": [
+          "bounce_7",
+          "courseD_bounce_events7s"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10",
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events10s",
+        "script_level.level_keys": [
+          "bounce_10",
+          "courseD_bounce_events10s"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11",
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events11s",
+        "script_level.level_keys": [
+          "bounce_11",
+          "courseD_bounce_events11s"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12",
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bounce_events12s",
+        "script_level.level_keys": [
+          "bounce_12",
+          "courseD_bounce_events12s"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 8,
+        "lesson.key": "Events in Bounce",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Conditionals",
+        "script_level.level_keys": [
+          "Conditionals"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals: Conditionals with Cards",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while1",
+        "script_level.level_keys": [
+          "courseD_farmer_while1"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 1,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while2",
+        "script_level.level_keys": [
+          "courseD_farmer_while2"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 2,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while3",
+        "script_level.level_keys": [
+          "courseD_farmer_while3"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 3,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 4,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 5,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4",
+        "script_level.level_keys": [
+          "courseD_farmer_while4"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 6,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while5",
+        "script_level.level_keys": [
+          "courseD_farmer_while5"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 7,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while6",
+        "script_level.level_keys": [
+          "courseD_farmer_while6"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 8,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while7",
+        "script_level.level_keys": [
+          "courseD_farmer_while7"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 9,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while8",
+        "script_level.level_keys": [
+          "courseD_farmer_while8"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 10,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while9",
+        "script_level.level_keys": [
+          "courseD_farmer_while9"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 11,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10",
+        "script_level.level_keys": [
+          "courseD_farmer_while10"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 12,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while10_predict2",
+        "script_level.level_keys": [
+          "courseD_farmer_while10_predict2"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 13,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge1"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 14,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_while_challenge2"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 15,
+        "lesson.key": "While Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until1",
+        "script_level.level_keys": [
+          "courseD_maze_until1"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 1,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 2,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until2_predict1",
+        "script_level.level_keys": [
+          "courseD_maze_until2_predict1"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 3,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until3",
+        "script_level.level_keys": [
+          "courseD_maze_until3"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 4,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until4",
+        "script_level.level_keys": [
+          "courseD_maze_until4"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 5,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until5",
+        "script_level.level_keys": [
+          "courseD_maze_until5"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 6,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until6",
+        "script_level.level_keys": [
+          "courseD_maze_until6"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 7,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until7",
+        "script_level.level_keys": [
+          "courseD_maze_until7"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 8,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ifElse",
+        "script_level.level_keys": [
+          "courseD_video_ifElse"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 9,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until8",
+        "script_level.level_keys": [
+          "courseD_maze_until8"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 10,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until9",
+        "script_level.level_keys": [
+          "courseD_maze_until9"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 11,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10",
+        "script_level.level_keys": [
+          "courseD_maze_until10"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 12,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until10_predict2",
+        "script_level.level_keys": [
+          "courseD_maze_until10_predict2"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 13,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_until_challenge1",
+        "script_level.level_keys": [
+          "courseD_maze_until_challenge1"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 14,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_until_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_until_challenge2"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 15,
+        "lesson.key": "Conditional Loops in Maze",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops1"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops2"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops3",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops3"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops4",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops4"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops5",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops5"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops6",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops6"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops7",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops7"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops8",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops8"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops9_predict1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops9_predict1"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge1",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge1"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_condLoops_challenge2",
+        "script_level.level_keys": [
+          "courseD_farmer_condLoops_challenge2"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals & Loops in Farmer",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 1,
+        "lesson.key": "Variables: Envelope Variables",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2",
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3",
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4",
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5",
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6",
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7",
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8",
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9",
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10",
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 1,
+        "lesson.key": "For Loops: For Loop Fun",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1",
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2",
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee",
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4",
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6",
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7",
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8",
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5",
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9",
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10",
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11",
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist",
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1",
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2",
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3",
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4",
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5",
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6",
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7",
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8",
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9",
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10",
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting with Parameters",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functionsPre7",
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistFunctions",
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 272,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 273,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 274,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 275,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 276,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 277,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 278,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 279,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 280,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 281,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 282,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 283,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 284,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 285,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 286,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 287,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "content",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 288,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork",
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 289,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight",
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 290,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number",
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 291,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 292,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 293,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project",
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 294,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 295,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 296,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 297,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 298,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-express"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/new-f.script_json
+++ b/dashboard/config/scripts_json/new-f.script_json
@@ -1,0 +1,8887 @@
+{
+  "script": {
+    "name": "new-f",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "new-f"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_f_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp Up to Course F (Optional)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "csf_f_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Course F Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Algorithms: Tangrams",
+      "name": "Algorithms: Tangrams",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Course E Introduction",
+      "name": "Course E Introduction",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "The Power of Words",
+      "name": "The Power of Words",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Ice Age Play Lab",
+      "name": "Ice Age Play Lab",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft",
+      "name": "Conditionals in Minecraft",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Envelope Variables",
+      "name": "Envelope Variables",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Variables in Artist",
+      "name": "Variables in Artist",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Variables in Play Lab",
+      "name": "Variables in Play Lab",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "For Loop Fun",
+      "name": "For Loop Fun",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "For Loops in Bee",
+      "name": "For Loops in Bee",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "For Loops in Artist",
+      "name": "For Loops in Artist",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Songwriting with Parameters",
+      "name": "Songwriting with Parameters",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Functions in Bee",
+      "name": "Functions in Bee",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Artist",
+      "name": "Functions with Parameters in Artist",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Functions with Parameters in Bee",
+      "name": "Functions with Parameters in Bee",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Explore Project Ideas",
+      "name": "Explore Project Ideas",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "The Design Process",
+      "name": "The Design Process",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Build Your Project",
+      "name": "Build Your Project",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Revise Your Project",
+      "name": "Revise Your Project",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "key": "Present Your Project",
+      "name": "Present Your Project",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "BuildingAFoundation"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_video_debugging"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_video_artist"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog3"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog4"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog5"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog6"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog7"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog8"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "TangramAlgorithms"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_unplugged_powerOfWords"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_IceAgeIntro"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_IceAgeIntro"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_1",
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_1",
+        "iceage_hello1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_2",
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_2",
+        "iceage_hello2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_3",
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_3",
+        "iceage_move_to_flag"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_4",
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_4",
+        "iceage_move_to_actor"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_iceAgeRepeat"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_iceAgeRepeat"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_5",
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_5",
+        "iceage_repeat"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_IceAgeEvents"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_IceAgeEvents"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_6",
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_6",
+        "iceage_click_hello"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_7",
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_7",
+        "iceage_move_events"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_8",
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_8",
+        "iceage_sound_and_points"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_9",
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_9",
+        "iceage_warn_ice_age"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_10",
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_10",
+        "iceage_throw_hearts"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_IceAge_11",
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_IceAge_11",
+        "iceage_free_play"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Move to Sheep"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Chop Tree"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Shear Sheep"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Chop Trees"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Place Wall"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld House Frame Chosen"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Plant Crops"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Avoid Monsters"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Underground Mining Coal"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Underground Iron"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Underground Avoiding Lava"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Underground If Statements"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Powered Minecart"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Overworld Free Play 20x20"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "EnvelopeVariables"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "grade5_artist_variables_triangles1"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables2"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_artistVariables"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables3a_predict1"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables3"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables4"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables5"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables6"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables6a"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_external_variableConstant"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables7"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables8"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables9"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables10"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variablesFP"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables1a"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables2b"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables3b_josh"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4c_predictive1"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables4b"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables5c"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables6c"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7c"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables8c"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables7b"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge1"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_playlab_variables_challenge2"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "ForLoopFun"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for1"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for2"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_forBee"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for3_predict1"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for4"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for6"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for7"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for8"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for5"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for9"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for10"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for11"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_forArtist"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for1"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for2"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for3"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for4"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for5"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for6"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for7"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for8"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for9"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for10_predict1"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for10"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge1"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_for_challenge2"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "SongwritingWithParameters"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVid1"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals1_predict1"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals2"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals3"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals4"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals5"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseD_bee_conditionalsVidIfElse"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals7_predict2"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals8"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_conditionals10"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_firstFunctions_map"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_firstFunctions_map"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseE_video_functionsBee"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions2"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions3"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions3a"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions4"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions5a"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_createFunctions"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions6"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functionsPre7"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 21,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions7"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 22,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions8a"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 23,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "coursef_functionsSummary_map"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "coursef_functionsSummary_map"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 24,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 24,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge1"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 25,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 25,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_functions_challenge2"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_artistFunctions"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp1"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "gradeF_video_artistParameters"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2_predict1"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp2"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_createFunctionArtist"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp3"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp4"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp5"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp6"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp7"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp8"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp9"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_artist_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp1"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp2"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp3"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp4"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp5"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp6"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp7"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp8"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 9,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp9_predict1"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge1"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_bee_fwp_challenge2"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "courseF_video_csMatters"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "InspirationalArtwork"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "FoodFight"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Guess The Number"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Choose Your Own Adventure"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Begin planning your project"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Course F: Artist Project"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Course F: Artist Project - Revise"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Course F: Play Lab Project - Revise"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      },
+      "level_keys": [
+        "Prepare for your presentation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1",
+        "script_level.level_keys": [
+          "courseD_video_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation",
+        "script_level.level_keys": [
+          "BuildingAFoundation"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist",
+        "script_level.level_keys": [
+          "courseC_video_artist"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1",
+        "script_level.level_keys": [
+          "courseC_artist_prog1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2",
+        "script_level.level_keys": [
+          "courseC_artist_prog2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3",
+        "script_level.level_keys": [
+          "courseC_artist_prog3"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4",
+        "script_level.level_keys": [
+          "courseC_artist_prog4"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5",
+        "script_level.level_keys": [
+          "courseC_artist_prog5"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6",
+        "script_level.level_keys": [
+          "courseC_artist_prog6"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7",
+        "script_level.level_keys": [
+          "courseC_artist_prog7"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8",
+        "script_level.level_keys": [
+          "courseC_artist_prog8"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "csf_f_1",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TangramAlgorithms",
+        "script_level.level_keys": [
+          "TangramAlgorithms"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Algorithms: Tangrams",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 2,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 3,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 4,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 5,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 6,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 7,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 8,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 9,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 10,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 11,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 12,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 13,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 14,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 15,
+        "lesson.key": "Course E Introduction",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_unplugged_powerOfWords",
+        "script_level.level_keys": [
+          "courseF_unplugged_powerOfWords"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 1,
+        "lesson.key": "The Power of Words",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_IceAgeIntro",
+        "script_level.level_keys": [
+          "courseF_video_IceAgeIntro"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_1",
+        "script_level.level_keys": [
+          "courseF_IceAge_1",
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello1",
+        "script_level.level_keys": [
+          "courseF_IceAge_1",
+          "iceage_hello1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_2",
+        "script_level.level_keys": [
+          "courseF_IceAge_2",
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_hello2",
+        "script_level.level_keys": [
+          "courseF_IceAge_2",
+          "iceage_hello2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_3",
+        "script_level.level_keys": [
+          "courseF_IceAge_3",
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_flag",
+        "script_level.level_keys": [
+          "courseF_IceAge_3",
+          "iceage_move_to_flag"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_4",
+        "script_level.level_keys": [
+          "courseF_IceAge_4",
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_to_actor",
+        "script_level.level_keys": [
+          "courseF_IceAge_4",
+          "iceage_move_to_actor"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_iceAgeRepeat",
+        "script_level.level_keys": [
+          "courseF_video_iceAgeRepeat"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_5",
+        "script_level.level_keys": [
+          "courseF_IceAge_5",
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_repeat",
+        "script_level.level_keys": [
+          "courseF_IceAge_5",
+          "iceage_repeat"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_IceAgeEvents",
+        "script_level.level_keys": [
+          "courseF_video_IceAgeEvents"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_6",
+        "script_level.level_keys": [
+          "courseF_IceAge_6",
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_click_hello",
+        "script_level.level_keys": [
+          "courseF_IceAge_6",
+          "iceage_click_hello"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_7",
+        "script_level.level_keys": [
+          "courseF_IceAge_7",
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_move_events",
+        "script_level.level_keys": [
+          "courseF_IceAge_7",
+          "iceage_move_events"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_8",
+        "script_level.level_keys": [
+          "courseF_IceAge_8",
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_sound_and_points",
+        "script_level.level_keys": [
+          "courseF_IceAge_8",
+          "iceage_sound_and_points"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_9",
+        "script_level.level_keys": [
+          "courseF_IceAge_9",
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_warn_ice_age",
+        "script_level.level_keys": [
+          "courseF_IceAge_9",
+          "iceage_warn_ice_age"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_10",
+        "script_level.level_keys": [
+          "courseF_IceAge_10",
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_throw_hearts",
+        "script_level.level_keys": [
+          "courseF_IceAge_10",
+          "iceage_throw_hearts"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_IceAge_11",
+        "script_level.level_keys": [
+          "courseF_IceAge_11",
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "iceage_free_play",
+        "script_level.level_keys": [
+          "courseF_IceAge_11",
+          "iceage_free_play"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Ice Age Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Move to Sheep",
+        "script_level.level_keys": [
+          "Overworld Move to Sheep"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Tree",
+        "script_level.level_keys": [
+          "Overworld Chop Tree"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Shear Sheep",
+        "script_level.level_keys": [
+          "Overworld Shear Sheep"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Chop Trees",
+        "script_level.level_keys": [
+          "Overworld Chop Trees"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Place Wall",
+        "script_level.level_keys": [
+          "Overworld Place Wall"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld House Frame Chosen",
+        "script_level.level_keys": [
+          "Overworld House Frame Chosen"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Plant Crops",
+        "script_level.level_keys": [
+          "Overworld Plant Crops"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Avoid Monsters",
+        "script_level.level_keys": [
+          "Overworld Avoid Monsters"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Mining Coal",
+        "script_level.level_keys": [
+          "Underground Mining Coal"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Iron",
+        "script_level.level_keys": [
+          "Underground Iron"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground Avoiding Lava",
+        "script_level.level_keys": [
+          "Underground Avoiding Lava"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Underground If Statements",
+        "script_level.level_keys": [
+          "Underground If Statements"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Powered Minecart",
+        "script_level.level_keys": [
+          "Overworld Powered Minecart"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overworld Free Play 20x20",
+        "script_level.level_keys": [
+          "Overworld Free Play 20x20"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 14,
+        "lesson.key": "Conditionals in Minecraft",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "EnvelopeVariables",
+        "script_level.level_keys": [
+          "EnvelopeVariables"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Envelope Variables",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "grade5_artist_variables_triangles1",
+        "script_level.level_keys": [
+          "grade5_artist_variables_triangles1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables2",
+        "script_level.level_keys": [
+          "courseF_artist_variables2"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistVariables",
+        "script_level.level_keys": [
+          "courseF_video_artistVariables"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3a_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_variables3a_predict1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables3",
+        "script_level.level_keys": [
+          "courseF_artist_variables3"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables4",
+        "script_level.level_keys": [
+          "courseF_artist_variables4"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables5",
+        "script_level.level_keys": [
+          "courseF_artist_variables5"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6",
+        "script_level.level_keys": [
+          "courseF_artist_variables6"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables6a",
+        "script_level.level_keys": [
+          "courseF_artist_variables6a"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_external_variableConstant",
+        "script_level.level_keys": [
+          "courseF_external_variableConstant"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables7",
+        "script_level.level_keys": [
+          "courseF_artist_variables7"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables8",
+        "script_level.level_keys": [
+          "courseF_artist_variables8"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables9",
+        "script_level.level_keys": [
+          "courseF_artist_variables9"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 13,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables10",
+        "script_level.level_keys": [
+          "courseF_artist_variables10"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 14,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variablesFP",
+        "script_level.level_keys": [
+          "courseF_artist_variablesFP"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 15,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge1"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 16,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_variables_challenge2"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 17,
+        "lesson.key": "Variables in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables1a",
+        "script_level.level_keys": [
+          "courseF_playlab_variables1a"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables2b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables2b"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables3b_josh",
+        "script_level.level_keys": [
+          "courseF_playlab_variables3b_josh"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4c_predictive1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4c_predictive1"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables4b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables4b"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables5c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables5c"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables6c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables6c"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7c"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables8c",
+        "script_level.level_keys": [
+          "courseF_playlab_variables8c"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables7b",
+        "script_level.level_keys": [
+          "courseF_playlab_variables7b"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 10,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge1",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge1"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 11,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_playlab_variables_challenge2",
+        "script_level.level_keys": [
+          "courseF_playlab_variables_challenge2"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 12,
+        "lesson.key": "Variables in Play Lab",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ForLoopFun",
+        "script_level.level_keys": [
+          "ForLoopFun"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 1,
+        "lesson.key": "For Loop Fun",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for1",
+        "script_level.level_keys": [
+          "courseF_bee_for1"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for2",
+        "script_level.level_keys": [
+          "courseF_bee_for2"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forBee",
+        "script_level.level_keys": [
+          "courseF_video_forBee"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for3_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_for3_predict1"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for4",
+        "script_level.level_keys": [
+          "courseF_bee_for4"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for6",
+        "script_level.level_keys": [
+          "courseF_bee_for6"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for7",
+        "script_level.level_keys": [
+          "courseF_bee_for7"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for8",
+        "script_level.level_keys": [
+          "courseF_bee_for8"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for5",
+        "script_level.level_keys": [
+          "courseF_bee_for5"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for9",
+        "script_level.level_keys": [
+          "courseF_bee_for9"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for10",
+        "script_level.level_keys": [
+          "courseF_bee_for10"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for11",
+        "script_level.level_keys": [
+          "courseF_bee_for11"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge1"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_for_challenge2"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_forArtist",
+        "script_level.level_keys": [
+          "courseF_video_forArtist"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 1,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for1",
+        "script_level.level_keys": [
+          "courseF_artist_for1"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 2,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for2",
+        "script_level.level_keys": [
+          "courseF_artist_for2"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 3,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for3",
+        "script_level.level_keys": [
+          "courseF_artist_for3"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 4,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for4",
+        "script_level.level_keys": [
+          "courseF_artist_for4"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 5,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for5",
+        "script_level.level_keys": [
+          "courseF_artist_for5"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 6,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for6",
+        "script_level.level_keys": [
+          "courseF_artist_for6"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 7,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for7",
+        "script_level.level_keys": [
+          "courseF_artist_for7"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 8,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for8",
+        "script_level.level_keys": [
+          "courseF_artist_for8"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 9,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for9",
+        "script_level.level_keys": [
+          "courseF_artist_for9"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 10,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_for10_predict1"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 11,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for10",
+        "script_level.level_keys": [
+          "courseF_artist_for10"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 12,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge1"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 13,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_for_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_for_challenge2"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 14,
+        "lesson.key": "For Loops in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingWithParameters",
+        "script_level.level_keys": [
+          "SongwritingWithParameters"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting with Parameters",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVid1",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVid1"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals1_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals1_predict1"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals2"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals3",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals3"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals4",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals4"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals5",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals5"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_conditionalsVidIfElse",
+        "script_level.level_keys": [
+          "courseD_bee_conditionalsVidIfElse"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals7_predict2",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals7_predict2"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals8",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals8"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_conditionals10",
+        "script_level.level_keys": [
+          "courseF_bee_conditionals10"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_firstFunctions_map",
+        "script_level.level_keys": [
+          "courseF_firstFunctions_map"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_functionsBee",
+        "script_level.level_keys": [
+          "courseE_video_functionsBee"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions2",
+        "script_level.level_keys": [
+          "courseF_bee_functions2"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3",
+        "script_level.level_keys": [
+          "courseF_bee_functions3"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions3a",
+        "script_level.level_keys": [
+          "courseF_bee_functions3a"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions4",
+        "script_level.level_keys": [
+          "courseF_bee_functions4"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 16,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions5a",
+        "script_level.level_keys": [
+          "courseF_bee_functions5a"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 17,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctions",
+        "script_level.level_keys": [
+          "courseF_video_createFunctions"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 18,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions6",
+        "script_level.level_keys": [
+          "courseF_bee_functions6"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 19,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functionsPre7",
+        "script_level.level_keys": [
+          "courseF_bee_functionsPre7"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 20,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions7",
+        "script_level.level_keys": [
+          "courseF_bee_functions7"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 21,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions8a",
+        "script_level.level_keys": [
+          "courseF_bee_functions8a"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 22,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "coursef_functionsSummary_map",
+        "script_level.level_keys": [
+          "coursef_functionsSummary_map"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 23,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge1"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 24,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_functions_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_functions_challenge2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 25,
+        "lesson.key": "Functions in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_artistFunctions",
+        "script_level.level_keys": [
+          "courseF_video_artistFunctions"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp1"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradeF_video_artistParameters",
+        "script_level.level_keys": [
+          "gradeF_video_artistParameters"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2_predict1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2_predict1"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp2"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_createFunctionArtist",
+        "script_level.level_keys": [
+          "courseF_video_createFunctionArtist"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp3",
+        "script_level.level_keys": [
+          "courseF_artist_fwp3"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp4",
+        "script_level.level_keys": [
+          "courseF_artist_fwp4"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp5",
+        "script_level.level_keys": [
+          "courseF_artist_fwp5"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp6",
+        "script_level.level_keys": [
+          "courseF_artist_fwp6"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp7",
+        "script_level.level_keys": [
+          "courseF_artist_fwp7"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp8",
+        "script_level.level_keys": [
+          "courseF_artist_fwp8"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 12,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp9",
+        "script_level.level_keys": [
+          "courseF_artist_fwp9"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 13,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge1"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 14,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_artist_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_artist_fwp_challenge2"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 15,
+        "lesson.key": "Functions with Parameters in Artist",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp1"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp2"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 2,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp3",
+        "script_level.level_keys": [
+          "courseF_bee_fwp3"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 3,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp4",
+        "script_level.level_keys": [
+          "courseF_bee_fwp4"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 4,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp5",
+        "script_level.level_keys": [
+          "courseF_bee_fwp5"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 5,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp6",
+        "script_level.level_keys": [
+          "courseF_bee_fwp6"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 6,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp7",
+        "script_level.level_keys": [
+          "courseF_bee_fwp7"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 7,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp8",
+        "script_level.level_keys": [
+          "courseF_bee_fwp8"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 8,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp9_predict1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp9_predict1"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 9,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge1",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge1"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 10,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_bee_fwp_challenge2",
+        "script_level.level_keys": [
+          "courseF_bee_fwp_challenge2"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 11,
+        "lesson.key": "Functions with Parameters in Bee",
+        "lesson_group.key": "csf_f_2",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_video_csMatters",
+        "script_level.level_keys": [
+          "courseF_video_csMatters"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 1,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "InspirationalArtwork",
+        "script_level.level_keys": [
+          "InspirationalArtwork"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 2,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "FoodFight",
+        "script_level.level_keys": [
+          "FoodFight"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 3,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Guess The Number",
+        "script_level.level_keys": [
+          "Guess The Number"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 4,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Choose Your Own Adventure",
+        "script_level.level_keys": [
+          "Choose Your Own Adventure"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 5,
+        "lesson.key": "Explore Project Ideas",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Begin planning your project",
+        "script_level.level_keys": [
+          "Begin planning your project"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 1,
+        "lesson.key": "The Design Process",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project",
+        "script_level.level_keys": [
+          "Course F: Artist Project"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 1,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 2,
+        "lesson.key": "Build Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Artist Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Artist Project - Revise"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 1,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course F: Play Lab Project - Revise",
+        "script_level.level_keys": [
+          "Course F: Play Lab Project - Revise"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 2,
+        "lesson.key": "Revise Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Prepare for your presentation",
+        "script_level.level_keys": [
+          "Prepare for your presentation"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 1,
+        "lesson.key": "Present Your Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "new-f"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/new-stages-sept-2017.script_json
+++ b/dashboard/config/scripts_json/new-stages-sept-2017.script_json
@@ -1,0 +1,1058 @@
+{
+  "script": {
+    "name": "new-stages-sept-2017",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "new-stages-sept-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "key": "Sequences with Scrat",
+      "name": "Sequences with Scrat",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "key": "Testing Template",
+      "name": "Testing Template",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Testing Template",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 13,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 14,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseC_video_angles"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 15,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Testing Template",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Testing Template",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      },
+      "level_keys": [
+        "courseC_artist_loops6a"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 8,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 9,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 10,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 11,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 12,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 13,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 14,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 15,
+        "lesson.key": "Sequences with Scrat",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Testing Template",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops6a",
+        "script_level.level_keys": [
+          "courseC_artist_loops6a"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 2,
+        "lesson.key": "Testing Template",
+        "lesson_group.key": "",
+        "script.name": "new-stages-sept-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/novice-view.script_json
+++ b/dashboard/config/scripts_json/novice-view.script_json
@@ -1,0 +1,1044 @@
+{
+  "script": {
+    "name": "novice-view",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "novice-view"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSP Tuesday",
+      "name": "CSP Tuesday",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "key": "CSP Wednesday",
+      "name": "CSP Wednesday",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "key": "CSP Thursday",
+      "name": "CSP Thursday",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "key": "CSD Tuesday",
+      "name": "CSD Tuesday",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "key": "CSD Wednesday",
+      "name": "CSD Wednesday",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "key": "CSD Thursday",
+      "name": "CSD Thursday",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-unit"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-tuesday-unit"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-unit2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-tuesday-unit2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-tuesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-tuesday-facilitation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-tuesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-unit"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-wednesday-unit"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-unit2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-wednesday-unit2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-wednesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-wednesday-facilitation"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-wednesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-unit"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-thursday-unit"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-unit2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-thursday-unit2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-thursday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-thursday-pedagogy2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp-thursday-facilitation"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csp-thursday-facilitation"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-unit"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-tuesday-unit"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-unit2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-tuesday-unit2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-tuesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-tuesday-facilitation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-tuesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-unit"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-wednesday-unit"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-unit2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-wednesday-unit2"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-wednesday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-wednesday-facilitation"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-wednesday-facilitation"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-unit"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-thursday-unit"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-unit2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-thursday-unit2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-thursday-pedagogy"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Pedagogy Reflection"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-thursday-pedagogy2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csd-thursday-facilitation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      },
+      "level_keys": [
+        "csd-thursday-facilitation"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-unit",
+        "script_level.level_keys": [
+          "csp-tuesday-unit"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-unit2",
+        "script_level.level_keys": [
+          "csp-tuesday-unit2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-pedagogy",
+        "script_level.level_keys": [
+          "csp-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-tuesday-facilitation",
+        "script_level.level_keys": [
+          "csp-tuesday-facilitation"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSP Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-unit",
+        "script_level.level_keys": [
+          "csp-wednesday-unit"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-unit2",
+        "script_level.level_keys": [
+          "csp-wednesday-unit2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-pedagogy",
+        "script_level.level_keys": [
+          "csp-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-wednesday-facilitation",
+        "script_level.level_keys": [
+          "csp-wednesday-facilitation"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "CSP Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-unit",
+        "script_level.level_keys": [
+          "csp-thursday-unit"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-unit2",
+        "script_level.level_keys": [
+          "csp-thursday-unit2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-pedagogy",
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-pedagogy2",
+        "script_level.level_keys": [
+          "csp-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp-thursday-facilitation",
+        "script_level.level_keys": [
+          "csp-thursday-facilitation"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "CSP Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-unit",
+        "script_level.level_keys": [
+          "csd-tuesday-unit"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-unit2",
+        "script_level.level_keys": [
+          "csd-tuesday-unit2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-pedagogy",
+        "script_level.level_keys": [
+          "csd-tuesday-pedagogy"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-tuesday-facilitation",
+        "script_level.level_keys": [
+          "csd-tuesday-facilitation"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "CSD Tuesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-unit",
+        "script_level.level_keys": [
+          "csd-wednesday-unit"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-unit2",
+        "script_level.level_keys": [
+          "csd-wednesday-unit2"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-pedagogy",
+        "script_level.level_keys": [
+          "csd-wednesday-pedagogy"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-wednesday-facilitation",
+        "script_level.level_keys": [
+          "csd-wednesday-facilitation"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "CSD Wednesday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-unit",
+        "script_level.level_keys": [
+          "csd-thursday-unit"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-unit2",
+        "script_level.level_keys": [
+          "csd-thursday-unit2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-pedagogy",
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-pedagogy2",
+        "script_level.level_keys": [
+          "csd-thursday-pedagogy2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csd-thursday-facilitation",
+        "script_level.level_keys": [
+          "csd-thursday-facilitation"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "CSD Thursday",
+        "lesson_group.key": "",
+        "script.name": "novice-view"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/oceans.script_json
+++ b/dashboard/config/scripts_json/oceans.script_json
@@ -1,0 +1,329 @@
+{
+  "script": {
+    "name": "oceans",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "oceans"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Oceans",
+      "name": "Oceans",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_Video_Machine_Learning"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_FishVTrash"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrashDemo"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_CreaturesVTrash"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_Video_Training_Data"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_Short"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_Video_Societal_Implications"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      },
+      "level_keys": [
+        "Oceans_Long"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Machine_Learning",
+        "script_level.level_keys": [
+          "Oceans_Video_Machine_Learning"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_FishVTrash",
+        "script_level.level_keys": [
+          "Oceans_FishVTrash"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrashDemo",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrashDemo"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_CreaturesVTrash",
+        "script_level.level_keys": [
+          "Oceans_CreaturesVTrash"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Training_Data",
+        "script_level.level_keys": [
+          "Oceans_Video_Training_Data"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Short",
+        "script_level.level_keys": [
+          "Oceans_Short"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Video_Societal_Implications",
+        "script_level.level_keys": [
+          "Oceans_Video_Societal_Implications"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Oceans_Long",
+        "script_level.level_keys": [
+          "Oceans_Long"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Oceans",
+        "lesson_group.key": "",
+        "script.name": "oceans"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/odometer.script_json
+++ b/dashboard/config/scripts_json/odometer.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "odometer",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "odometer"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "odometer"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Odometer Widget",
+      "name": "Odometer Widget",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Odometer Widget",
+        "lesson_group.key": "",
+        "script.name": "odometer"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Odometer Widget",
+        "lesson_group.key": "",
+        "script.name": "odometer"
+      },
+      "level_keys": [
+        "Odometer"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Odometer",
+        "script_level.level_keys": [
+          "Odometer"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Odometer Widget",
+        "lesson_group.key": "",
+        "script.name": "odometer"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/peru-2019.script_json
+++ b/dashboard/config/scripts_json/peru-2019.script_json
@@ -1,0 +1,3500 @@
+{
+  "script": {
+    "name": "peru-2019",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "version_year": "2019"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "peru-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Introduction to Debugging",
+      "name": "Introduction to Debugging",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Nested Loops",
+      "name": "Nested Loops",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Nested Loops in Frozen",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "key": "Events in Star Wars",
+      "name": "Events in Star Wars",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseE_video_ramp1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp1",
+        "courseE_maze_ramp1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp2",
+        "courseE_maze_ramp2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp3",
+        "courseE_maze_ramp3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp4",
+        "courseE_maze_ramp4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp5",
+        "courseE_maze_ramp5"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_predict1",
+        "courseE_maze_predict1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseCDEF_video_AngryBirdLoops": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseCDEF_video_AngryBirdLoops",
+        "courseD_video_ScratLoops"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp6",
+        "courseE_maze_ramp6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_maze_ramp7": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp7",
+        "courseE_maze_ramp7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true,
+        "variants": {
+          "courseE_artist_ramp8": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_scrat_ramp8",
+        "courseE_artist_ramp8"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseC_video_angles": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_video_angles",
+        "ramp_video_artistIntro"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_artist_ramp9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseE_artist_ramp8_2",
+        "courseE_artist_ramp9"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseE_artist_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_video_angles2",
+        "courseE_artist_predict1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_video_nestedLoopsArtist": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist",
+        "courseE_artist_ramp9_2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_video_debugging": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_video_debugging",
+        "courseD_video_debugging"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1",
+        "courseD_collector_debugging1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging2": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2",
+        "courseD_collector_debugging2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging3": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3",
+        "courseD_collector_debugging3"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging4": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4",
+        "courseD_collector_debugging4"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging5": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5",
+        "courseD_collector_debugging5"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging6": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6",
+        "courseD_collector_debugging6"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true,
+        "variants": {
+          "courseD_collector_debugging8": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7",
+        "courseD_collector_debugging8"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging9": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1",
+        "courseD_collector_debugging9"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "variants": {
+          "courseD_collector_debugging10_predict1": {
+            "active": false
+          }
+        }
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9",
+        "courseD_collector_debugging10_predict1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_maze_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_debugging_challenge1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_collector_debugging_challenge2"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "ramp_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops1a"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops2a"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops3a"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops4a"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops5b"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseC_artist_loops8a"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project1"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project2"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project3"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project4"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project5"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project1a"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project2a"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project3a"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "courseD_artist_project4a"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_ramp1",
+        "script_level.level_keys": [
+          "courseE_video_ramp1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp1",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp1",
+          "courseE_maze_ramp1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp2",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp2",
+          "courseE_maze_ramp2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp3",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp3",
+          "courseE_maze_ramp3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp4",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp4",
+          "courseE_maze_ramp4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp5",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp5",
+          "courseE_maze_ramp5"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_predict1",
+        "script_level.level_keys": [
+          "courseD_scrat_predict1",
+          "courseE_maze_predict1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseCDEF_video_AngryBirdLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ScratLoops",
+        "script_level.level_keys": [
+          "courseCDEF_video_AngryBirdLoops",
+          "courseD_video_ScratLoops"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp6",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp6",
+          "courseE_maze_ramp6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_maze_ramp7",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp7",
+          "courseE_maze_ramp7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_scrat_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8",
+        "script_level.level_keys": [
+          "courseD_scrat_ramp8",
+          "courseE_artist_ramp8"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro",
+        "script_level.level_keys": [
+          "courseC_video_angles",
+          "ramp_video_artistIntro"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp8_2",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9",
+        "script_level.level_keys": [
+          "courseE_artist_ramp8_2",
+          "courseE_artist_ramp9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_angles2",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_predict1",
+        "script_level.level_keys": [
+          "courseC_video_angles2",
+          "courseE_artist_predict1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_ramp9_2",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist",
+          "courseE_artist_ramp9_2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_debugging",
+        "script_level.level_keys": [
+          "courseC_video_debugging",
+          "courseD_video_debugging"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1",
+          "courseD_collector_debugging1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2",
+          "courseD_collector_debugging2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging3",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3",
+          "courseD_collector_debugging3"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging4",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4",
+          "courseD_collector_debugging4"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging5",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5",
+          "courseD_collector_debugging5"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6",
+          "courseD_collector_debugging6"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging8",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7",
+          "courseD_collector_debugging8"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1",
+          "courseD_collector_debugging9"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging10_predict1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9",
+          "courseD_collector_debugging10_predict1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge1"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseC_maze_debugging_challenge2"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_debugging_challenge1",
+        "script_level.level_keys": [
+          "courseD_bee_debugging_challenge1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 13,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_debugging_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_debugging_challenge2"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 14,
+        "lesson.key": "Introduction to Debugging",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro2",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1",
+        "script_level.level_keys": [
+          "ramp_artist_loops1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2",
+        "script_level.level_keys": [
+          "ramp_artist_loops2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3",
+        "script_level.level_keys": [
+          "ramp_artist_loops3"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4",
+        "script_level.level_keys": [
+          "ramp_artist_loops4"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5",
+        "script_level.level_keys": [
+          "ramp_artist_loops5"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6",
+        "script_level.level_keys": [
+          "ramp_artist_loops6"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7",
+        "script_level.level_keys": [
+          "ramp_artist_loops7"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8",
+        "script_level.level_keys": [
+          "ramp_artist_loops8"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9",
+        "script_level.level_keys": [
+          "ramp_artist_loops9"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops1a",
+        "script_level.level_keys": [
+          "courseC_artist_loops1a"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops2a",
+        "script_level.level_keys": [
+          "courseC_artist_loops2a"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops3a",
+        "script_level.level_keys": [
+          "courseC_artist_loops3a"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops4a",
+        "script_level.level_keys": [
+          "courseC_artist_loops4a"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops5b",
+        "script_level.level_keys": [
+          "courseC_artist_loops5b"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 16,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_loops8a",
+        "script_level.level_keys": [
+          "courseC_artist_loops8a"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 17,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1",
+        "script_level.level_keys": [
+          "courseD_artist_project1"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2",
+        "script_level.level_keys": [
+          "courseD_artist_project2"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3",
+        "script_level.level_keys": [
+          "courseD_artist_project3"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4",
+        "script_level.level_keys": [
+          "courseD_artist_project4"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5",
+        "script_level.level_keys": [
+          "courseD_artist_project5"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a",
+        "script_level.level_keys": [
+          "courseD_artist_project1a"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a",
+        "script_level.level_keys": [
+          "courseD_artist_project2a"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a",
+        "script_level.level_keys": [
+          "courseD_artist_project3a"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a",
+        "script_level.level_keys": [
+          "courseD_artist_project4a"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 1,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 2,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 3,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 4,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 5,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 6,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 7,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 8,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 9,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 10,
+        "lesson.key": "Events in Star Wars",
+        "lesson_group.key": "",
+        "script.name": "peru-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/petgame.script_json
+++ b/dashboard/config/scripts_json/petgame.script_json
@@ -1,0 +1,363 @@
+{
+  "script": {
+    "name": "petgame",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "petgame"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "pet game",
+      "name": "pet game",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pet game 9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      },
+      "level_keys": [
+        "pet game 9"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "pet game 1",
+        "script_level.level_keys": [
+          "pet game 1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 2",
+        "script_level.level_keys": [
+          "pet game 2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 3",
+        "script_level.level_keys": [
+          "pet game 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 4",
+        "script_level.level_keys": [
+          "pet game 4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 5",
+        "script_level.level_keys": [
+          "pet game 5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 6",
+        "script_level.level_keys": [
+          "pet game 6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 7",
+        "script_level.level_keys": [
+          "pet game 7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 8",
+        "script_level.level_keys": [
+          "pet game 8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pet game 9",
+        "script_level.level_keys": [
+          "pet game 9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "pet game",
+        "lesson_group.key": "",
+        "script.name": "petgame"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pixelation.script_json
+++ b/dashboard/config/scripts_json/pixelation.script_json
@@ -1,0 +1,385 @@
+{
+  "script": {
+    "name": "pixelation",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "pixelation"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Black & White Pixelation Tutorial",
+      "name": "Black & White Pixelation Tutorial",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Black & White Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "key": "Black & White Pixelation Freeplay",
+      "name": "Black & White Pixelation Freeplay",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Black & White Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "key": "Color Pixelation Tutorial",
+      "name": "Color Pixelation Tutorial",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "key": "Color Pixelation Examples",
+      "name": "Color Pixelation Examples",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Color Pixelation Examples",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "key": "Color Pixelation Freeplay",
+      "name": "Color Pixelation Freeplay",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Color Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation 4x4 Empty"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Black & White Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation 4x4 Empty"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Black & White Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Complete 3-bit color"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation - Lesson 15 - Color Shades 4x4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Examples",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation Flappy"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Color Pixelation Examples",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Pixelation Bee"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Mixing Colors"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      },
+      "level_keys": [
+        "Mixing Colors"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Pixelation 4x4 Empty",
+        "script_level.level_keys": [
+          "Pixelation 4x4 Empty"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Black & White Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation 1",
+        "script_level.level_keys": [
+          "Pixelation 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Black & White Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Complete 3-bit color",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Complete 3-bit color"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation - Lesson 15 - Color Shades 4x4",
+        "script_level.level_keys": [
+          "Pixelation - Lesson 15 - Color Shades 4x4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Color Pixelation Tutorial",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Flappy",
+        "script_level.level_keys": [
+          "Pixelation Flappy"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Examples",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Pixelation Bee",
+        "script_level.level_keys": [
+          "Pixelation Bee"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Color Pixelation Examples",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Mixing Colors",
+        "script_level.level_keys": [
+          "Mixing Colors"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Color Pixelation Freeplay",
+        "lesson_group.key": "",
+        "script.name": "pixelation"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pl-csd-bugs.script_json
+++ b/dashboard/config/scripts_json/pl-csd-bugs.script_json
@@ -1,0 +1,223 @@
+{
+  "script": {
+    "name": "pl-csd-bugs",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "pl-csd-bugs"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "CSD Workshop 1 Bugs",
+      "name": "CSD Workshop 1 Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      },
+      "level_keys": [
+        "CSD-PL AYWS1 Debugging Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing practice 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      },
+      "level_keys": [
+        "CSD U3 drawing practice 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 drawing practice 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      },
+      "level_keys": [
+        "CSD U3 drawing practice 3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variable names debug"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      },
+      "level_keys": [
+        "CSD U3 Variable names debug"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD-PL AYWS1 Debugging Intro",
+        "script_level.level_keys": [
+          "CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing practice 1",
+        "script_level.level_keys": [
+          "CSD U3 drawing practice 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 drawing practice 3",
+        "script_level.level_keys": [
+          "CSD U3 drawing practice 3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variable names debug",
+        "script_level.level_keys": [
+          "CSD U3 Variable names debug"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "CSD Workshop 1 Bugs",
+        "lesson_group.key": "",
+        "script.name": "pl-csd-bugs"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/playlab.script_json
+++ b/dashboard/config/scripts_json/playlab.script_json
@@ -1,0 +1,398 @@
+{
+  "script": {
+    "name": "playlab",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "playlab"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Play Lab",
+      "name": "Play Lab",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      },
+      "level_keys": [
+        "blockly:Studio:playlab_10"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_1",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_2",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_3",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_4",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_5",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_6",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_7",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_8",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_9",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:playlab_10",
+        "script_level.level_keys": [
+          "blockly:Studio:playlab_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Play Lab",
+        "lesson_group.key": "",
+        "script.name": "playlab"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pluralsight.script_json
+++ b/dashboard/config/scripts_json/pluralsight.script_json
@@ -1,0 +1,83 @@
+{
+  "script": {
+    "name": "pluralsight",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "pluralsight"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pluralsight"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Pluralsight LevelGroup",
+      "name": "Pluralsight LevelGroup",
+      "absolute_position": 1,
+      "lockable": true,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pluralsight LevelGroup",
+        "lesson_group.key": "",
+        "script.name": "pluralsight"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Pluralsight for CSP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pluralsight LevelGroup",
+        "lesson_group.key": "",
+        "script.name": "pluralsight"
+      },
+      "level_keys": [
+        "Pluralsight for CSP"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Pluralsight for CSP",
+        "script_level.level_keys": [
+          "Pluralsight for CSP"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Pluralsight LevelGroup",
+        "lesson_group.key": "",
+        "script.name": "pluralsight"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pre-express-2017.script_json
+++ b/dashboard/config/scripts_json/pre-express-2017.script_json
@@ -1,0 +1,3654 @@
+{
+  "script": {
+    "name": "pre-express-2017",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-1718/pre-express/{LESSON}",
+      "version_year": "2017",
+      "supported_locales": [
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "hi-IN",
+        "it-IT",
+        "ja-JP",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": "pre-express-2017",
+    "family_name": "pre-express",
+    "seeding_key": {
+      "script.name": "pre-express-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Marbles",
+      "name": "Persistence: Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Sequencing with Drag and Drop",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Online Safety: Your Digital Footprint",
+      "name": "Digital Citizenship: My Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Online Safety: Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming in Maze",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Programming: Star Wars",
+      "name": "Programming: Star Wars",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops in Collector",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "Events in Play Lab",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "key": "Spelling Bee",
+      "name": "Spelling Bee",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseA_video_Stevie"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "PlantASeed"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "gradek1_activity_beNice"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "gradek1_activity_beNice"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:13"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Online Safety: Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "DigitalFootprint"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_video_debuggingOrg"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq2"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq3"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq4"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq5"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq6"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq7"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq8"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq9"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq10"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq11"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq12"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge1"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge2"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseAB_video_collector"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseA_video_Loops"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops3"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops4"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops5"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops6"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops7"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops8"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops9"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops10"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops11"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops1"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops2"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops3"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops4"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops5"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops6"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops7"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops8"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops9"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops10"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "BigEvent"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseA_video_events"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playLab_events1"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events2"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events3"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events4"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events5"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events6"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events7"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_1"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_2"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_3"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_4"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_6"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_9"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_13"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_15"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_16"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie",
+        "script_level.level_keys": [
+          "courseA_video_Stevie"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Marbles",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed",
+        "script_level.level_keys": [
+          "PlantASeed"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "gradek1_activity_beNice",
+        "script_level.level_keys": [
+          "gradek1_activity_beNice"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 13,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:13",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:13"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 14,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint",
+        "script_level.level_keys": [
+          "DigitalFootprint"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Online Safety: Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1",
+        "script_level.level_keys": [
+          "courseB_maze_seq1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_debuggingOrg",
+        "script_level.level_keys": [
+          "courseB_video_debuggingOrg"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq2",
+        "script_level.level_keys": [
+          "courseB_maze_seq2"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq3",
+        "script_level.level_keys": [
+          "courseB_maze_seq3"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq4",
+        "script_level.level_keys": [
+          "courseB_maze_seq4"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq5",
+        "script_level.level_keys": [
+          "courseB_maze_seq5"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq6",
+        "script_level.level_keys": [
+          "courseB_maze_seq6"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq7",
+        "script_level.level_keys": [
+          "courseB_maze_seq7"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq8",
+        "script_level.level_keys": [
+          "courseB_maze_seq8"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq9",
+        "script_level.level_keys": [
+          "courseB_maze_seq9"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10",
+        "script_level.level_keys": [
+          "courseB_maze_seq10"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq11",
+        "script_level.level_keys": [
+          "courseB_maze_seq11"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq12",
+        "script_level.level_keys": [
+          "courseB_maze_seq12"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge1",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge2",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 16,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 1,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 2,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 3,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 4,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 5,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 6,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 7,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 8,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 9,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 10,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 11,
+        "lesson.key": "Programming: Star Wars",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector",
+        "script_level.level_keys": [
+          "courseAB_video_collector"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1",
+        "script_level.level_keys": [
+          "courseB_collector_loops1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2",
+        "script_level.level_keys": [
+          "courseB_collector_loops2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops",
+        "script_level.level_keys": [
+          "courseA_video_Loops"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3",
+        "script_level.level_keys": [
+          "courseB_collector_loops3"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4",
+        "script_level.level_keys": [
+          "courseB_collector_loops4"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5",
+        "script_level.level_keys": [
+          "courseB_collector_loops5"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6",
+        "script_level.level_keys": [
+          "courseB_collector_loops6"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7",
+        "script_level.level_keys": [
+          "courseB_collector_loops7"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8",
+        "script_level.level_keys": [
+          "courseB_collector_loops8"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9",
+        "script_level.level_keys": [
+          "courseB_collector_loops9"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10",
+        "script_level.level_keys": [
+          "courseB_collector_loops10"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11",
+        "script_level.level_keys": [
+          "courseB_collector_loops11"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1",
+        "script_level.level_keys": [
+          "courseB_artist_loops1"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2",
+        "script_level.level_keys": [
+          "courseB_artist_loops2"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3",
+        "script_level.level_keys": [
+          "courseB_artist_loops3"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4",
+        "script_level.level_keys": [
+          "courseB_artist_loops4"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5",
+        "script_level.level_keys": [
+          "courseB_artist_loops5"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6",
+        "script_level.level_keys": [
+          "courseB_artist_loops6"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7",
+        "script_level.level_keys": [
+          "courseB_artist_loops7"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8",
+        "script_level.level_keys": [
+          "courseB_artist_loops8"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9",
+        "script_level.level_keys": [
+          "courseB_artist_loops9"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10",
+        "script_level.level_keys": [
+          "courseB_artist_loops10"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent",
+        "script_level.level_keys": [
+          "BigEvent"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events",
+        "script_level.level_keys": [
+          "courseA_video_events"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1",
+        "script_level.level_keys": [
+          "courseB_playLab_events1"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2",
+        "script_level.level_keys": [
+          "courseB_playlab_events2"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3",
+        "script_level.level_keys": [
+          "courseB_playlab_events3"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4",
+        "script_level.level_keys": [
+          "courseB_playlab_events4"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5",
+        "script_level.level_keys": [
+          "courseB_playlab_events5"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6",
+        "script_level.level_keys": [
+          "courseB_playlab_events6"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7",
+        "script_level.level_keys": [
+          "courseB_playlab_events7"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_1",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_2",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_3",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_4",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_6",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_9",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_13",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_15",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_16",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2017"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pre-express-2018.script_json
+++ b/dashboard/config/scripts_json/pre-express-2018.script_json
@@ -1,0 +1,3859 @@
+{
+  "script": {
+    "name": "pre-express-2018",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-18/pre-express/{LESSON}",
+      "announcements": [
+        {
+          "notice": "New: Choose Which Lessons to Show or Hide for Your Section",
+          "details": "Click \"Learn More\" to read the help article on showing and hiding lessons.",
+          "link": "https://support.code.org/hc/en-us/articles/115001479372-Hiding-units-and-lessons-in-Code-org-s-CS-Principles-and-CS-Discoveries-courses",
+          "type": "bullhorn"
+        }
+      ],
+      "version_year": "2018",
+      "supported_locales": [
+        "it-IT",
+        "sk-SK"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": null,
+    "family_name": "pre-express",
+    "seeding_key": {
+      "script.name": "pre-express-2018"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Big Project",
+      "name": "Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Move It, Move It",
+      "name": "Move It, Move It",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Sequencing with Scrat",
+      "name": "Sequencing with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Your Digital Footprint",
+      "name": "Your Digital Footprint",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "My Robotic Friends Jr.",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Programming in Ice Age",
+      "name": "Programming with Scrat",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Copyright and Creativity",
+      "name": "It's Great to Create and Play Fair",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "My Loopy Robotic Friends Jr.",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops with Scrat",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Gardens with Loops",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "The Big Event Jr.",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Events in Play Lab",
+      "name": "A Royal Battle with Events",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "key": "Spelling Bee",
+      "name": "Spelling Bee",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseA_video_Stevie_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MoveItMoveIt_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "MoveItMoveIt_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3a_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3b_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp4a_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DigitalFootprint_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "DigitalFootprint_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq1_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq1_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq4_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq4_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq5_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq5_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq6_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq6_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq7_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq7_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq8_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq8_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq9_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq9_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq10_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq10_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq11_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq11_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq12_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq12_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_maze_seq_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_CnC_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "bb8_skinOverview_K-1_video"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops1"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops2"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops_video"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops3"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops4"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops6"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops7"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops7"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops8"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops8"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops9"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops9"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops10"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops10"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops11"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops11"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops12"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_iceage_loops12"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2018"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2018"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops11_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2018"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "BigEvent_2018"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseA_video_events_2018"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playLab_events1_2018"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events2_2018"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events3_2018"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events4_2018"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events5_2018"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2018"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2018"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2018"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_1"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_2"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_3"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_4"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_6"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_9"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_13"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_15"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_16"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted_2018",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie_2018",
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MoveItMoveIt_2018",
+        "script_level.level_keys": [
+          "MoveItMoveIt_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Move It, Move It",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2018",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp1_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp2_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3b_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp4a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DigitalFootprint_2018",
+        "script_level.level_keys": [
+          "DigitalFootprint_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Your Digital Footprint",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2018",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq1_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq4_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq4_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq5_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq5_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq6_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq6_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq7_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq7_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq8_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq8_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq9_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq9_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq10_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq10_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq11_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq11_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq12_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq12_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_maze_seq_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_maze_seq_challenge2_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_CnC_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_CnC_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Copyright and Creativity",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_K-1_video",
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11_2018",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops1",
+        "script_level.level_keys": [
+          "courseB_iceage_loops1"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops2",
+        "script_level.level_keys": [
+          "courseB_iceage_loops2"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops_video",
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops3",
+        "script_level.level_keys": [
+          "courseB_iceage_loops3"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops4",
+        "script_level.level_keys": [
+          "courseB_iceage_loops4"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops6",
+        "script_level.level_keys": [
+          "courseB_iceage_loops6"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops7",
+        "script_level.level_keys": [
+          "courseB_iceage_loops7"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops8",
+        "script_level.level_keys": [
+          "courseB_iceage_loops8"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops9",
+        "script_level.level_keys": [
+          "courseB_iceage_loops9"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops10",
+        "script_level.level_keys": [
+          "courseB_iceage_loops10"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops11",
+        "script_level.level_keys": [
+          "courseB_iceage_loops11"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops12",
+        "script_level.level_keys": [
+          "courseB_iceage_loops12"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2018",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2018"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2018",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2018"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2018",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2018"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2018",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2018"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2018"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2018"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2018"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2018",
+        "script_level.level_keys": [
+          "BigEvent_2018"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2018",
+        "script_level.level_keys": [
+          "courseA_video_events_2018"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1_2018",
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2018"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2018"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2018"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2018"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2018"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2018"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2018"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2018"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2018"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2018",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2018"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Events in Play Lab",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_1",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_2",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_3",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_4",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_6",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_9",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_13",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_15",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_16",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "",
+        "script.name": "pre-express-2018"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pre-express-2019.script_json
+++ b/dashboard/config/scripts_json/pre-express-2019.script_json
@@ -1,0 +1,5299 @@
+{
+  "script": {
+    "name": "pre-express-2019",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-19/pre-express/{LESSON}",
+      "version_year": "2019",
+      "supported_locales": [
+        "cs-CZ",
+        "es-ES",
+        "es-MX",
+        "fr-FR",
+        "id-ID",
+        "it-IT",
+        "pt-BR",
+        "sk-SK",
+        "zh-CN"
+      ],
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true
+    },
+    "new_name": null,
+    "family_name": "pre-express",
+    "seeding_key": {
+      "script.name": "pre-express-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Learn to Drag and Drop",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Sequencing with Scrat",
+      "name": "Sequencing with Scrat",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Programming in Maze",
+      "name": "Programming with Angry Birds",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Programming in Harvester",
+      "name": "Programming with Harvester",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Spelling Bee",
+      "name": "Spelling Bee",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Loops in Ice Age",
+      "name": "Loops with Scrat",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Loops in Collector",
+      "name": "Loops with Laurel",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Ocean Scene with Loops",
+      "name": "Ocean Scene with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Drawing Gardens with Loops",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Tell a Story in Play Lab",
+      "name": "On the Move with Events",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "key": "Make a Game in Play Lab",
+      "name": "A Royal Battle with Events",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp1_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp2_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3a_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3b_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp4a_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp5a_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "bb8_skinOverview_K-1_video_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10_2019"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_intro_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq1_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq2_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq3_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq4_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq5_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq6_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq7_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq8_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq9_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq10_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq12_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq11_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_harvester_seq13_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_1"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_2"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_3"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_4"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_6"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_9"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_13"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_15"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "blockly:CustomMaze:wordsearch_k_16"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops_video_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_iceage_loops12_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2019"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_video_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops11_2019"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops12_2019"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2a_2019"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2019"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops1_2019"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops_2019"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops2_2019"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops3_2019"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops4_2019"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops5_2019"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops6_2019"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2019"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2019"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops9_2019"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2019"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_video_events_2019"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events1_2019"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events2_2019"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events3_2019"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events4_2019"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events5_2019"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events6_2019"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playLab_events7_2019"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playLab_events1_2019"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events2_2019"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events3_2019"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events4_2019"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events5_2019"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2019"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2019"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2019"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:1",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2019",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp1_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp2_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3b_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp4a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp5a_2019",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2019",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2019",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_K-1_video_2019",
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2019"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11_2019",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_intro_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq1_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq2_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq3_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2019",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq4_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq5_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq6_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq7_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq8_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq9_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq10_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq12_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq11_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq13_2019",
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_1",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_1"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_2",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_2"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_3",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_3"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_4",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_4"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_6",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_6"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_9",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_9"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_13",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_13"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_15",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_15"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:CustomMaze:wordsearch_k_16",
+        "script_level.level_keys": [
+          "blockly:CustomMaze:wordsearch_k_16"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Spelling Bee",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops1_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops2_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops_video_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops3_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops4_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops6_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops7_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops8_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops9_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops10_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops11_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops12_2019",
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Ice Age",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2019",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2019",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2019"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2019"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2019"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2019"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2019"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2019"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 15,
+        "lesson.key": "Loops in Collector",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2019",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops1_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2019"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2019"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2019"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1_2019",
+        "script_level.level_keys": [
+          "courseA_video_loops1_2019"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2019"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2019"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2019"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2019"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2019"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2019"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2019"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2019"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2019"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2a_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2019"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 16,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2019",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2019"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2019"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2019",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2019"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2019"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2019"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2019"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2019"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2019"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2019"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2019"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2019"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2019"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 14,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2019",
+        "script_level.level_keys": [
+          "courseA_video_events_2019"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 1,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2019"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 2,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2019"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 3,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2019"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 4,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2019"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 5,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2019"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 6,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events6_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2019"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 7,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events7_2019",
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2019"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 8,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2_2019",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 9,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1_2019",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 10,
+        "lesson.key": "Tell a Story in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1_2019",
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2019"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 1,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2019"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 2,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2019"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 3,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2019"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 4,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2019"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 5,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2019"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 6,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2019"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 7,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2019"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 8,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2019"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 9,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2019",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2019"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 10,
+        "lesson.key": "Make a Game in Play Lab",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2019"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pre-express-2020.script_json
+++ b/dashboard/config/scripts_json/pre-express-2020.script_json
@@ -1,0 +1,4977 @@
+{
+  "script": {
+    "name": "pre-express-2020",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "project_widget_visible": true,
+      "project_widget_types": [
+        "playlab_k1",
+        "artist_k1"
+      ],
+      "lesson_extras_available": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csf-20/pre-express/{LESSON}",
+      "version_year": "2020",
+      "curriculum_umbrella": "CSF",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "tts": true,
+      "is_course": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csf-20/express/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/c/csf"
+        ],
+        [
+          "vocabulary",
+          "https://curriculum.code.org/csf-20/express/vocab/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csf-20/express/standards"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": "pre-express",
+    "seeding_key": {
+      "script.name": "pre-express-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Learn to Drag and Drop",
+      "name": "Learn to Drag and Drop",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Sequencing with Scrat",
+      "name": "Sequencing with Scrat",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Programming in with Angry Birds",
+      "name": "Programming in with Angry Birds",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Programming with Rey and BB-8",
+      "name": "Programming with Rey and BB-8",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Programming in Harvester",
+      "name": "Programming in Harvester",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Loops with Scrat",
+      "name": "Loops with Scrat",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Loops with Laurel",
+      "name": "Loops with Laurel",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Ocean Scene with Loops",
+      "name": "Ocean Scene with Loops",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "Drawing Gardens with Loops",
+      "name": "Drawing Gardens with Loops",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "On the Move with Events",
+      "name": "On the Move with Events",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "key": "A Royal Battle with Events",
+      "name": "A Royal Battle with Events",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "blockly:Jigsaw:12"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseAB_video_NewIntro_2020"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp1_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp2_2020"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3a_2020"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp3b_2020"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp4a_2020"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_Scrat_ramp5a_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "elementary_video_pairProgramming_2020"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq1_2020"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq5_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq5a_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq6_2020"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq8_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq10_2020"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq11_2020"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq12_2020"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq13_2020"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_maze_seq_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "bb8_skinOverview_K-1_video_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog1_2020"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog2_2020"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog3_2020"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog4_2020"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog5_2020"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog6_2020"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog7_2020"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog8_2020"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog9_2020"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog10_2020"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_starWars_prog11_2020"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_intro_2020"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq1_2020"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq2_2020"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq3_2020"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseAB_video_debugging_2020"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq4_2020"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq5_2020"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq6_2020"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq7_2020"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq8_2020"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq9_2020"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq10_2020"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq12_2020"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq11_2020"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_harvester_seq13_2020"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops_video_2020"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_iceage_loops12_2020"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseAB_video_collector_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseAB_video_collector_2020"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Loops_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_video_Loops_2020"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_collector_loops_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2020"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_loops1_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_video_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops11_2020"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops12_2020"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge2a_2020"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 16,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_artist_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_video_ArtistIntro_2020"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops1_2020"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_video_artistLoops_2020"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops2_2020"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops3_2020"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops4_2020"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops5_2020"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops6_2020"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops7_2020"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops8_2020"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops9_2020"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops10_2020"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_artist_loops_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_events_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_video_events_2020"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events1_2020"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events2_2020"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events3_2020"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events4_2020"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events5_2020"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events6_2020"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playLab_events7_2020"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge2_2020"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseA_playlab_events_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playLab_events1_2020"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events2_2020"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 3,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events3_2020"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 4,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events4_2020"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 5,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events5_2020"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 6,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events6_2020"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 7,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events7_2020"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 8,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_eventsFP_2020"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 9,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge1_2020"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 10,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      },
+      "level_keys": [
+        "courseB_playlab_events_challenge2_2020"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:1",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:2",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:3",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:4",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:5",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:6",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:7",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:8",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:9",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:10",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:11",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Jigsaw:12",
+        "script_level.level_keys": [
+          "blockly:Jigsaw:12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Learn to Drag and Drop",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_NewIntro_2020",
+        "script_level.level_keys": [
+          "courseAB_video_NewIntro_2020"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp1_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp1_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp2_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp2_2020"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3a_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3a_2020"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp3b_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp3b_2020"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp4a_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp4a_2020"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_Scrat_ramp5a_2020",
+        "script_level.level_keys": [
+          "courseB_Scrat_ramp5a_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing with Scrat",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "elementary_video_pairProgramming_2020",
+        "script_level.level_keys": [
+          "elementary_video_pairProgramming_2020"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq1_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq1_2020"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 2,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq5_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 3,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq5a_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq5a_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 4,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq6_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq6_2020"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 5,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq8_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq8_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 6,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq10_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq10_2020"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 7,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq11_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq11_2020"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 8,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq12_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq12_2020"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 9,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq13_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq13_2020"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 10,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge1_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge1_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 11,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_maze_seq_challenge2_2020",
+        "script_level.level_keys": [
+          "courseA_maze_seq_challenge2_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 12,
+        "lesson.key": "Programming in with Angry Birds",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bb8_skinOverview_K-1_video_2020",
+        "script_level.level_keys": [
+          "bb8_skinOverview_K-1_video_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog1_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog1_2020"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog2_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog2_2020"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog3_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog3_2020"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog4_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog4_2020"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog5_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog5_2020"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog6_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog6_2020"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog7_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog7_2020"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog8_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog8_2020"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog9_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog9_2020"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog10_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog10_2020"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_starWars_prog11_2020",
+        "script_level.level_keys": [
+          "courseB_starWars_prog11_2020"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 12,
+        "lesson.key": "Programming with Rey and BB-8",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_intro_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_intro_2020"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq1_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq1_2020"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq2_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq2_2020"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq3_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq3_2020"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_debugging_2020",
+        "script_level.level_keys": [
+          "courseAB_video_debugging_2020"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq4_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq4_2020"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq5_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq5_2020"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq6_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq6_2020"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq7_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq7_2020"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq8_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq8_2020"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq9_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq9_2020"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq10_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq10_2020"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq12_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq12_2020"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 13,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq11_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq11_2020"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 14,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_harvester_seq13_2020",
+        "script_level.level_keys": [
+          "courseA_harvester_seq13_2020"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 15,
+        "lesson.key": "Programming in Harvester",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops1_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops1_2020"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops2_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops2_2020"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops_video_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops_video_2020"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops3_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops3_2020"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops4_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops4_2020"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops6_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops6_2020"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops7_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops7_2020"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops8_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops8_2020"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops9_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops9_2020"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops10_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops10_2020"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops11_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops11_2020"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_iceage_loops12_2020",
+        "script_level.level_keys": [
+          "courseB_iceage_loops12_2020"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Scrat",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseAB_video_collector_2020",
+        "script_level.level_keys": [
+          "courseAB_video_collector_2020"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops1_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops1_2020"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops2_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops2_2020"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Loops_2020",
+        "script_level.level_keys": [
+          "courseA_video_Loops_2020"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops3_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops3_2020"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops4_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops4_2020"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops5_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops5_2020"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 7,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops6_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops6_2020"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 8,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops7_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops7_2020"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 9,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops8_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops8_2020"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 10,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops9_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops9_2020"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 11,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops10_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops10_2020"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 12,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops11_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops11_2020"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 13,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 14,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_collector_loops_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseB_collector_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 15,
+        "lesson.key": "Loops with Laurel",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2020",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 1,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops1_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops1_2020"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 2,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops2_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops2_2020"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 3,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops3_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops3_2020"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 4,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_loops1_2020",
+        "script_level.level_keys": [
+          "courseA_video_loops1_2020"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 5,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops4_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops4_2020"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 6,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops5_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops5_2020"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 7,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops6_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops6_2020"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 8,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops7_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops7_2020"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 9,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops8_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops8_2020"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 10,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops9_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops9_2020"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 11,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops10_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops10_2020"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 12,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops11_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops11_2020"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 13,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops12_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops12_2020"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 14,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge2a_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge2a_2020"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 15,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_artist_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseA_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 16,
+        "lesson.key": "Ocean Scene with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_ArtistIntro_2020",
+        "script_level.level_keys": [
+          "courseB_video_ArtistIntro_2020"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops1_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops1_2020"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_artistLoops_2020",
+        "script_level.level_keys": [
+          "courseB_video_artistLoops_2020"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops2_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops2_2020"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops3_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops3_2020"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops4_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops4_2020"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops5_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops5_2020"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops6_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops6_2020"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops7_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops7_2020"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops8_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops8_2020"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops9_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops9_2020"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops10_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops10_2020"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 12,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge1_2020"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 13,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_artist_loops_challenge2_2020",
+        "script_level.level_keys": [
+          "courseB_artist_loops_challenge2_2020"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 14,
+        "lesson.key": "Drawing Gardens with Loops",
+        "lesson_group.key": "csf_loops",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_events_2020",
+        "script_level.level_keys": [
+          "courseA_video_events_2020"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 1,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events1_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events1_2020"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 2,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events2_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events2_2020"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 3,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events3_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events3_2020"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 4,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events4_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events4_2020"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 5,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events5_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events5_2020"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 6,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events6_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events6_2020"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 7,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playLab_events7_2020",
+        "script_level.level_keys": [
+          "courseA_playLab_events7_2020"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 8,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge2_2020",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 9,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_playlab_events_challenge1_2020",
+        "script_level.level_keys": [
+          "courseA_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 10,
+        "lesson.key": "On the Move with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playLab_events1_2020",
+        "script_level.level_keys": [
+          "courseB_playLab_events1_2020"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events2_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events2_2020"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 2,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events3_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events3_2020"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 3,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events4_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events4_2020"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 4,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events5_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events5_2020"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 5,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events6_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events6_2020"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 6,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events7_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events7_2020"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 7,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_eventsFP_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_eventsFP_2020"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 8,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge1_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge1_2020"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 9,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_playlab_events_challenge2_2020",
+        "script_level.level_keys": [
+          "courseB_playlab_events_challenge2_2020"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 10,
+        "lesson.key": "A Royal Battle with Events",
+        "lesson_group.key": "csf_events",
+        "script.name": "pre-express-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/public-key-cryptography.script_json
+++ b/dashboard/config/scripts_json/public-key-cryptography.script_json
@@ -1,0 +1,118 @@
+{
+  "script": {
+    "name": "public-key-cryptography",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "public-key-cryptography"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Public Key Crypto Widgets",
+      "name": "Public Key Crypto Widgets",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Public Key Crypto Widgets",
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Modulo Clock"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto Widgets",
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      },
+      "level_keys": [
+        "The Modulo Clock"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto Widgets",
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      },
+      "level_keys": [
+        "Public Key Cryptography Widget"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "The Modulo Clock",
+        "script_level.level_keys": [
+          "The Modulo Clock"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Public Key Crypto Widgets",
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Public Key Cryptography Widget",
+        "script_level.level_keys": [
+          "Public Key Cryptography Widget"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Public Key Crypto Widgets",
+        "lesson_group.key": "",
+        "script.name": "public-key-cryptography"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/pwc.script_json
+++ b/dashboard/config/scripts_json/pwc.script_json
@@ -1,0 +1,833 @@
+{
+  "script": {
+    "name": "pwc",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/pwc/ayp"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "pwc"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Personal Innovations",
+      "name": "Personal Innovations",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "What is a Computer?",
+      "name": "What is a Computer?",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Problem Solving with Big Data",
+      "name": "Problem Solving with Big Data",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Programming - Hour of Code",
+      "name": "Programming - Hour of Code",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming - Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Creating Webpages",
+      "name": "Creating Webpages",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Webpages",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "User Interfaces",
+      "name": "User Interfaces",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Intro to App Lab (13+)",
+      "name": "Intro to App Lab (13+)",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro to App Lab (13+)",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Simple Encryption",
+      "name": "Simple Encryption",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "key": "Smart Clothing Design",
+      "name": "Smart Clothing Design",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Smart Clothing Design",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_problemsolving"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_problemsolving"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Computer Science is Changing Everything"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_technologyfoundations"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_technologyfoundations"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "CSD What Makes a Computer a Computer Video"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_data"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_data"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "CSD U5 Waze Data Video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Problem Solving"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "CSD U5 Amazon Data Video"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_programming"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Programming - Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_programming"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_webdevelopment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Creating Webpages",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_webdevelopment"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_appdevunplugged"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_appdevunplugged"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_appdev"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab (13+)",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_appdev"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_cybersecurity"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_cybersecurity"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Crack a Caesar Cipher"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Terminology Recap"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "New Challenge Introduction"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Crack Random Substitution"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Technique: Frequency Analysis"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "Video - Encryption and Public Keys"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "pwc_internetofthings"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Smart Clothing Design",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      },
+      "level_keys": [
+        "pwc_internetofthings"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "pwc_problemsolving",
+        "script_level.level_keys": [
+          "pwc_problemsolving"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Computer Science is Changing Everything",
+        "script_level.level_keys": [
+          "Computer Science is Changing Everything"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Personal Innovations",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_technologyfoundations",
+        "script_level.level_keys": [
+          "pwc_technologyfoundations"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD What Makes a Computer a Computer Video",
+        "script_level.level_keys": [
+          "CSD What Makes a Computer a Computer Video"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "What is a Computer?",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_data",
+        "script_level.level_keys": [
+          "pwc_data"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Waze Data Video",
+        "script_level.level_keys": [
+          "CSD U5 Waze Data Video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U5 Amazon Data Video",
+        "script_level.level_keys": [
+          "CSD U5 Amazon Data Video"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Problem Solving with Big Data",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_programming",
+        "script_level.level_keys": [
+          "pwc_programming"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Programming - Hour of Code",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_webdevelopment",
+        "script_level.level_keys": [
+          "pwc_webdevelopment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Creating Webpages",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_appdevunplugged",
+        "script_level.level_keys": [
+          "pwc_appdevunplugged"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "User Interfaces",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_appdev",
+        "script_level.level_keys": [
+          "pwc_appdev"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Intro to App Lab (13+)",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_cybersecurity",
+        "script_level.level_keys": [
+          "pwc_cybersecurity"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack a Caesar Cipher",
+        "script_level.level_keys": [
+          "Crack a Caesar Cipher"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Terminology Recap",
+        "script_level.level_keys": [
+          "Terminology Recap"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "New Challenge Introduction",
+        "script_level.level_keys": [
+          "New Challenge Introduction"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Crack Random Substitution",
+        "script_level.level_keys": [
+          "Crack Random Substitution"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Technique: Frequency Analysis",
+        "script_level.level_keys": [
+          "Technique: Frequency Analysis"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Video - Encryption and Public Keys",
+        "script_level.level_keys": [
+          "Video - Encryption and Public Keys"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Simple Encryption",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "pwc_internetofthings",
+        "script_level.level_keys": [
+          "pwc_internetofthings"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Smart Clothing Design",
+        "lesson_group.key": "",
+        "script.name": "pwc"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/rbo-reference.script_json
+++ b/dashboard/config/scripts_json/rbo-reference.script_json
@@ -1,0 +1,258 @@
+{
+  "script": {
+    "name": "rbo-reference",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "rbo-reference"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "reference",
+      "name": "reference",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Intro C"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "PDK5 Intro C"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "2-3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "2-3"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Visual Languages"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "PDK5 Visual Languages"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "PDK5 Pair programming match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "PDK5 Strategies O"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDK5 Promo Video 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      },
+      "level_keys": [
+        "PDK5 Promo Video 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Intro C",
+        "script_level.level_keys": [
+          "PDK5 Intro C"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "2-3",
+        "script_level.level_keys": [
+          "2-3"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Visual Languages",
+        "script_level.level_keys": [
+          "PDK5 Visual Languages"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Pair programming match",
+        "script_level.level_keys": [
+          "PDK5 Pair programming match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Strategies O",
+        "script_level.level_keys": [
+          "PDK5 Strategies O"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDK5 Promo Video 2",
+        "script_level.level_keys": [
+          "PDK5 Promo Video 2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "reference",
+        "lesson_group.key": "",
+        "script.name": "rbo-reference"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/removed19.script_json
+++ b/dashboard/config/scripts_json/removed19.script_json
@@ -1,0 +1,181 @@
+{
+  "script": {
+    "name": "removed19",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "removed19"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Debugging: Unspotted Bugs",
+      "name": "Debugging: Unspotted Bugs",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    },
+    {
+      "key": "Persistence & Frustration: Stevie and the Big Project",
+      "name": "Persistence & Frustration: Stevie and the Big Project",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    },
+    {
+      "key": "Real-life Algorithms: Plant a Seed",
+      "name": "Real-life Algorithms: Plant a Seed",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted_2019"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      },
+      "level_keys": [
+        "courseA_video_Stevie_2019"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PlantASeed_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      },
+      "level_keys": [
+        "PlantASeed_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted_2019",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted_2019"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Debugging: Unspotted Bugs",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_video_Stevie_2019",
+        "script_level.level_keys": [
+          "courseA_video_Stevie_2019"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Persistence & Frustration: Stevie and the Big Project",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PlantASeed_2019",
+        "script_level.level_keys": [
+          "PlantASeed_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Real-life Algorithms: Plant a Seed",
+        "lesson_group.key": "",
+        "script.name": "removed19"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/science-PD2.script_json
+++ b/dashboard/config/scripts_json/science-PD2.script_json
@@ -1,0 +1,1078 @@
+{
+  "script": {
+    "name": "science-PD2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "science-PD2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Reviewing the Modules",
+      "name": "Reviewing the Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Advanced StarLogo Nova",
+      "name": "Advanced StarLogo Nova",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Remixing Phases 1 and 2",
+      "name": "Remixing Phases 1 and 2",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciencePD2b remixing"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 mods"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 remember"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 challenge"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 SLN explore"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 sliders"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD breeds"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 camera"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 wiggle"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 color"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 procedures"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 conditionals"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 remix1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciencePD2b remixing",
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 mods",
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remember",
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 challenge",
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 SLN explore",
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 sliders",
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD breeds",
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 camera",
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 wiggle",
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 color",
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 procedures",
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 conditionals",
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remix1",
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "science-PD2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD-NexTech.script_json
+++ b/dashboard/config/scripts_json/sciencePD-NexTech.script_json
@@ -1,0 +1,2023 @@
+{
+  "script": {
+    "name": "sciencePD-NexTech",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD-NexTech"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "What to Expect",
+      "name": "What to Expect",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Introduction to Complex Adaptive Systems",
+      "name": "Introduction to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Introduction to Computational Science",
+      "name": "Introduction to Computational Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Agent Based Modeling of Complex Adaptive Systems",
+      "name": "Agent Based Modeling of Complex Adaptive Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Using Computer Models in Science",
+      "name": "Using Computer Models in Science",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Using Models in the Classroom",
+      "name": "Using Models in the Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Dispositions and Classroom Culture",
+      "name": "Dispositions and Classroom Culture",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Computational Thinking And The Framework For K-12 Science Education",
+      "name": "Computational Thinking And The Framework For K-12 Science Education",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Introduction to StarLogo Nova",
+      "name": "Introduction to StarLogo Nova",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "The Tutorial",
+      "name": "The Tutorial",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "key": "Post-Survey",
+      "name": "Post-Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "PDSci commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD what to expect"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD intro video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD expectations"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD meet and greet"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD complex adaptive video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD complex adaptive forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD intro to CS video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD intro to CS 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD intro to CS 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD intro to CS forum"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD agent based video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD agent based 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD agent based 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD agent based forum"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD computer models video"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD computer models 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD computer models 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD computer models forum"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD class models video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD class models 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD class models 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD class models forum"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD culture video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD culture 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD culture 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD culture forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD framework video"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD framework 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD framework 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD framework forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro video"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD survey1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      },
+      "level_keys": [
+        "sciPD finish"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD Intro",
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDSci commitment",
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment match",
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD what to expect",
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro video",
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD expectations",
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD meet and greet",
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive video",
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 1",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 2",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive forum",
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS video",
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 1",
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 2",
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS forum",
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based video",
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 1",
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 2",
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based forum",
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models video",
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 1",
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 2",
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models forum",
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models video",
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 1",
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 2",
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models forum",
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture video",
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 1",
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 2",
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture forum",
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework video",
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 1",
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 2",
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework forum",
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro video",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 5",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 6",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 7",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 8",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD survey1",
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD finish",
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-NexTech"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD-iZone.script_json
+++ b/dashboard/config/scripts_json/sciencePD-iZone.script_json
@@ -1,0 +1,2023 @@
+{
+  "script": {
+    "name": "sciencePD-iZone",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD-iZone"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "What to Expect",
+      "name": "What to Expect",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Introduction to Complex Adaptive Systems",
+      "name": "Introduction to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Introduction to Computational Science",
+      "name": "Introduction to Computational Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Agent Based Modeling of Complex Adaptive Systems",
+      "name": "Agent Based Modeling of Complex Adaptive Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Using Computer Models in Science",
+      "name": "Using Computer Models in Science",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Using Models in the Classroom",
+      "name": "Using Models in the Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Dispositions and Classroom Culture",
+      "name": "Dispositions and Classroom Culture",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Computational Thinking And The Framework For K-12 Science Education",
+      "name": "Computational Thinking And The Framework For K-12 Science Education",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Introduction to StarLogo Nova",
+      "name": "Introduction to StarLogo Nova",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "The Tutorial",
+      "name": "The Tutorial",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "key": "Post-Survey",
+      "name": "Post-Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "PDSci commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD what to expect"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD intro video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD expectations"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD meet and greet"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD complex adaptive video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD complex adaptive forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD intro to CS video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD intro to CS 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD intro to CS 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD intro to CS forum"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD agent based video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD agent based 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD agent based 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD agent based forum"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD computer models video"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD computer models 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD computer models 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD computer models forum"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD class models video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD class models 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD class models 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD class models forum"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD culture video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD culture 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD culture 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD culture forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD framework video"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD framework 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD framework 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD framework forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro video"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD survey1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      },
+      "level_keys": [
+        "sciPD finish"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD Intro",
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDSci commitment",
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment match",
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD what to expect",
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro video",
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD expectations",
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD meet and greet",
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive video",
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 1",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 2",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive forum",
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS video",
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 1",
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 2",
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS forum",
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based video",
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 1",
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 2",
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based forum",
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models video",
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 1",
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 2",
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models forum",
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models video",
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 1",
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 2",
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models forum",
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture video",
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 1",
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 2",
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture forum",
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework video",
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 1",
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 2",
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework forum",
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro video",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 5",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 6",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 7",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 8",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD survey1",
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD finish",
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD-iZone"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD.script_json
+++ b/dashboard/config/scripts_json/sciencePD.script_json
@@ -1,0 +1,2023 @@
+{
+  "script": {
+    "name": "sciencePD",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "What to Expect",
+      "name": "What to Expect",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Introduction to Complex Adaptive Systems",
+      "name": "Introduction to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Introduction to Computational Science",
+      "name": "Introduction to Computational Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Agent Based Modeling of Complex Adaptive Systems",
+      "name": "Agent Based Modeling of Complex Adaptive Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Using Computer Models in Science",
+      "name": "Using Computer Models in Science",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Using Models in the Classroom",
+      "name": "Using Models in the Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Dispositions and Classroom Culture",
+      "name": "Dispositions and Classroom Culture",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Computational Thinking And The Framework For K-12 Science Education",
+      "name": "Computational Thinking And The Framework For K-12 Science Education",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Introduction to StarLogo Nova",
+      "name": "Introduction to StarLogo Nova",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "The Tutorial",
+      "name": "The Tutorial",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "key": "Post-Survey",
+      "name": "Post-Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "PDSci commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD what to expect"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD intro video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD expectations"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD meet and greet"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD complex adaptive video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD complex adaptive forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD intro to CS video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD intro to CS 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD intro to CS 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD intro to CS forum"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD agent based video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD agent based 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD agent based 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD agent based forum"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD computer models video"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD computer models 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD computer models 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD computer models forum"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD class models video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD class models 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD class models 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD class models forum"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD culture video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD culture 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD culture 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD culture forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD framework video"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD framework 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD framework 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD framework forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro video"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD survey1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      },
+      "level_keys": [
+        "sciPD finish"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD Intro",
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDSci commitment",
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment match",
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD what to expect",
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro video",
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD expectations",
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD meet and greet",
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive video",
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 1",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 2",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive forum",
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS video",
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 1",
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 2",
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS forum",
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based video",
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 1",
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 2",
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based forum",
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models video",
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 1",
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 2",
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models forum",
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models video",
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 1",
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 2",
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models forum",
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture video",
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 1",
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 2",
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture forum",
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework video",
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 1",
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 2",
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework forum",
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro video",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 5",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 6",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 7",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 8",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD survey1",
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD finish",
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD1.script_json
+++ b/dashboard/config/scripts_json/sciencePD1.script_json
@@ -1,0 +1,2023 @@
+{
+  "script": {
+    "name": "sciencePD1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to PD",
+      "name": "Introduction to PD",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "What to Expect",
+      "name": "What to Expect",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Introduction to Complex Adaptive Systems",
+      "name": "Introduction to Complex Adaptive Systems",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Introduction to Computational Science",
+      "name": "Introduction to Computational Science",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Agent Based Modeling of Complex Adaptive Systems",
+      "name": "Agent Based Modeling of Complex Adaptive Systems",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Using Computer Models in Science",
+      "name": "Using Computer Models in Science",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Using Models in the Classroom",
+      "name": "Using Models in the Classroom",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Dispositions and Classroom Culture",
+      "name": "Dispositions and Classroom Culture",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Computational Thinking And The Framework For K-12 Science Education",
+      "name": "Computational Thinking And The Framework For K-12 Science Education",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Introduction to StarLogo Nova",
+      "name": "Introduction to StarLogo Nova",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "The Tutorial",
+      "name": "The Tutorial",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "key": "Post-Survey",
+      "name": "Post-Survey",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "PDSci commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD commitment match"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD what to expect"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD intro video"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD expectations"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD meet and greet"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "AlgPD Break"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive video"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 1"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive 2"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD complex adaptive forum"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD intro to CS video"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD intro to CS 1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD intro to CS 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD intro to CS forum"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD agent based video"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD agent based 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD agent based 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD agent based forum"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD computer models video"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD computer models 1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD computer models 2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD computer models forum"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD class models video"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD class models 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD class models 2"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD class models forum"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD culture video"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD culture 1"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD culture 2"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD culture forum"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD framework video"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD framework 1"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD framework 2"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD framework forum"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro video"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 7"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD StarLogo tutorial 8"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD survey1"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      },
+      "level_keys": [
+        "sciPD finish"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD Intro",
+        "script_level.level_keys": [
+          "sciPD Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDSci commitment",
+        "script_level.level_keys": [
+          "PDSci commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD commitment match",
+        "script_level.level_keys": [
+          "sciPD commitment match"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to PD",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD what to expect",
+        "script_level.level_keys": [
+          "sciPD what to expect"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro video",
+        "script_level.level_keys": [
+          "sciPD intro video"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD expectations",
+        "script_level.level_keys": [
+          "sciPD expectations"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD meet and greet",
+        "script_level.level_keys": [
+          "sciPD meet and greet"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "AlgPD Break",
+        "script_level.level_keys": [
+          "AlgPD Break"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "What to Expect",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive video",
+        "script_level.level_keys": [
+          "sciPD complex adaptive video"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 1",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 1"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive 2",
+        "script_level.level_keys": [
+          "sciPD complex adaptive 2"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD complex adaptive forum",
+        "script_level.level_keys": [
+          "sciPD complex adaptive forum"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS video",
+        "script_level.level_keys": [
+          "sciPD intro to CS video"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 1",
+        "script_level.level_keys": [
+          "sciPD intro to CS 1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS 2",
+        "script_level.level_keys": [
+          "sciPD intro to CS 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD intro to CS forum",
+        "script_level.level_keys": [
+          "sciPD intro to CS forum"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to Computational Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based video",
+        "script_level.level_keys": [
+          "sciPD agent based video"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 1",
+        "script_level.level_keys": [
+          "sciPD agent based 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based 2",
+        "script_level.level_keys": [
+          "sciPD agent based 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD agent based forum",
+        "script_level.level_keys": [
+          "sciPD agent based forum"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Agent Based Modeling of Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models video",
+        "script_level.level_keys": [
+          "sciPD computer models video"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 1",
+        "script_level.level_keys": [
+          "sciPD computer models 1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models 2",
+        "script_level.level_keys": [
+          "sciPD computer models 2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD computer models forum",
+        "script_level.level_keys": [
+          "sciPD computer models forum"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Using Computer Models in Science",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models video",
+        "script_level.level_keys": [
+          "sciPD class models video"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 1",
+        "script_level.level_keys": [
+          "sciPD class models 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models 2",
+        "script_level.level_keys": [
+          "sciPD class models 2"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD class models forum",
+        "script_level.level_keys": [
+          "sciPD class models forum"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Using Models in the Classroom",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture video",
+        "script_level.level_keys": [
+          "sciPD culture video"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 1,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 1",
+        "script_level.level_keys": [
+          "sciPD culture 1"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 2,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture 2",
+        "script_level.level_keys": [
+          "sciPD culture 2"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 3,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD culture forum",
+        "script_level.level_keys": [
+          "sciPD culture forum"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 4,
+        "lesson.key": "Dispositions and Classroom Culture",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework video",
+        "script_level.level_keys": [
+          "sciPD framework video"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 1",
+        "script_level.level_keys": [
+          "sciPD framework 1"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework 2",
+        "script_level.level_keys": [
+          "sciPD framework 2"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD framework forum",
+        "script_level.level_keys": [
+          "sciPD framework forum"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Computational Thinking And The Framework For K-12 Science Education",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro video",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro video"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 5",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 6",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 7",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 7"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo tutorial 8",
+        "script_level.level_keys": [
+          "sciPD StarLogo tutorial 8"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "The Tutorial",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD survey1",
+        "script_level.level_keys": [
+          "sciPD survey1"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD finish",
+        "script_level.level_keys": [
+          "sciPD finish"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 2,
+        "lesson.key": "Post-Survey",
+        "lesson_group.key": "",
+        "script.name": "sciencePD1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD2.script_json
+++ b/dashboard/config/scripts_json/sciencePD2.script_json
@@ -1,0 +1,798 @@
+{
+  "script": {
+    "name": "sciencePD2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Creating Breeds in Starlogo Nova",
+      "name": "Creating Breeds in Starlogo Nova",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Creating Breeds in Starlogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Revisiting Agent Movement",
+      "name": "Revisiting Agent Movement",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revisiting Agent Movement",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Epidemic Model Extensions",
+      "name": "Epidemic Model Extensions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed2a"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Creating Breeds in Starlogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed2a"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed2b"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Creating Breeds in Starlogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed2b"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed3a"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Revisiting Agent Movement",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed3a"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed3b"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Revisiting Agent Movement",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed3b"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed4a"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed4b"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4c"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed4c"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 breed4d"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 breed4d"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed2a",
+        "script_level.level_keys": [
+          "sciPD2 breed2a"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Creating Breeds in Starlogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed2b",
+        "script_level.level_keys": [
+          "sciPD2 breed2b"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Creating Breeds in Starlogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed3a",
+        "script_level.level_keys": [
+          "sciPD2 breed3a"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Revisiting Agent Movement",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed3b",
+        "script_level.level_keys": [
+          "sciPD2 breed3b"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Revisiting Agent Movement",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4a",
+        "script_level.level_keys": [
+          "sciPD2 breed4a"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4b",
+        "script_level.level_keys": [
+          "sciPD2 breed4b"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4c",
+        "script_level.level_keys": [
+          "sciPD2 breed4c"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 breed4d",
+        "script_level.level_keys": [
+          "sciPD2 breed4d"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 4,
+        "lesson.key": "Epidemic Model Extensions",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD2b-iZone.script_json
+++ b/dashboard/config/scripts_json/sciencePD2b-iZone.script_json
@@ -1,0 +1,1078 @@
+{
+  "script": {
+    "name": "sciencePD2b-iZone",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD2b-iZone"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Reviewing the Modules",
+      "name": "Reviewing the Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Advanced StarLogo Nova",
+      "name": "Advanced StarLogo Nova",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Remixing Phases 1 and 2",
+      "name": "Remixing Phases 1 and 2",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciencePD2b remixing"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 mods"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 remember"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 challenge"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 SLN explore"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 sliders"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD breeds"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 camera"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 wiggle"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 color"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 procedures"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 conditionals"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 remix1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciencePD2b remixing",
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 mods",
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remember",
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 challenge",
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 SLN explore",
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 sliders",
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD breeds",
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 camera",
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 wiggle",
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 color",
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 procedures",
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 conditionals",
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remix1",
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b-iZone"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD2b.script_json
+++ b/dashboard/config/scripts_json/sciencePD2b.script_json
@@ -1,0 +1,1113 @@
+{
+  "script": {
+    "name": "sciencePD2b",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD2b"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Review StarLogo Nova",
+      "name": "Review StarLogo Nova",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Reviewing the Modules",
+      "name": "Reviewing the Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Advanced StarLogo Nova",
+      "name": "Advanced StarLogo Nova",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Remixing Phases 1 and 2",
+      "name": "Remixing Phases 1 and 2",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Thinking Ahead to Implementation",
+      "name": "Thinking Ahead to Implementation",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2b intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 StarLogoNova"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 3"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD StarLogo intro 4"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciencePD2b remixing"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 mods"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 remember"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 challenge"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 SLN explore"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 sliders"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD breeds"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 camera"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 wiggle"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 color"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 procedures"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 conditionals"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 remix1"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 implement1"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 implement2"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2 thanks"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2b reflection"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      },
+      "level_keys": [
+        "sciPD2b end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b intro",
+        "script_level.level_keys": [
+          "sciPD2b intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 StarLogoNova",
+        "script_level.level_keys": [
+          "sciPD2 StarLogoNova"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 1",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 2",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 3",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 3"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD StarLogo intro 4",
+        "script_level.level_keys": [
+          "sciPD StarLogo intro 4"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciencePD2b remixing",
+        "script_level.level_keys": [
+          "sciencePD2b remixing"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "Review StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 mods",
+        "script_level.level_keys": [
+          "sciPD2 mods"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remember",
+        "script_level.level_keys": [
+          "sciPD2 remember"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 challenge",
+        "script_level.level_keys": [
+          "sciPD2 challenge"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing the Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 SLN explore",
+        "script_level.level_keys": [
+          "sciPD2 SLN explore"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 sliders",
+        "script_level.level_keys": [
+          "sciPD2 sliders"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD breeds",
+        "script_level.level_keys": [
+          "sciPD breeds"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 camera",
+        "script_level.level_keys": [
+          "sciPD2 camera"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 wiggle",
+        "script_level.level_keys": [
+          "sciPD2 wiggle"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 color",
+        "script_level.level_keys": [
+          "sciPD2 color"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 procedures",
+        "script_level.level_keys": [
+          "sciPD2 procedures"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 conditionals",
+        "script_level.level_keys": [
+          "sciPD2 conditionals"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Advanced StarLogo Nova",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 remix1",
+        "script_level.level_keys": [
+          "sciPD2 remix1"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Remixing Phases 1 and 2",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement1",
+        "script_level.level_keys": [
+          "sciPD2 implement1"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 implement2",
+        "script_level.level_keys": [
+          "sciPD2 implement2"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Thinking Ahead to Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 thanks",
+        "script_level.level_keys": [
+          "sciPD2 thanks"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b reflection",
+        "script_level.level_keys": [
+          "sciPD2b reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2b end",
+        "script_level.level_keys": [
+          "sciPD2b end"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencePD2b"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD3.script_json
+++ b/dashboard/config/scripts_json/sciencePD3.script_json
@@ -1,0 +1,357 @@
+{
+  "script": {
+    "name": "sciencePD3",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD3"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome Back!",
+      "name": "Welcome Back!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "key": "Mystery Model",
+      "name": "Mystery Model",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Mystery Model",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "key": "Decode and Share",
+      "name": "Decode and Share",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPDpart4_S1_L1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPDpart4_S1_L1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S1_L2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S1_L3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Mystery Model",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S2_L1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Mystery Model",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S2_L2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPDpart4_S1_L1",
+        "script_level.level_keys": [
+          "sciPDpart4_S1_L1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S1_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S1_L3",
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S2_L1",
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Mystery Model",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S2_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Mystery Model",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L1",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L3",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Decode and Share",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencePD3_pre1.script_json
+++ b/dashboard/config/scripts_json/sciencePD3_pre1.script_json
@@ -1,0 +1,357 @@
+{
+  "script": {
+    "name": "sciencePD3_pre1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencePD3_pre1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome Back!",
+      "name": "Welcome Back!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "key": "The TLO",
+      "name": "The TLO",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "key": "Prep With Your Modules",
+      "name": "Prep With Your Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3pre1 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "sciPD3pre1 intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "ECSPD PD details"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TLO intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "TLO intro"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TLO practical"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "TLO practical"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3pre1 prep"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "sciPD3pre1 prep"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3pre1 remember"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "sciPD3pre1 remember"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3pre1 thanks"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      },
+      "level_keys": [
+        "sciPD3pre1 thanks"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD3pre1 intro",
+        "script_level.level_keys": [
+          "sciPD3pre1 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ECSPD PD details",
+        "script_level.level_keys": [
+          "ECSPD PD details"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TLO intro",
+        "script_level.level_keys": [
+          "TLO intro"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TLO practical",
+        "script_level.level_keys": [
+          "TLO practical"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3pre1 prep",
+        "script_level.level_keys": [
+          "sciPD3pre1 prep"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3pre1 remember",
+        "script_level.level_keys": [
+          "sciPD3pre1 remember"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3pre1 thanks",
+        "script_level.level_keys": [
+          "sciPD3pre1 thanks"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencePD3_pre1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencepd3-2016.script_json
+++ b/dashboard/config/scripts_json/sciencepd3-2016.script_json
@@ -1,0 +1,357 @@
+{
+  "script": {
+    "name": "sciencepd3-2016",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Legacy"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencepd3-2016"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome Back!",
+      "name": "Welcome Back!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "key": "The TLO",
+      "name": "The TLO",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "key": "Prep With Your Modules",
+      "name": "Prep With Your Modules",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPDpart4_S1_L1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPDpart4_S1_L1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S1_L2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S1_L3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S2_L1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S2_L2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L1"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      },
+      "level_keys": [
+        "sciPD2Part4_S3_L3"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPDpart4_S1_L1",
+        "script_level.level_keys": [
+          "sciPDpart4_S1_L1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S1_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S1_L3",
+        "script_level.level_keys": [
+          "sciPD2Part4_S1_L3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome Back!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S2_L1",
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S2_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S2_L2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "The TLO",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L1",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L2",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2Part4_S3_L3",
+        "script_level.level_keys": [
+          "sciPD2Part4_S3_L3"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Prep With Your Modules",
+        "lesson_group.key": "",
+        "script.name": "sciencepd3-2016"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencepd4.script_json
+++ b/dashboard/config/scripts_json/sciencepd4.script_json
@@ -1,0 +1,441 @@
+{
+  "script": {
+    "name": "sciencepd4",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "professional_learning_course": "CS in Science Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencepd4"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "key": "Revisiting Complex Adaptive Systems",
+      "name": "Revisiting Complex Adaptive Systems",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Revisiting Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "key": "Thinking About Implementation",
+      "name": "Thinking About Implementation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Thinking About Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3OLP32 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3OLP32 intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3 mods2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3 mods2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 refresh"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Revisiting Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD33 refresh"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 refresh2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Revisiting Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD33 refresh2"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3 implement1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Thinking About Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3 implement1"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3 implement2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Thinking About Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3 implement2"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3 thanks"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3 thanks"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3 end"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      },
+      "level_keys": [
+        "sciPD3 end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD3OLP32 intro",
+        "script_level.level_keys": [
+          "sciPD3OLP32 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3 mods2",
+        "script_level.level_keys": [
+          "sciPD3 mods2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 refresh",
+        "script_level.level_keys": [
+          "sciPD33 refresh"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Revisiting Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 refresh2",
+        "script_level.level_keys": [
+          "sciPD33 refresh2"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 2,
+        "lesson.key": "Revisiting Complex Adaptive Systems",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3 implement1",
+        "script_level.level_keys": [
+          "sciPD3 implement1"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Thinking About Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3 implement2",
+        "script_level.level_keys": [
+          "sciPD3 implement2"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "Thinking About Implementation",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3 thanks",
+        "script_level.level_keys": [
+          "sciPD3 thanks"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD3 end",
+        "script_level.level_keys": [
+          "sciPD3 end"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd4"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sciencepd5.script_json
+++ b/dashboard/config/scripts_json/sciencepd5.script_json
@@ -1,0 +1,525 @@
+{
+  "script": {
+    "name": "sciencepd5",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "professional_learning_course": "CS in Science Support"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sciencepd5"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Welcome!",
+      "name": "Welcome!",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "key": "Earth Science Challenges",
+      "name": "Earth Science Challenges",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Earth Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "key": "Life Science Challenges",
+      "name": "Life Science Challenges",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "key": "Physical Science Challenges",
+      "name": "Physical Science Challenges",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Physical Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "key": "Wrap-Up",
+      "name": "Wrap-Up",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD3OLP33 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD3OLP33 intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD2 timeline"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "PD check your progress"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 earth1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Earth Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD33 earth1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 earth2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Earth Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD33 earth2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "challenges sample 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "challenges sample 3"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "challenges sample 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "challenges sample 4"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "challenges sample 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "challenges sample 5"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "challenges sample 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Physical Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "challenges sample 6"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "challenges sample 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Physical Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "challenges sample 7"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 thanks"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD33 thanks"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "sciPD33 end"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      },
+      "level_keys": [
+        "sciPD33 end"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "sciPD3OLP33 intro",
+        "script_level.level_keys": [
+          "sciPD3OLP33 intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD2 timeline",
+        "script_level.level_keys": [
+          "sciPD2 timeline"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PD check your progress",
+        "script_level.level_keys": [
+          "PD check your progress"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Welcome!",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 earth1",
+        "script_level.level_keys": [
+          "sciPD33 earth1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Earth Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 earth2",
+        "script_level.level_keys": [
+          "sciPD33 earth2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "Earth Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "challenges sample 3",
+        "script_level.level_keys": [
+          "challenges sample 3"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "challenges sample 4",
+        "script_level.level_keys": [
+          "challenges sample 4"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "challenges sample 5",
+        "script_level.level_keys": [
+          "challenges sample 5"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "Life Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "challenges sample 6",
+        "script_level.level_keys": [
+          "challenges sample 6"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Physical Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "challenges sample 7",
+        "script_level.level_keys": [
+          "challenges sample 7"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Physical Science Challenges",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 thanks",
+        "script_level.level_keys": [
+          "sciPD33 thanks"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "sciPD33 end",
+        "script_level.level_keys": [
+          "sciPD33 end"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 2,
+        "lesson.key": "Wrap-Up",
+        "lesson_group.key": "",
+        "script.name": "sciencepd5"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sconyers.script_json
+++ b/dashboard/config/scripts_json/sconyers.script_json
@@ -1,0 +1,1113 @@
+{
+  "script": {
+    "name": "sconyers",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "project_widget_types": [
+        "applab"
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sconyers"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Digital Design",
+      "name": "Digital Design",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "key": "Linking Screens",
+      "name": "Linking Screens",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "key": "Test Lesson",
+      "name": "Test Lesson",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Test Lesson",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4L12 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 Design Mode Map_2018"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSDU4 Design Mode Video_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 2_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 3_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Build a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 4_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 Design Elements Map_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 5_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 6_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 6_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Finish a Screen"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Design 7_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Design 7_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "Design a Screen for your App_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": true,
+      "properties": {
+        "progression": "App Project: Screen Design"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 - Design Mode Project_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4L13 autoSFLP_2018"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 Mult Screen Map_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 1_2018"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 1.5_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 Importing Screens Map_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 2_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Adding Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 2.5_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 User Input Map_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 3_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 3_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSD U4 Change Screen Map_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 4_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 4_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Linking Screens"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U4 Model Program 5_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "U4 Model Program 5_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSDU4 Project Import_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "CSDU4 Project Events_2018"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TraceySconyers_Level1_Test"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Test Lesson",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "TraceySconyers_Level1_Test"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TraceySconyers_Level2_Test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Test Lesson",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      },
+      "level_keys": [
+        "TraceySconyers_Level2_Test"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L12 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L12 autoSFLP_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Mode Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Design Mode Map_2018"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Design Mode Video_2018",
+        "script_level.level_keys": [
+          "CSDU4 Design Mode Video_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 1_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 2_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 3_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 4_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 4_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Design Elements Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Design Elements Map_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 5_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 6_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 6_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Design 7_2018",
+        "script_level.level_keys": [
+          "U4 Model Design 7_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Design a Screen for your App_2018",
+        "script_level.level_keys": [
+          "Design a Screen for your App_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 - Design Mode Project_2018",
+        "script_level.level_keys": [
+          "CSD U4 - Design Mode Project_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Digital Design",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4L13 autoSFLP_2018",
+        "script_level.level_keys": [
+          "CSD U4L13 autoSFLP_2018"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Mult Screen Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Mult Screen Map_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 1_2018"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 1.5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 1.5_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Importing Screens Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Importing Screens Map_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 2.5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 2.5_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 User Input Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 User Input Map_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 3_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 3_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U4 Change Screen Map_2018",
+        "script_level.level_keys": [
+          "CSD U4 Change Screen Map_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 4_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 4_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 11,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U4 Model Program 5_2018",
+        "script_level.level_keys": [
+          "U4 Model Program 5_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 12,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Import_2018",
+        "script_level.level_keys": [
+          "CSDU4 Project Import_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 13,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU4 Project Events_2018",
+        "script_level.level_keys": [
+          "CSDU4 Project Events_2018"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 14,
+        "lesson.key": "Linking Screens",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TraceySconyers_Level1_Test",
+        "script_level.level_keys": [
+          "TraceySconyers_Level1_Test"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Test Lesson",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TraceySconyers_Level2_Test",
+        "script_level.level_keys": [
+          "TraceySconyers_Level2_Test"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Test Lesson",
+        "lesson_group.key": "",
+        "script.name": "sconyers"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/sports.script_json
+++ b/dashboard/config/scripts_json/sports.script_json
@@ -1,0 +1,329 @@
+{
+  "script": {
+    "name": "sports",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "tts": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "sports"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sports",
+      "name": "Sports",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_1_sports"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_1_sports"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_2_sports"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_2_sports"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_5_sports"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_5_sports"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_6_sports"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_6_sports"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_7_sports"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_7_sports"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_10_sports"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_10_sports"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_11_sports"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_11_sports"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "bounce_12_sports"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      },
+      "level_keys": [
+        "bounce_12_sports"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "bounce_1_sports",
+        "script_level.level_keys": [
+          "bounce_1_sports"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_2_sports",
+        "script_level.level_keys": [
+          "bounce_2_sports"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_5_sports",
+        "script_level.level_keys": [
+          "bounce_5_sports"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_6_sports",
+        "script_level.level_keys": [
+          "bounce_6_sports"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_7_sports",
+        "script_level.level_keys": [
+          "bounce_7_sports"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_10_sports",
+        "script_level.level_keys": [
+          "bounce_10_sports"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_11_sports",
+        "script_level.level_keys": [
+          "bounce_11_sports"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "bounce_12_sports",
+        "script_level.level_keys": [
+          "bounce_12_sports"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sports",
+        "lesson_group.key": "",
+        "script.name": "sports"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/spritelab-ee.script_json
+++ b/dashboard/config/scripts_json/spritelab-ee.script_json
@@ -1,0 +1,846 @@
+{
+  "script": {
+    "name": "spritelab-ee",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "spritelab-ee"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Fish Tank - Creating Sprites",
+      "name": "Fish Tank - Creating Sprites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "key": "Alien Dance Party - Input",
+      "name": "Alien Dance Party - Input",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "key": "Virtual Pet - Interactions",
+      "name": "Virtual Pet - Interactions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_simple"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_simple"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_simple"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_simple"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_simple"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_simple"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_simple"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_simple"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_simple"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_simple"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_simple"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_simple"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_simple"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_simple"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_simple"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_simple"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 2_simple"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_simple"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 3_simple"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_simple"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 4_simple"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_simple"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 5_simple"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_simple"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 6_simple"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_simple"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party 7_simple"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_simple"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_simple"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_simple"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 1_simple"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_simple"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 2_simple"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_simple"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 3_simple"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_simple"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 4_simple"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_simple"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 5_simple"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_simple"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet 6_simple"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay_simple"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay_simple"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_simple"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_simple"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_simple"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_simple"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_simple"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_simple"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_simple",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_simple"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_simple",
+        "script_level.level_keys": [
+          "Dance Party 2_simple"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_simple",
+        "script_level.level_keys": [
+          "Dance Party 3_simple"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_simple",
+        "script_level.level_keys": [
+          "Dance Party 4_simple"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_simple",
+        "script_level.level_keys": [
+          "Dance Party 5_simple"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_simple",
+        "script_level.level_keys": [
+          "Dance Party 6_simple"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_simple",
+        "script_level.level_keys": [
+          "Dance Party 7_simple"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_simple",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_simple"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 1_simple"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 2_simple"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 3_simple"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 4_simple"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 5_simple"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 6_simple"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay_simple",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay_simple"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-ee"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/spritelab-simple.script_json
+++ b/dashboard/config/scripts_json/spritelab-simple.script_json
@@ -1,0 +1,846 @@
+{
+  "script": {
+    "name": "spritelab-simple",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "spritelab-simple"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Fish Tank - Creating Sprites",
+      "name": "Fish Tank - Creating Sprites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "key": "Alien Dance Party - Input",
+      "name": "Alien Dance Party - Input",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "key": "Virtual Pet - Interactions",
+      "name": "Virtual Pet - Interactions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_simple"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_simple"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_simple"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_simple"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_simple"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_simple"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_simple"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_simple"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_simple"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_simple"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_simple"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_simple"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_simple"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_simple"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_simple"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_simple"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 2_simple"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_simple"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 3_simple"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_simple"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 4_simple"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_simple"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 5_simple"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_simple"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 6_simple"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_simple"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party 7_simple"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_simple"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_simple"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1_simple"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 1_simple"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2_simple"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 2_simple"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3_simple"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 3_simple"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4_simple"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 4_simple"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5_simple"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 5_simple"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6_simple"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet 6_simple"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay_simple"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay_simple"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_simple"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_simple"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_simple"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_simple"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_simple"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_simple"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_simple",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_simple"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_simple",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_simple"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_simple",
+        "script_level.level_keys": [
+          "Dance Party 2_simple"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_simple",
+        "script_level.level_keys": [
+          "Dance Party 3_simple"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_simple",
+        "script_level.level_keys": [
+          "Dance Party 4_simple"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_simple",
+        "script_level.level_keys": [
+          "Dance Party 5_simple"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_simple",
+        "script_level.level_keys": [
+          "Dance Party 6_simple"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_simple",
+        "script_level.level_keys": [
+          "Dance Party 7_simple"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_simple",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_simple"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 1_simple"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 2_simple"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 3_simple"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 4_simple"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 5_simple"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6_simple",
+        "script_level.level_keys": [
+          "Virtual Pet 6_simple"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay_simple",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay_simple"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-simple"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/spritelab-validated.script_json
+++ b/dashboard/config/scripts_json/spritelab-validated.script_json
@@ -1,0 +1,846 @@
+{
+  "script": {
+    "name": "spritelab-validated",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "spritelab-validated"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Fish Tank - Creating Sprites",
+      "name": "Fish Tank - Creating Sprites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "key": "Alien Dance Party - Input",
+      "name": "Alien Dance Party - Input",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "key": "Virtual Pet - Interactions",
+      "name": "Virtual Pet - Interactions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1-validated"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 1-validated"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1-validated",
+        "script_level.level_keys": [
+          "Virtual Pet 1-validated"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab-validated"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/spritelab.script_json
+++ b/dashboard/config/scripts_json/spritelab.script_json
@@ -1,0 +1,855 @@
+{
+  "script": {
+    "name": "spritelab",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "announcements": [
+        {
+          "notice": "This Progression is No Longer Supported",
+          "details": "The standalone Sprite Lab progression is no longer supported by Code.org. We recommend you click \"Learn More\" to try the Express course.",
+          "link": "https://studio.code.org/s/express",
+          "type": "failure",
+          "visibility": "Teacher and student"
+        }
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "spritelab"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Fish Tank - Creating Sprites",
+      "name": "Fish Tank - Creating Sprites",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "key": "Alien Dance Party - Input",
+      "name": "Alien Dance Party - Input",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "key": "Virtual Pet - Interactions",
+      "name": "Virtual Pet - Interactions",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Fish Tank - Creating Sprites",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party - Input",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Virtual Pet - Interactions",
+        "lesson_group.key": "",
+        "script.name": "spritelab"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/starwars.script_json
+++ b/dashboard/config/scripts_json/starwars.script_json
@@ -1,0 +1,573 @@
+{
+  "script": {
+    "name": "starwars",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "starwars"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Hour of Code 2015",
+      "name": "Hour of Code 2015",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_right"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_right"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_right_down"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_right_down"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_backtrack"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_backtrack"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_diagonal"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_diagonal"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_around"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_around"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_finale"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_move_finale"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_two_items"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_event_two_items"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_four_items"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_event_four_items"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_score"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_score"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_win_lose"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_win_lose"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_add_characters"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_add_characters"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_chain_characters"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_chain_characters"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_multiply_characters"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_multiply_characters"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_change_setting"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_change_setting"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_free"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      },
+      "level_keys": [
+        "blockly:StudioEC:js_hoc2015_event_free"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_right",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_right"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_right_down",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_right_down"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_backtrack",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_backtrack"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_diagonal",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_diagonal"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_around",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_around"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_move_finale",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_move_finale"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_event_two_items",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_two_items"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_event_four_items",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_four_items"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_score",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_score"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_win_lose",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_win_lose"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_add_characters",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_add_characters"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_chain_characters",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_chain_characters"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_multiply_characters",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_multiply_characters"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_change_setting",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_change_setting"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:StudioEC:js_hoc2015_event_free",
+        "script_level.level_keys": [
+          "blockly:StudioEC:js_hoc2015_event_free"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwars"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/starwarsblocks.script_json
+++ b/dashboard/config/scripts_json/starwarsblocks.script_json
@@ -1,0 +1,573 @@
+{
+  "script": {
+    "name": "starwarsblocks",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "starwarsblocks"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Hour of Code 2015",
+      "name": "Hour of Code 2015",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_1",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_2",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_3",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_4",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_5",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_6",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Hour of Code 2015",
+        "lesson_group.key": "",
+        "script.name": "starwarsblocks"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/step.script_json
+++ b/dashboard/config/scripts_json/step.script_json
@@ -1,0 +1,258 @@
+{
+  "script": {
+    "name": "step",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "step"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Step",
+      "name": "Step",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_1_step"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:2_1_step"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_2_step"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:2_2_step"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_17_step"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:2_17_step"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_1_9_step"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:karel_1_9_step"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_2_9_step"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:karel_2_9_step"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_bee_1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      },
+      "level_keys": [
+        "blockly:MazeStep:karel_bee_1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:2_1_step",
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_1_step"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:2_2_step",
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_2_step"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:2_17_step",
+        "script_level.level_keys": [
+          "blockly:MazeStep:2_17_step"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:karel_1_9_step",
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_1_9_step"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:karel_2_9_step",
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_2_9_step"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:MazeStep:karel_bee_1",
+        "script_level.level_keys": [
+          "blockly:MazeStep:karel_bee_1"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Step",
+        "lesson_group.key": "",
+        "script.name": "step"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/subgoal-labels-opt-in.script_json
+++ b/dashboard/config/scripts_json/subgoal-labels-opt-in.script_json
@@ -1,0 +1,84 @@
+{
+  "script": {
+    "name": "subgoal-labels-opt-in",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "subgoal-labels-opt-in"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "subgoal-labels-opt-in"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Subgoal Labels Study Opt-In",
+      "name": "Subgoal Labels Study Opt-In",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Subgoal Labels Study Opt-In",
+        "lesson_group.key": "",
+        "script.name": "subgoal-labels-opt-in"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Click here to participate in the subgoal labels study"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_subgoal_labels_consent_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Subgoal Labels Study Opt-In",
+        "lesson_group.key": "",
+        "script.name": "subgoal-labels-opt-in"
+      },
+      "level_keys": [
+        "csp_subgoal_labels_consent_intro"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp_subgoal_labels_consent_intro",
+        "script_level.level_keys": [
+          "csp_subgoal_labels_consent_intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Subgoal Labels Study Opt-In",
+        "lesson_group.key": "",
+        "script.name": "subgoal-labels-opt-in"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/subgoals-assessment-staging.script_json
+++ b/dashboard/config/scripts_json/subgoals-assessment-staging.script_json
@@ -1,0 +1,829 @@
+{
+  "script": {
+    "name": "subgoals-assessment-staging",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "subgoals-assessment-staging"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "all assessment items as standalone assessment levels",
+      "name": "all assessment items as standalone assessment levels",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "key": "submittable if last assessment item",
+      "name": "submittable if last assessment item",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "key": "dummy",
+      "name": "dummy",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "dummy",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "key": "assessment sandwiched between app lab levels",
+      "name": "assessment sandwiched between app lab levels",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "key": "all assessment items clustered in levelgroup as a single \"test\"",
+      "name": "all assessment items clustered in levelgroup as a single \"test\"",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "all assessment items clustered in levelgroup as a single \"test\"",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "key": "CSP 3 updates staging ground",
+      "name": "CSP 3 updates staging ground",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_plan_code_FR"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q1_mc"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q1_mc"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q2_mc"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q2_mc"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q3_mc"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_subgoal_q4_mc"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "subgoals_U3_turtle_prediction_FR"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "subgoals_u3_top_down_FR"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Some app lab progression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "U3L03 Three Steps"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Some app lab progression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "U3L03 draw diamond"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q1_mc"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_turtle_subgoal_q1_mc"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for understanding"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp3_U3_turtle_subgoal_mc_levelgroup"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+        "progression": "Check for understanding (diff between 3 and 4)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoals_assessement_levelgroup_test2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "dummy",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "subgoals_assessement_levelgroup_test2"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Some app lab progression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "U3L03 Draw a T using turnAround"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": true,
+      "properties": {
+        "progression": "Some app lab progression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "csp_U3_square_v_rect_FR"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Some app lab progression"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "U3L03 define turnRight and draw a rectangle"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "subgoal_assessments_levelgroup_test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "all assessment items clustered in levelgroup as a single \"test\"",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "subgoal_assessments_levelgroup_test"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson 5.6 - (new) Abstraction in Programming"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "SG CSP Abstraction in Programming 2"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson 8.8 - (new) What is a comment?"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "SG U3 whats a comment"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson 8.9 - How to add comments - Review for instructions and starting code"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      },
+      "level_keys": [
+        "SG U3L08 how to add comments"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_plan_code_FR",
+        "script_level.level_keys": [
+          "csp_U3_plan_code_FR"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q1_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q1_mc"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q2_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q2_mc"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q3_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q3_mc"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_subgoal_q4_mc",
+        "script_level.level_keys": [
+          "csp_U3_subgoal_q4_mc"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_U3_turtle_prediction_FR",
+        "script_level.level_keys": [
+          "subgoals_U3_turtle_prediction_FR"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_u3_top_down_FR",
+        "script_level.level_keys": [
+          "subgoals_u3_top_down_FR"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "all assessment items as standalone assessment levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Three Steps",
+        "script_level.level_keys": [
+          "U3L03 Three Steps"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 draw diamond",
+        "script_level.level_keys": [
+          "U3L03 draw diamond"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_turtle_subgoal_q1_mc",
+        "script_level.level_keys": [
+          "csp_U3_turtle_subgoal_q1_mc"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp3_U3_turtle_subgoal_mc_levelgroup",
+        "script_level.level_keys": [
+          "csp3_U3_turtle_subgoal_mc_levelgroup"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "submittable if last assessment item",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoals_assessement_levelgroup_test2",
+        "script_level.level_keys": [
+          "subgoals_assessement_levelgroup_test2"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "dummy",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 Draw a T using turnAround",
+        "script_level.level_keys": [
+          "U3L03 Draw a T using turnAround"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "csp_U3_square_v_rect_FR",
+        "script_level.level_keys": [
+          "csp_U3_square_v_rect_FR"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3L03 define turnRight and draw a rectangle",
+        "script_level.level_keys": [
+          "U3L03 define turnRight and draw a rectangle"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "assessment sandwiched between app lab levels",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "subgoal_assessments_levelgroup_test",
+        "script_level.level_keys": [
+          "subgoal_assessments_levelgroup_test"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "all assessment items clustered in levelgroup as a single \"test\"",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG CSP Abstraction in Programming 2",
+        "script_level.level_keys": [
+          "SG CSP Abstraction in Programming 2"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3 whats a comment",
+        "script_level.level_keys": [
+          "SG U3 whats a comment"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SG U3L08 how to add comments",
+        "script_level.level_keys": [
+          "SG U3L08 how to add comments"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "CSP 3 updates staging ground",
+        "lesson_group.key": "",
+        "script.name": "subgoals-assessment-staging"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/teachercon.script_json
+++ b/dashboard/config/scripts_json/teachercon.script_json
@@ -1,0 +1,1431 @@
+{
+  "script": {
+    "name": "teachercon",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "teachercon"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to Teachercon",
+      "name": "Introduction to Teachercon",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 1,4",
+      "name": "Lesson 1.4: Number Systems (Circle Triangle Square)",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 1,6",
+      "name": "Lesson 1.6: Sending Numbers",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 1,9",
+      "name": "Lesson 1.9: Internet Addressing (Battleship)",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 1,10",
+      "name": "Lesson 1.10: Routers and Redundancy",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 1,11",
+      "name": "Lesson 1.11: Packets and Making a Reliable Internet",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 2,2",
+      "name": "Lesson 2.2: Text Compression",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 2,3",
+      "name": "Lesson 2.3: Black and White Pixelation",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Lesson 2,10",
+      "name": "Lesson 2.10: Good and Bad Data Visualizations",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Group Work and Peer Learning",
+      "name": "Group Work and Peer Learning",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Balancing Teachers and Tools",
+      "name": "Balancing Teachers and Tools",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Discovery Learning",
+      "name": "Discovery Learning",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "key": "Measuring Student Learning",
+      "name": "Measuring Student Learning",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Welcome to TeacherCon!"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Welcome to TeacherCon!"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TeacherCon Agenda"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "TeacherCon Agenda"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "TeacherCon Self-Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "TeacherCon Self-Assessment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L4 Lesson Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U1L4 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L6 Lesson Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U1L6 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L9 Lesson Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U1L9 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L10 Lesson Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U1L10 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L11 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U1L11 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L2 Lesson Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U2L2 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L3 Lesson Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U2L3 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U2L10 Lesson Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "U2L10 Lesson Overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Overview: Group Work and Peer Learning"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Collaborative Learning and Group Work: Description and Strategies"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "The Official Peer Instruction Blog"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "the Journal of Peer Learning"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tuesday Report: Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Tuesday Report: Group Work and Peer Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Wednesday Report: Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Wednesday Report: Group Work and Peer Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Overview: Balancing Teachers and Tools"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tuesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Tuesday Report: Balancing Teachers and Tools in Unit 1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Overview: Discovery Learning"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Discovery learning definition and history"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Discovery learning techniques"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tuesday Report: Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Tuesday Report: Discovery Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Wednesday Report: Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Wednesday Report: Discovery Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Exploring Practices and Strategies during TeacherCon"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Overview: Capturing Student Learning"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "What is the difference between formative and summative assessment?"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Classroom Assessment Techniques"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Tuesday Report: Measuring Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Tuesday Report: Measuring Student Learning in Unit 1"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Wednesday Report: Measuring Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      },
+      "level_keys": [
+        "Wednesday Report: Measuring Student Learning in Unit 1"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Welcome to TeacherCon!",
+        "script_level.level_keys": [
+          "Welcome to TeacherCon!"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TeacherCon Agenda",
+        "script_level.level_keys": [
+          "TeacherCon Agenda"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "TeacherCon Self-Assessment",
+        "script_level.level_keys": [
+          "TeacherCon Self-Assessment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to Teachercon",
+        "lesson_group.key": "required",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L4 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L4 Lesson Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,4",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L6 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L6 Lesson Overview"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,6",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L9 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L9 Lesson Overview"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,9",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L10 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L10 Lesson Overview"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U1L11 Lesson Overview",
+        "script_level.level_keys": [
+          "U1L11 Lesson Overview"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 1,11",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L2 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L2 Lesson Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,2",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L3 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L3 Lesson Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,3",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U2L10 Lesson Overview",
+        "script_level.level_keys": [
+          "U2L10 Lesson Overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Lesson 2,10",
+        "lesson_group.key": "content",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Group Work and Peer Learning",
+        "script_level.level_keys": [
+          "Overview: Group Work and Peer Learning"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 2,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Collaborative Learning and Group Work: Description and Strategies",
+        "script_level.level_keys": [
+          "Collaborative Learning and Group Work: Description and Strategies"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 3,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "The Official Peer Instruction Blog",
+        "script_level.level_keys": [
+          "The Official Peer Instruction Blog"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 4,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "the Journal of Peer Learning",
+        "script_level.level_keys": [
+          "the Journal of Peer Learning"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 5,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tuesday Report: Group Work and Peer Learning in Unit 1",
+        "script_level.level_keys": [
+          "Tuesday Report: Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 6,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Wednesday Report: Group Work and Peer Learning in Unit 1",
+        "script_level.level_keys": [
+          "Wednesday Report: Group Work and Peer Learning in Unit 1"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 7,
+        "lesson.key": "Group Work and Peer Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Balancing Teachers and Tools",
+        "script_level.level_keys": [
+          "Overview: Balancing Teachers and Tools"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tuesday Report: Balancing Teachers and Tools in Unit 1",
+        "script_level.level_keys": [
+          "Tuesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 3,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Wednesday Report: Balancing Teachers and Tools in Unit 1",
+        "script_level.level_keys": [
+          "Wednesday Report: Balancing Teachers and Tools in Unit 1"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 4,
+        "lesson.key": "Balancing Teachers and Tools",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Discovery Learning",
+        "script_level.level_keys": [
+          "Overview: Discovery Learning"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 2,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning definition and history",
+        "script_level.level_keys": [
+          "Discovery learning definition and history"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 3,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Discovery learning techniques",
+        "script_level.level_keys": [
+          "Discovery learning techniques"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 4,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tuesday Report: Discovery Learning in Unit 1",
+        "script_level.level_keys": [
+          "Tuesday Report: Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 5,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Wednesday Report: Discovery Learning in Unit 1",
+        "script_level.level_keys": [
+          "Wednesday Report: Discovery Learning in Unit 1"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 6,
+        "lesson.key": "Discovery Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Exploring Practices and Strategies during TeacherCon",
+        "script_level.level_keys": [
+          "Exploring Practices and Strategies during TeacherCon"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Overview: Capturing Student Learning",
+        "script_level.level_keys": [
+          "Overview: Capturing Student Learning"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "What is the difference between formative and summative assessment?",
+        "script_level.level_keys": [
+          "What is the difference between formative and summative assessment?"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Classroom Assessment Techniques",
+        "script_level.level_keys": [
+          "Classroom Assessment Techniques"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Tuesday Report: Measuring Student Learning in Unit 1",
+        "script_level.level_keys": [
+          "Tuesday Report: Measuring Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Wednesday Report: Measuring Student Learning in Unit 1",
+        "script_level.level_keys": [
+          "Wednesday Report: Measuring Student Learning in Unit 1"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Measuring Student Learning",
+        "lesson_group.key": "practice",
+        "script.name": "teachercon"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/test-teaching-ap-cs-unit-1.script_json
+++ b/dashboard/config/scripts_json/test-teaching-ap-cs-unit-1.script_json
@@ -1,0 +1,857 @@
+{
+  "script": {
+    "name": "test-teaching-ap-cs-unit-1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "test-teaching-ap-cs-unit-1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "required",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Overview"
+      },
+      "seeding_key": {
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "practice",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Teaching Practices"
+      },
+      "seeding_key": {
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "test Unit 1 required reading",
+      "name": "test Unit 1 required reading",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 content module Alpha",
+      "name": "test Unit 1 content module Alpha",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 content module Bravo",
+      "name": "test Unit 1 content module Bravo",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 content module Charlie",
+      "name": "test Unit 1 content module Charlie",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 practice module Delta",
+      "name": "test Unit 1 practice module Delta",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 practice module Echo",
+      "name": "test Unit 1 practice module Echo",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "key": "test Unit 1 practice module Foxtrot",
+      "name": "test Unit 1 practice module Foxtrot",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "test Unit 1 practice module Foxtrot",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD Welcome Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD Welcome Video"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "PDECS tour"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "PDECS commitment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 1 lessons"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PIvideo"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 PIvideo"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 lessons"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2 lessons"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 reflection"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 2 reflection"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 3"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 lessons"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 3 lessons"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 share protocol"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 share protocol"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 lessons"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 chunk 4 lessons"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 share compression"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 share compression"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 PT"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT activity"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 PT activity"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 PT forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 PT forum"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Foxtrot",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 congrats"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSPPD2 next step announcements"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Foxtrot",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      },
+      "level_keys": [
+        "CSPPD2 next step announcements"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSPPD Welcome Video",
+        "script_level.level_keys": [
+          "CSPPD Welcome Video"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS tour",
+        "script_level.level_keys": [
+          "PDECS tour"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PDECS commitment",
+        "script_level.level_keys": [
+          "PDECS commitment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 required reading",
+        "lesson_group.key": "required",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 1",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 1 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 1 lessons"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PIvideo",
+        "script_level.level_keys": [
+          "CSPPD2 PIvideo"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Alpha",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 lessons"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 2 reflection",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 2 reflection"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Bravo",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 3",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 3 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 3 lessons"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 share protocol",
+        "script_level.level_keys": [
+          "CSPPD2 share protocol"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 content module Charlie",
+        "lesson_group.key": "content",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 4",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 chunk 4 lessons",
+        "script_level.level_keys": [
+          "CSPPD2 chunk 4 lessons"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 share compression",
+        "script_level.level_keys": [
+          "CSPPD2 share compression"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 practice module Delta",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT",
+        "script_level.level_keys": [
+          "CSPPD2 PT"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT activity",
+        "script_level.level_keys": [
+          "CSPPD2 PT activity"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 PT forum",
+        "script_level.level_keys": [
+          "CSPPD2 PT forum"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "test Unit 1 practice module Echo",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 congrats",
+        "script_level.level_keys": [
+          "CSPPD2 congrats"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "test Unit 1 practice module Foxtrot",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSPPD2 next step announcements",
+        "script_level.level_keys": [
+          "CSPPD2 next step announcements"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 2,
+        "lesson.key": "test Unit 1 practice module Foxtrot",
+        "lesson_group.key": "practice",
+        "script.name": "test-teaching-ap-cs-unit-1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/text-compression.script_json
+++ b/dashboard/config/scripts_json/text-compression.script_json
@@ -1,0 +1,119 @@
+{
+  "script": {
+    "name": "text-compression",
+    "wrapup_video_id": null,
+    "hidden": false,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "text-compression"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Text Compression",
+      "name": "Text Compression",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Text Compression"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      },
+      "level_keys": [
+        "Text Compression"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      },
+      "level_keys": [
+        "Widget: Text Compression"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Text Compression",
+        "script_level.level_keys": [
+          "Text Compression"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Widget: Text Compression",
+        "script_level.level_keys": [
+          "Widget: Text Compression"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Text Compression",
+        "lesson_group.key": "",
+        "script.name": "text-compression"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/textbook.script_json
+++ b/dashboard/config/scripts_json/textbook.script_json
@@ -1,0 +1,188 @@
+{
+  "script": {
+    "name": "textbook",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "textbook"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "new stage",
+      "name": "new stage",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Test Map Level"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      },
+      "level_keys": [
+        "Test Map Level"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "e_textbook_nested_loops_wrapup"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      },
+      "level_keys": [
+        "e_textbook_nested_loops_wrapup"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_bee_seq1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      },
+      "level_keys": [
+        "courseA_bee_seq1"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseA_bee_seq2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      },
+      "level_keys": [
+        "courseA_bee_seq2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Test Map Level",
+        "script_level.level_keys": [
+          "Test Map Level"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "e_textbook_nested_loops_wrapup",
+        "script_level.level_keys": [
+          "e_textbook_nested_loops_wrapup"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_bee_seq1",
+        "script_level.level_keys": [
+          "courseA_bee_seq1"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseA_bee_seq2",
+        "script_level.level_keys": [
+          "courseA_bee_seq2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "new stage",
+        "lesson_group.key": "",
+        "script.name": "textbook"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/time4cs-control-unit-1.script_json
+++ b/dashboard/config/scripts_json/time4cs-control-unit-1.script_json
@@ -1,0 +1,3530 @@
+{
+  "script": {
+    "name": "time4cs-control-unit-1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "pilot_experiment": "time4cs-control",
+      "editor_experiment": "broward"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "time4cs-control-unit-1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 8,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sequencing in Maze",
+      "name": "Sequencing in Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Programming and Loops with the Artist",
+      "name": "Programming and Loops with the Artist",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Simon Says",
+      "name": "Simon Says",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprites with Sprite Lab",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "About Me",
+      "name": "About Me",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Access Ability",
+      "name": "Access Ability",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals Review",
+      "name": "Conditionals Review",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_control"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_control"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_control"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_control"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_control"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_control"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_control"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_control"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_control"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_video_debugging_control"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_control"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_control"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_control"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_control"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_control"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_control"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_control"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_control"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_control"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_control"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_control"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_control"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_control"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_control"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_control"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_video_artist_control"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_control"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_control"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_control"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_control"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_control"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_control"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_control"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_control"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_control"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_control"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_control"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_control"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_control"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_control"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_control"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_control"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_control"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_control"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_control"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_control"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_control"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_control"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_control"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_control"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_control"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1_control"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_control"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2_control"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_control"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3_control"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_control"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4_control"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_control"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5_control"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_control"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6_control"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_control"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a_control"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_control"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8_control"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_control"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b_control"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_control"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10_control"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_control"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11_control"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_control"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_control"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_control"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_control"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_control"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_control"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_control"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_control"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_control"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_control"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_control"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_control"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_control"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_control"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_control"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_control"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_control"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_control"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_control"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_control"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_control"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_control"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_control"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_control"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_control"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_control"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_control"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "BigEvent-Unplugged_control"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_control"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "SimonSays-Unplugged_control"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_control"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_control"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_control"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_control"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_control"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_control"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_control"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_control"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_control"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_control"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_control"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_control"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_control"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_control"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_control"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_control"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_control"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_control"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_control"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_control"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_control"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_control"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_control"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 2_control"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_control"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 3_control"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_control"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 4_control"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_control"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 5_control"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_control"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 6_control"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_control"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 7_control"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_control"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_control"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_control"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "PrivatePersonalInformation-Unplugged_control"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_1_control"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_1_control"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_2_control"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_2_control"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_3_control"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_3_control"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_4_control"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_4_control"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_5_control"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_5_control"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_6_control"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_6_control"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_control"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "DesigningForAccessibilityMarkdownLevel_2019_control"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_control"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_control"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_control"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_control"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_control"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_control"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_control"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_control"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_control"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_control"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_control"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_control"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_control"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_control"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_control"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_control"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_control"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_control"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_control"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_control"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_control"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_control"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_control"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_control"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_control"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_control"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_control",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_control"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_control",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_control"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_control",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_control"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_control",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_control"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_control",
+        "script_level.level_keys": [
+          "courseC_video_debugging_control"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_control",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_control"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_control",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_control"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_control",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_control"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_control",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_control"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_control",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_control"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_control",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_control"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_control",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_control"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_control",
+        "script_level.level_keys": [
+          "courseC_video_artist_control"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_control"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_control"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_control",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_control"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_control"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_control"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_control"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_control",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_control"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_control",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_control"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_control",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_control"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_control",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_control"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_control"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_control",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_control"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_control"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_control"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_control"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_control"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_control"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_control"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_control"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_control"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_control"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_control"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11_control",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_control"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_control",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_control"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_control",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_control"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_control"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_control"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_control"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_control"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_control",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_control"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_control"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_control"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_control"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_control",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_control"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_control"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_control"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent-Unplugged_control",
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_control"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SimonSays-Unplugged_control",
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_control"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_control",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_control"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_control"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_control"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_control"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_control"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_control",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_control"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_control"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_control"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_control",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_control"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_control",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_control"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_control",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_control"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_control",
+        "script_level.level_keys": [
+          "Dance Party 2_control"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_control",
+        "script_level.level_keys": [
+          "Dance Party 3_control"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_control",
+        "script_level.level_keys": [
+          "Dance Party 4_control"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_control",
+        "script_level.level_keys": [
+          "Dance Party 5_control"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_control",
+        "script_level.level_keys": [
+          "Dance Party 6_control"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_control",
+        "script_level.level_keys": [
+          "Dance Party 7_control"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_control",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_control"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PrivatePersonalInformation-Unplugged_control",
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_control"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_1_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_1_control"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_2_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_2_control"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_3_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_3_control"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_4_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_4_control"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_5_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_5_control"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_6_control",
+        "script_level.level_keys": [
+          "courseE_aboutme_6_control"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesigningForAccessibilityMarkdownLevel_2019_control",
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_control"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_control",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_control"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_control",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_control"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_control"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_control"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_control"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_control"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_control",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_control"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_control"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_control"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_control"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_control",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_control"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_control"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_control",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_control"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-control-unit-1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/time4cs-control-unit-2.script_json
+++ b/dashboard/config/scripts_json/time4cs-control-unit-2.script_json
@@ -1,0 +1,3317 @@
+{
+  "script": {
+    "name": "time4cs-control-unit-2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "editor_experiment": "broward"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "time4cs-control-unit-2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "csf_nested_loops",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Nested Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "csf_functions",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Functions"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "end_of_course_project",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "End of Course Project"
+      },
+      "seeding_key": {
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee",
+      "name": "Nested Loops in Bee",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Nested Loops in Artist",
+      "name": "Nested Loops in Artist",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Nested Loops in Frozen",
+      "name": "Nested Loops in Frozen",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions in Harvester",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "key": "End of Course Project",
+      "name": "End of Course Project",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Crowdsourcing-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "Crowdsourcing-Unplugged"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "ConditionalsWithCards-Unplugged"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Nested Loops with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2019"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2019"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_harvester_nested_loops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_collector_nested_loops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1_2019"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops1a_2019"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoopsArtist_2019"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops2_2019"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops3_2019"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops4_2019"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops5_2019"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops7_2019"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops8_2019"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_2019"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops10_2019"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops9_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoopsFP_2019"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_nestedLoops_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2019"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2019"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2019"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2019"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #1"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2019"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2019"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2019"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2019"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Snowflake #2"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2019"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Songwriting-Unplugged"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "Songwriting-Unplugged"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2019"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2019"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2019"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2019"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2019"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2019"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Create a Simple Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2019"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2019"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2019"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2019"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2019"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2019"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2019"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2019"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2019"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2019"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2019"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2019"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2019"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2019"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2019"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2019"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2019"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2019"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Example Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "courseE_project_exemplars_2019"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sprite Lab Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "CourseE_Project_SpriteLab_2019"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Project"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course E: Artist Project_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      },
+      "level_keys": [
+        "Course E: Artist Project_2019"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Crowdsourcing-Unplugged",
+        "script_level.level_keys": [
+          "Crowdsourcing-Unplugged"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ConditionalsWithCards-Unplugged",
+        "script_level.level_keys": [
+          "ConditionalsWithCards-Unplugged"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2019"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2019"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2019",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2019"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2019",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2019"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_harvester_nested_loops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_harvester_nested_loops_challenge1_2019"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_collector_nested_loops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_collector_nested_loops_challenge2_2019"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1_2019"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops1a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops1a_2019"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoopsArtist_2019",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoopsArtist_2019"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops2_2019"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops3_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops3_2019"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops4_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops4_2019"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops5_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops5_2019"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops7_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops7_2019"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops8_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops8_2019"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_2019"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops10_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops10_2019"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops9_predict1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops9_predict1_2019"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoopsFP_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoopsFP_2019"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge1_2019"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_nestedLoops_challenge2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_nestedLoops_challenge2_2019"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Artist",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2019"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2019"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2019"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2019"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2019"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2019"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2019"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2019"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2019",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2019"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Frozen",
+        "lesson_group.key": "csf_nested_loops",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Songwriting-Unplugged",
+        "script_level.level_keys": [
+          "Songwriting-Unplugged"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2019",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "csf_functions",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_project_exemplars_2019",
+        "script_level.level_keys": [
+          "courseE_project_exemplars_2019"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_Project_SpriteLab_2019",
+        "script_level.level_keys": [
+          "CourseE_Project_SpriteLab_2019"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 2,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course E: Artist Project_2019",
+        "script_level.level_keys": [
+          "Course E: Artist Project_2019"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 3,
+        "lesson.key": "End of Course Project",
+        "lesson_group.key": "end_of_course_project",
+        "script.name": "time4cs-control-unit-2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/time4cs-experiment-unit-1.script_json
+++ b/dashboard/config/scripts_json/time4cs-experiment-unit-1.script_json
@@ -1,0 +1,3529 @@
+{
+  "script": {
+    "name": "time4cs-experiment-unit-1",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "lesson_extras_available": true,
+      "editor_experiment": "broward"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "time4cs-experiment-unit-1"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "csf_sequencing",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Sequencing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_loops",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Loops"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_conditionals",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Conditionals"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_events",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Events"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_digcit",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Digital Citizenship"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "csf_impacts",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "Impacts of Computing"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 8,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Sequencing in Maze",
+      "name": "Sequencing in Maze",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Programming and Loops with the Artist",
+      "name": "Programming and Loops with the Artist",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals in Minecraft: Voyage Aquatic",
+      "name": "Conditionals in Minecraft: Voyage Aquatic",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals",
+      "name": "Conditionals",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Simon Says",
+      "name": "Simon Says",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprites with Sprite Lab",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Private and Personal Information",
+      "name": "Private and Personal Information",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "About Me",
+      "name": "About Me",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Access Ability",
+      "name": "Access Ability",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "key": "Conditionals Review",
+      "name": "Conditionals Review",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Maze Intro: Programming with Blocks"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_experiment"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_experiment"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_experiment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_experiment"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_experiment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_experiment"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_experiment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_experiment"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging with the Step Button"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_experiment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_video_debugging_experiment"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_experiment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_experiment"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_experiment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_experiment"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_experiment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_experiment"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_experiment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_experiment"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_experiment"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_experiment"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_experiment"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_experiment"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_experiment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_experiment"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Artist Intro with JR Hildebrande"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_experiment"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_video_artist_experiment"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_experiment"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_experiment"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_experiment"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_experiment"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Loops with the Artist"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_experiment"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_experiment"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_experiment"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_experiment"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_experiment"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_experiment"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_experiment"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_experiment"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_experiment"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_experiment"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_experiment"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_experiment"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_experiment"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_experiment"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_experiment"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_experiment"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_experiment"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_experiment"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_experiment"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_experiment"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_experiment"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_1_experiment"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_experiment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_2_experiment"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_experiment"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_3_experiment"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_4_experiment"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_experiment"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_5_experiment"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_experiment"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_6_experiment"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_experiment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_7a_experiment"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_experiment"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_8_experiment"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_experiment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_9b_experiment"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_experiment"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_10_experiment"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_experiment"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseE_HOC 2018 Level_11_experiment"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_experiment"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_experiment"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_experiment"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_experiment"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_experiment"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_experiment"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_experiment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_experiment"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_experiment"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_experiment"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_experiment"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_experiment"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_experiment"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_experiment"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_experiment"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_experiment"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_experiment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_experiment"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_experiment"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_experiment"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_experiment"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_experiment"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_experiment"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_experiment"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_experiment"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_experiment"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_experiment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "BigEvent-Unplugged_experiment"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_experiment"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "SimonSays-Unplugged_experiment"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing Sprite Lab"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_experiment"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab_experiment"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_experiment"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_experiment"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_experiment"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_experiment"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Make a Sprite"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_experiment"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite_experiment"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_experiment"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Swimming Fish (continued)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_experiment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_experiment"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated_experiment"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 1-validated_experiment"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Video"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_experiment"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction_experiment"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2_experiment"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 2_experiment"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3_experiment"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 3_experiment"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4_experiment"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 4_experiment"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Moves"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5_experiment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 5_experiment"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6_experiment"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 6_experiment"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7_experiment"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party 7_experiment"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-Project: Alien Dance Party"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay_experiment"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "Dance Party Freeplay_experiment"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_experiment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "PrivatePersonalInformation-Unplugged_experiment"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_1_experiment"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_1_experiment"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_2_experiment"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_2_experiment"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_3_experiment"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_3_experiment"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_4_experiment"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_4_experiment"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_5_experiment"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_5_experiment"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Interactive Poster"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_aboutme_6_experiment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_aboutme_6_experiment"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_experiment"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "DesigningForAccessibilityMarkdownLevel_2019_experiment"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "While Loops with the Farmer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_experiment"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_whileIntro_experiment"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_experiment"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_farmer_while4_predict1_experiment"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_experiment"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11a_experiment"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_experiment"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp11b_experiment"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_experiment"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12b_experiment"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_experiment"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12_forswap_experiment"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Repeat Unit Statements"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_experiment"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseD_video_repeatUntil_experiment"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_experiment"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12c_experiment"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_experiment"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12d_experiment"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_experiment"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12e_experiment"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "\"If/Else\" with the Bee"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_experiment"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_video_BeeifElse_experiment"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_experiment"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12f_experiment"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Updated"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_experiment"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      },
+      "level_keys": [
+        "courseE_farmer_ramp12g_experiment"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_experiment",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_experiment"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_experiment",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_experiment"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_experiment",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_experiment"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_experiment",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_experiment"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_experiment",
+        "script_level.level_keys": [
+          "courseC_video_debugging_experiment"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_experiment",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_experiment"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_experiment",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_experiment"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_experiment",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_experiment"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_experiment",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_experiment"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_experiment",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_experiment"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_experiment",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_experiment"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_experiment",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_experiment"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Sequencing in Maze",
+        "lesson_group.key": "csf_sequencing",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_experiment",
+        "script_level.level_keys": [
+          "courseC_video_artist_experiment"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_experiment"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 2,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_experiment"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 3,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_experiment",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_experiment"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 4,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_experiment"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 5,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_experiment"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 6,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_experiment"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 7,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_experiment",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_experiment"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 8,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_experiment",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_experiment"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 9,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_experiment",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_experiment"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 10,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_experiment",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_experiment"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 11,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_experiment"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 12,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_experiment",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_experiment"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 13,
+        "lesson.key": "Programming and Loops with the Artist",
+        "lesson_group.key": "csf_loops",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_1_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_1_experiment"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_2_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_2_experiment"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_3_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_3_experiment"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_4_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_4_experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_5_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_5_experiment"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_6_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_6_experiment"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_7a_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_7a_experiment"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_8_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_8_experiment"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_9b_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_9b_experiment"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_10_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_10_experiment"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseE_HOC 2018 Level_11_experiment",
+        "script_level.level_keys": [
+          "CourseE_HOC 2018 Level_11_experiment"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals in Minecraft: Voyage Aquatic",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_experiment",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_experiment"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_experiment",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_experiment"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_experiment"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_experiment"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_experiment"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_experiment"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_experiment",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_experiment"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_experiment"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_experiment"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_experiment"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_experiment",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_experiment"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_experiment"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_experiment"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent-Unplugged_experiment",
+        "script_level.level_keys": [
+          "BigEvent-Unplugged_experiment"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "csf_events",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SimonSays-Unplugged_experiment",
+        "script_level.level_keys": [
+          "SimonSays-Unplugged_experiment"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 1,
+        "lesson.key": "Simon Says",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab_experiment",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab_experiment"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated_experiment"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated_experiment"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated_experiment"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated_experiment"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite_experiment",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite_experiment"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated_experiment"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated_experiment"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated_experiment",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated_experiment"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated_experiment",
+        "script_level.level_keys": [
+          "Dance Party 1-validated_experiment"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction_experiment",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction_experiment"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2_experiment",
+        "script_level.level_keys": [
+          "Dance Party 2_experiment"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3_experiment",
+        "script_level.level_keys": [
+          "Dance Party 3_experiment"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4_experiment",
+        "script_level.level_keys": [
+          "Dance Party 4_experiment"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5_experiment",
+        "script_level.level_keys": [
+          "Dance Party 5_experiment"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6_experiment",
+        "script_level.level_keys": [
+          "Dance Party 6_experiment"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7_experiment",
+        "script_level.level_keys": [
+          "Dance Party 7_experiment"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay_experiment",
+        "script_level.level_keys": [
+          "Dance Party Freeplay_experiment"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "PrivatePersonalInformation-Unplugged_experiment",
+        "script_level.level_keys": [
+          "PrivatePersonalInformation-Unplugged_experiment"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 1,
+        "lesson.key": "Private and Personal Information",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_1_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_1_experiment"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 1,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_2_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_2_experiment"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 2,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_3_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_3_experiment"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 3,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_4_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_4_experiment"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 4,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_5_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_5_experiment"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 5,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_aboutme_6_experiment",
+        "script_level.level_keys": [
+          "courseE_aboutme_6_experiment"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 6,
+        "lesson.key": "About Me",
+        "lesson_group.key": "csf_digcit",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "DesigningForAccessibilityMarkdownLevel_2019_experiment",
+        "script_level.level_keys": [
+          "DesigningForAccessibilityMarkdownLevel_2019_experiment"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 1,
+        "lesson.key": "Access Ability",
+        "lesson_group.key": "csf_impacts",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_whileIntro_experiment",
+        "script_level.level_keys": [
+          "courseD_video_whileIntro_experiment"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_farmer_while4_predict1_experiment",
+        "script_level.level_keys": [
+          "courseD_farmer_while4_predict1_experiment"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11a_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11a_experiment"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp11b_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp11b_experiment"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12b_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12b_experiment"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12_forswap_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12_forswap_experiment"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_repeatUntil_experiment",
+        "script_level.level_keys": [
+          "courseD_video_repeatUntil_experiment"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12c_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12c_experiment"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12d_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12d_experiment"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12e_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12e_experiment"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 10,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_BeeifElse_experiment",
+        "script_level.level_keys": [
+          "courseE_video_BeeifElse_experiment"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 11,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12f_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12f_experiment"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 12,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_ramp12g_experiment",
+        "script_level.level_keys": [
+          "courseE_farmer_ramp12g_experiment"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 13,
+        "lesson.key": "Conditionals Review",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4cs-experiment-unit-1"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/time4cs-experiment-unit-2.script_json
+++ b/dashboard/config/scripts_json/time4cs-experiment-unit-2.script_json
@@ -1,0 +1,1430 @@
+{
+  "script": {
+    "name": "time4cs-experiment-unit-2",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": true,
+    "properties": {
+      "hideable_lessons": true,
+      "pilot_experiment": "time4cs-experiment",
+      "editor_experiment": "broward"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "time4cs-experiment-unit-2"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "time4cs_c1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Collection 1: The Everglades & its Ecosystems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "time4cs_c2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Collection 2: Food Chains (in the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "time4cs_c3",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Collection 3: Native Species (in the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "time4cs_c4",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Collection 4: Impact of Invasive Species (on the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "time4cs_c5",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Collection 5: Citizens Take Action"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction to the Problem",
+      "name": "Introduction to the Problem",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Crowdsourcing (Integrated lesson)",
+      "name": "Crowdsourcing (Integrated lesson)",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing (Integrated lesson)",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Everglades Habitats",
+      "name": "Everglades Habitats",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Evaluating a Project in Sprite Lab",
+      "name": "Evaluating a Project in Sprite Lab",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Evaluating a Project in Sprite Lab",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Food Chains",
+      "name": "Food Chains",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Conditionals with Cards (Integrated Lesson)- Part 1",
+      "name": "Conditionals with Cards (Integrated Lesson)- Part 1",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 1",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Alligator Holes",
+      "name": "Alligator Holes",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Food Chain Game",
+      "name": "Food Chain Game",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Food Chain Game",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Invasive Species",
+      "name": "Invasive Species",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Conditionals with Cards (Integrated Lesson)- Part 2",
+      "name": "Conditionals with Cards (Integrated Lesson)- Part 2",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 2",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "I am in Big Trouble",
+      "name": "I am in Big Trouble",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Conditionals in Sprite Lab",
+      "name": "Conditionals in Sprite Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Nested Loops in Maze",
+      "name": "Nested Loops in Maze",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Fancy Shapes using Nested Loops",
+      "name": "Fancy Shapes using Nested Loops",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fancy Shapes using Nested Loops",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Fishy Business",
+      "name": "Fishy Business",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Songwriting (Integrated Lesson)",
+      "name": "Songwriting (Integrated Lesson)",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Songwriting (Integrated Lesson)",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Functions with Harvester",
+      "name": "Functions with Harvester",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Functions with Artist",
+      "name": "Functions with Artist",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Pythons impacting native populations",
+      "name": "Pythons impacting native populations",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Functions in Sprite Lab",
+      "name": "Functions in Sprite Lab",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Python Problem- Current Solutions",
+      "name": "Python Problem- Current Solutions",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Python Problem- Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "End of Course Project (integrated- project planning lesson)",
+      "name": "End of Course Project (integrated- project planning lesson)",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "End of Course Project (integrated- project planning lesson)",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Debate- Pythons impacting native populations",
+      "name": "Debate- Pythons impacting native populations",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debate- Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "key": "Work on Project",
+      "name": "Work on Project",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Work on Project",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing (Integrated lesson)",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Crowdsourcing (Integrated lesson)",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel2"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Evaluating a Project in Sprite Lab",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 1",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Food Chain Game",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 2",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Fancy Shapes using Nested Loops",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting (Integrated Lesson)",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Python Problem- Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project (integrated- project planning lesson)",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Debate- Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Work on Project",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      },
+      "level_keys": [
+        "BrowardTestMarkdownLevel"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel2",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing (Integrated lesson)",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel2",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel2"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Crowdsourcing (Integrated lesson)",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 1,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "Evaluating a Project in Sprite Lab",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 1,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 1",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Food Chain Game",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 1,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards (Integrated Lesson)- Part 2",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 1,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Maze",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Fancy Shapes using Nested Loops",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 1,
+        "lesson.key": "Songwriting (Integrated Lesson)",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Harvester",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions with Artist",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 1,
+        "lesson.key": "Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Python Problem- Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 1,
+        "lesson.key": "End of Course Project (integrated- project planning lesson)",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 1,
+        "lesson.key": "Debate- Pythons impacting native populations",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BrowardTestMarkdownLevel",
+        "script_level.level_keys": [
+          "BrowardTestMarkdownLevel"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Work on Project",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4cs-experiment-unit-2"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/time4csdemo.script_json
+++ b/dashboard/config/scripts_json/time4csdemo.script_json
@@ -1,0 +1,10226 @@
+{
+  "script": {
+    "name": "time4csdemo",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "lesson_extras_available": true,
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "time4csdemo"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "ramp_up",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Ramp-Up"
+      },
+      "seeding_key": {
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "csf_sprites",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Sprites"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "time4cs_c1",
+      "user_facing": true,
+      "position": 3,
+      "properties": {
+        "display_name": "Collection 1: The Everglades & its Ecosystems"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "time4cs_c2",
+      "user_facing": true,
+      "position": 4,
+      "properties": {
+        "display_name": "Collection 2: Food Chains (in the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "time4cs_c3",
+      "user_facing": true,
+      "position": 5,
+      "properties": {
+        "display_name": "Collection 3: Native Species (in the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "time4cs_c4",
+      "user_facing": true,
+      "position": 6,
+      "properties": {
+        "display_name": "Collection 4: Impact of Invasive Species (on the Everglades)"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "time4cs_c5",
+      "user_facing": true,
+      "position": 7,
+      "properties": {
+        "display_name": "Collection 5: Citizens Take Action"
+      },
+      "seeding_key": {
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Programming: My Robotic Friends",
+      "name": "Programming: My Robotic Friends",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Sequence in Maze",
+      "name": "Sequence in Maze",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Building a Foundation",
+      "name": "Building a Foundation",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Debugging with Scrat",
+      "name": "Debugging with Scrat",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Programming in Artist",
+      "name": "Programming in Artist",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Loops: My Loopy Robotic Friends",
+      "name": "Loops: My Loopy Robotic Friends",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Loops in Artist",
+      "name": "Loops in Artist",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Nested Loops in Bee/Zombie",
+      "name": "Nested Loops in Bee/Zombie",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Nested Loops with Frozen",
+      "name": "Nested Loops with Frozen",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Learning Sprites with Sprite Lab",
+      "name": "Learning Sprites with Sprite Lab",
+      "absolute_position": 10,
+      "lockable": false,
+      "relative_position": 10,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Alien Dance Party with Sprite Lab",
+      "name": "Alien Dance Party with Sprite Lab",
+      "absolute_position": 11,
+      "lockable": false,
+      "relative_position": 11,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Pet Giraffe with Sprite Lab",
+      "name": "Pet Giraffe with Sprite Lab",
+      "absolute_position": 12,
+      "lockable": false,
+      "relative_position": 12,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Introduction to the Problem",
+      "name": "Introduction to the Problem",
+      "absolute_position": 13,
+      "lockable": false,
+      "relative_position": 13,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Crowdsourcing",
+      "name": "Crowdsourcing",
+      "absolute_position": 14,
+      "lockable": false,
+      "relative_position": 14,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Everglades Habitats",
+      "name": "Everglades Habitats",
+      "absolute_position": 15,
+      "lockable": false,
+      "relative_position": 15,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Reviewing Projects",
+      "name": "Reviewing Projects",
+      "absolute_position": 16,
+      "lockable": false,
+      "relative_position": 16,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Food Chains",
+      "name": "Food Chains",
+      "absolute_position": 17,
+      "lockable": false,
+      "relative_position": 17,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Conditionals with Cards",
+      "name": "Conditionals with Cards",
+      "absolute_position": 18,
+      "lockable": false,
+      "relative_position": 18,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Alligator Holes",
+      "name": "Alligator Holes",
+      "absolute_position": 19,
+      "lockable": false,
+      "relative_position": 19,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Conditionals in Sprite Lab",
+      "name": "Conditionals in Sprite Lab",
+      "absolute_position": 20,
+      "lockable": false,
+      "relative_position": 20,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Invasive Species",
+      "name": "Invasive Species",
+      "absolute_position": 21,
+      "lockable": false,
+      "relative_position": 21,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Events: The Big Event",
+      "name": "Events: The Big Event",
+      "absolute_position": 22,
+      "lockable": false,
+      "relative_position": 22,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Build a Flappy Game",
+      "name": "Build a Flappy Game",
+      "absolute_position": 23,
+      "lockable": false,
+      "relative_position": 23,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Build a Star Wars Game",
+      "name": "Build a Star Wars Game",
+      "absolute_position": 24,
+      "lockable": false,
+      "relative_position": 24,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "I am in Big Trouble",
+      "name": "I am in Big Trouble",
+      "absolute_position": 25,
+      "lockable": false,
+      "relative_position": 25,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Events in Sprite Lab",
+      "name": "Events in Sprite Lab",
+      "absolute_position": 26,
+      "lockable": false,
+      "relative_position": 26,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Fishy Business",
+      "name": "Fishy Business",
+      "absolute_position": 27,
+      "lockable": false,
+      "relative_position": 27,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Broadcast a Message",
+      "name": "Broadcast a Message",
+      "absolute_position": 28,
+      "lockable": false,
+      "relative_position": 28,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Pythons & Mammals",
+      "name": "Pythons & Mammals",
+      "absolute_position": 29,
+      "lockable": false,
+      "relative_position": 29,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Broadcast in Scratch",
+      "name": "Broadcast in Scratch",
+      "absolute_position": 30,
+      "lockable": false,
+      "relative_position": 30,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Current Solutions",
+      "name": "Current Solutions",
+      "absolute_position": 31,
+      "lockable": false,
+      "relative_position": 31,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Functions: Songwriting",
+      "name": "Functions: Songwriting",
+      "absolute_position": 32,
+      "lockable": false,
+      "relative_position": 32,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Functions in Minecraft",
+      "name": "Functions in Minecraft",
+      "absolute_position": 33,
+      "lockable": false,
+      "relative_position": 33,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Functions in Harvester",
+      "name": "Functions in Harvester",
+      "absolute_position": 34,
+      "lockable": false,
+      "relative_position": 34,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Functions in Artist",
+      "name": "Functions in Artist",
+      "absolute_position": 35,
+      "lockable": false,
+      "relative_position": 35,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Determine the Concept",
+      "name": "Determine the Concept",
+      "absolute_position": 36,
+      "lockable": false,
+      "relative_position": 36,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Debate",
+      "name": "Debate",
+      "absolute_position": 37,
+      "lockable": false,
+      "relative_position": 37,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "key": "Functions in Sprite Lab",
+      "name": "Functions in Sprite Lab",
+      "absolute_position": 38,
+      "lockable": false,
+      "relative_position": 38,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseB_unplugged_MRF_2018"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_intro"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_video_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp1_2018"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp2_2018"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp3_2018"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "comment_intro_maze_2018"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp4_2018"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5_2018"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5a_2018"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5b_2018"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5c_2018"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_ramp5d_2018"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_algorithms_end"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "BuildingAFoundation_2018"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_intro"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_video_debugging_2018"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging1_2018"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging2_2018"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging3_2018"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging4_2018"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging5_2018"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging6_2018"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging7_2018"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging8_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_maze_debugging9_2018"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_debugging_end"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_video_artist_2018"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog1_2018"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog2_2018"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog3_2018"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog4_2018"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog5_2018"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_2018"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog7_2018"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog8_2018"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 10,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog6_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_artist_prog_challenge2a_2018"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseB_unplugged_loopyMRF_2018"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_intro"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_video_artistIntro_2018"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops1_2018"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops2_2018"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_video_loopsArtist_2018"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops3_2018"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops4_2018"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops5_2018"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops6_2018"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops7_2018"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops8_2018"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "ramp_artist_loops9_2018"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_loops_end"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1a_2018"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops1_2018"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_intro"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_video_nestedLoops_2018"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_predict1_2018"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops2_2018"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops3_2018"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops4_2018"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops5_2018"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_maze_nestedLoops6_2018"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops7_2018"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops8_2018"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_2018"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 14,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_bee_nestedLoops9_predict2_2018"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseF_markdown_nestedloops_end"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project1_2018"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project2_2018"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project3_2018"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project4_2018"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project5_2018"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project1a_2018"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project2a_2018"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project3a_2018"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseD_artist_project4a_2018"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "CourseEF_video_IntroSpriteLab"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 1-validated"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 2-validated"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 3-validated"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 4-validated"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "CourseEF_video_MakeSprite"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 5-validated"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 6-validated"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Fish Tank 7-validated"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 1-validated"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 2"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "CDEF_video_SpritesInAction"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 3"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 4"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 5"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 6"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party 7"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Dance Party Freeplay"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 1"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 2"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 3"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 4"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 5"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet 6"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Virtual Pet Freeplay"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c1_1"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c1_2"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c1_3"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c1_4"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_5_journal"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c1_5_journal"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Crowdsourcing"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_crowdsourcing"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_crowdsourcing"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 113,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 114,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c3_1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c3_1"
+      ]
+    },
+    {
+      "chapter": 115,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_spritelab_1"
+      ]
+    },
+    {
+      "chapter": 116,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_spritelab_1"
+      ]
+    },
+    {
+      "chapter": 117,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_spritelab_1"
+      ]
+    },
+    {
+      "chapter": 118,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_spritelab_1"
+      ]
+    },
+    {
+      "chapter": 119,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Projects"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_spritelab_1"
+      ]
+    },
+    {
+      "chapter": 120,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Rubric"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 121,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 122,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 123,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 124,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 125,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 126,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Conditionals"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_conditionals"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_conditionals"
+      ]
+    },
+    {
+      "chapter": 127,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 128,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 129,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 130,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 131,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 132,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Engage"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_1"
+      ]
+    },
+    {
+      "chapter": 133,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_2"
+      ]
+    },
+    {
+      "chapter": 134,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_3"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_3"
+      ]
+    },
+    {
+      "chapter": 135,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Explain"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_4"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_4"
+      ]
+    },
+    {
+      "chapter": 136,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Explain"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_5"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_5"
+      ]
+    },
+    {
+      "chapter": 137,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Elaborate/Extend"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_6"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_6"
+      ]
+    },
+    {
+      "chapter": 138,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Elaborate/Extend"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_7"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_7"
+      ]
+    },
+    {
+      "chapter": 139,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluate"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_8"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_8"
+      ]
+    },
+    {
+      "chapter": 140,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluate"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_9"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_9"
+      ]
+    },
+    {
+      "chapter": 141,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 142,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 143,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 144,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 145,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 146,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "BigEvent_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "BigEvent_2019"
+      ]
+    },
+    {
+      "chapter": 147,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Code Your Own Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_video_flappyIntro_2019"
+      ]
+    },
+    {
+      "chapter": 148,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events1_2019"
+      ]
+    },
+    {
+      "chapter": 149,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events2_2019"
+      ]
+    },
+    {
+      "chapter": 150,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events3_2019"
+      ]
+    },
+    {
+      "chapter": 151,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events4_2019"
+      ]
+    },
+    {
+      "chapter": 152,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events5_2019"
+      ]
+    },
+    {
+      "chapter": 153,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events6_2019"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events7_2019"
+      ]
+    },
+    {
+      "chapter": 155,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events8_2019"
+      ]
+    },
+    {
+      "chapter": 156,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events9_2019"
+      ]
+    },
+    {
+      "chapter": 157,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Mini-project: Flappy Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseC_flappy_events10_2019"
+      ]
+    },
+    {
+      "chapter": 158,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_video_StarWarsProject_2019"
+      ]
+    },
+    {
+      "chapter": 159,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_7_no_video"
+      ]
+    },
+    {
+      "chapter": 160,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_8"
+      ]
+    },
+    {
+      "chapter": 161,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_9"
+      ]
+    },
+    {
+      "chapter": 162,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_10"
+      ]
+    },
+    {
+      "chapter": 163,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_11"
+      ]
+    },
+    {
+      "chapter": 164,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_12"
+      ]
+    },
+    {
+      "chapter": 165,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_13"
+      ]
+    },
+    {
+      "chapter": 166,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_14"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "blockly:Studio:hoc2015_blockly_15"
+      ]
+    },
+    {
+      "chapter": 168,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 1,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 169,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 2,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 170,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 3,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 171,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 4,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 172,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 5,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 173,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Engage"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_1"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_1"
+      ]
+    },
+    {
+      "chapter": 174,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_2"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_2"
+      ]
+    },
+    {
+      "chapter": 175,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Explore"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_3"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_3"
+      ]
+    },
+    {
+      "chapter": 176,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Explain"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_4"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_4"
+      ]
+    },
+    {
+      "chapter": 177,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Explain"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_5"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_5"
+      ]
+    },
+    {
+      "chapter": 178,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Elaborate/Extend"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_6"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_6"
+      ]
+    },
+    {
+      "chapter": 179,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Elaborate/Extend"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_7"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_7"
+      ]
+    },
+    {
+      "chapter": 180,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluate"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_8"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_8"
+      ]
+    },
+    {
+      "chapter": 181,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Evaluate"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_9"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 9,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_sl_9"
+      ]
+    },
+    {
+      "chapter": 182,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 183,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 2,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 184,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 3,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 185,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 4,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 186,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 5,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 187,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 188,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 189,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 190,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 191,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 192,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 1,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 193,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 2,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 194,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 3,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 195,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 4,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 196,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 5,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 197,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 198,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 199,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 200,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 201,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 202,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 1,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 203,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 2,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 204,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 3,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 205,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 4,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 206,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 5,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 207,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "SongwritingParameters_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "SongwritingParameters_2019"
+      ]
+    },
+    {
+      "chapter": 208,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_01_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 209,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_02_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 210,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_03_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 211,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 212,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_04POINT5_RYAN_2019"
+      ]
+    },
+    {
+      "chapter": 213,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_05_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 214,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_06_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 215,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "Function intro Ryan_2019"
+      ]
+    },
+    {
+      "chapter": 216,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_07_Cole_2019"
+      ]
+    },
+    {
+      "chapter": 217,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_10_RETRY_2019"
+      ]
+    },
+    {
+      "chapter": 218,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_Ali_2019"
+      ]
+    },
+    {
+      "chapter": 219,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Free Play"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "MC_HOC_2017_FP20x20_2019"
+      ]
+    },
+    {
+      "chapter": 220,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "The Harvester"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "harvester_skinOverview_video_2019"
+      ]
+    },
+    {
+      "chapter": 221,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1_2019"
+      ]
+    },
+    {
+      "chapter": 222,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions1a_2019"
+      ]
+    },
+    {
+      "chapter": 223,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2b_2019"
+      ]
+    },
+    {
+      "chapter": 224,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions2ba_2019"
+      ]
+    },
+    {
+      "chapter": 225,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c_2019"
+      ]
+    },
+    {
+      "chapter": 226,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions3c1_2019"
+      ]
+    },
+    {
+      "chapter": 227,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "How to Create a Simple Function"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_video_createFunctions2_2019"
+      ]
+    },
+    {
+      "chapter": 228,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions7a1_2019"
+      ]
+    },
+    {
+      "chapter": 229,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions8a1_2019"
+      ]
+    },
+    {
+      "chapter": 230,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions9a1_2019"
+      ]
+    },
+    {
+      "chapter": 231,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions10a1_2019"
+      ]
+    },
+    {
+      "chapter": 232,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions13_2019"
+      ]
+    },
+    {
+      "chapter": 233,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_functions11_predict_2019"
+      ]
+    },
+    {
+      "chapter": 234,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict1_2019"
+      ]
+    },
+    {
+      "chapter": 235,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions2_2019"
+      ]
+    },
+    {
+      "chapter": 236,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions3_2019"
+      ]
+    },
+    {
+      "chapter": 237,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions5_2019"
+      ]
+    },
+    {
+      "chapter": 238,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions7_2019"
+      ]
+    },
+    {
+      "chapter": 239,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions8a_2019"
+      ]
+    },
+    {
+      "chapter": 240,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions8b_2019"
+      ]
+    },
+    {
+      "chapter": 241,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions8c_2019"
+      ]
+    },
+    {
+      "chapter": 242,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions8_2019"
+      ]
+    },
+    {
+      "chapter": 243,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions9_2019"
+      ]
+    },
+    {
+      "chapter": 244,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions10_2019"
+      ]
+    },
+    {
+      "chapter": 245,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions_predict2_2019"
+      ]
+    },
+    {
+      "chapter": 246,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functionsProj_2019"
+      ]
+    },
+    {
+      "chapter": 247,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge1_2019"
+      ]
+    },
+    {
+      "chapter": 248,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_functions_challenge2_2019"
+      ]
+    },
+    {
+      "chapter": 249,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_bee_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 250,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 251,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_bee_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 252,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_bee_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 253,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_concept1_2018"
+      ]
+    },
+    {
+      "chapter": 254,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_bee_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 255,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_concept2_2018"
+      ]
+    },
+    {
+      "chapter": 256,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_bee_concept5_2018"
+      ]
+    },
+    {
+      "chapter": 257,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_farmer_concept3_2018"
+      ]
+    },
+    {
+      "chapter": 258,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_concept4_2018"
+      ]
+    },
+    {
+      "chapter": 259,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge1_2018"
+      ]
+    },
+    {
+      "chapter": 260,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": true,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "courseE_artist_concept_challenge2_2018"
+      ]
+    },
+    {
+      "chapter": 261,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_1"
+      ]
+    },
+    {
+      "chapter": 262,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_2"
+      ]
+    },
+    {
+      "chapter": 263,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_3"
+      ]
+    },
+    {
+      "chapter": 264,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_4"
+      ]
+    },
+    {
+      "chapter": 265,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "timeforcs_demo_c2_5"
+      ]
+    },
+    {
+      "chapter": 266,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Prediction"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 1"
+      ]
+    },
+    {
+      "chapter": 267,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 2"
+      ]
+    },
+    {
+      "chapter": 268,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 3"
+      ]
+    },
+    {
+      "chapter": 269,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 4"
+      ]
+    },
+    {
+      "chapter": 270,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Practice"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 5"
+      ]
+    },
+    {
+      "chapter": 271,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge",
+        "challenge": true
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      },
+      "level_keys": [
+        "behaviors 6"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_MRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_MRF_2018"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Programming: My Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_intro"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 1,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_video_ramp1_2018"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 2,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp1_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp1_2018"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 3,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp2_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp2_2018"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 4,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp3_2018"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 5,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "comment_intro_maze_2018",
+        "script_level.level_keys": [
+          "comment_intro_maze_2018"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 6,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp4_2018"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 7,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5_2018"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 8,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5a_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5a_2018"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 9,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5b_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5b_2018"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 10,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5c_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5c_2018"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 11,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_ramp5d_2018",
+        "script_level.level_keys": [
+          "courseD_maze_ramp5d_2018"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 12,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_algorithms_end",
+        "script_level.level_keys": [
+          "courseF_markdown_algorithms_end"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 13,
+        "lesson.key": "Sequence in Maze",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BuildingAFoundation_2018",
+        "script_level.level_keys": [
+          "BuildingAFoundation_2018"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Building a Foundation",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_intro"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_debugging_2018",
+        "script_level.level_keys": [
+          "courseC_video_debugging_2018"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging1_2018"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging2_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging2_2018"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging3_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging3_2018"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging4_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging4_2018"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging5_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging5_2018"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 7,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging6_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging6_2018"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 8,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging7_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging7_2018"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 9,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging8_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging8_predict1_2018"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 10,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_maze_debugging9_2018",
+        "script_level.level_keys": [
+          "courseC_maze_debugging9_2018"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 11,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_debugging_end",
+        "script_level.level_keys": [
+          "courseF_markdown_debugging_end"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 12,
+        "lesson.key": "Debugging with Scrat",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_artist_2018",
+        "script_level.level_keys": [
+          "courseC_video_artist_2018"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog1_2018"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog2_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog2_2018"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog3_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog3_2018"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog4_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog4_2018"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog5_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog5_2018"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_2018"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog7_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog7_2018"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog8_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog8_2018"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog6_predict1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog6_predict1_2018"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 10,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge1_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge1_2018"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 11,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_artist_prog_challenge2a_2018",
+        "script_level.level_keys": [
+          "courseC_artist_prog_challenge2a_2018"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 12,
+        "lesson.key": "Programming in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseB_unplugged_loopyMRF_2018",
+        "script_level.level_keys": [
+          "courseB_unplugged_loopyMRF_2018"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 1,
+        "lesson.key": "Loops: My Loopy Robotic Friends",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_intro"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 1,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_artistIntro_2018",
+        "script_level.level_keys": [
+          "ramp_video_artistIntro_2018"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 2,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops1_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops1_2018"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 3,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops2_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops2_2018"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 4,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_video_loopsArtist_2018",
+        "script_level.level_keys": [
+          "ramp_video_loopsArtist_2018"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 5,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops3_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops3_2018"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 6,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops4_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops4_2018"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 7,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops5_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops5_2018"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 8,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops6_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops6_2018"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 9,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops7_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops7_2018"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 10,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops8_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops8_2018"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 11,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "ramp_artist_loops9_2018",
+        "script_level.level_keys": [
+          "ramp_artist_loops9_2018"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 12,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_loops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_loops_end"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 13,
+        "lesson.key": "Loops in Artist",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1a_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1a_2018"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops1_2018"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_intro",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_intro"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_video_nestedLoops_2018",
+        "script_level.level_keys": [
+          "courseD_video_nestedLoops_2018"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_predict1_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_predict1_2018"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops2_2018"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops3_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops3_2018"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops4_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops4_2018"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops5_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops5_2018"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_maze_nestedLoops6_2018",
+        "script_level.level_keys": [
+          "courseD_maze_nestedLoops6_2018"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops7_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops7_2018"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops8_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops8_2018"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_2018"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_bee_nestedLoops9_predict2_2018",
+        "script_level.level_keys": [
+          "courseD_bee_nestedLoops9_predict2_2018"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 14,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_markdown_nestedloops_end",
+        "script_level.level_keys": [
+          "courseF_markdown_nestedloops_end"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 15,
+        "lesson.key": "Nested Loops in Bee/Zombie",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1_2018"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 1,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2_2018"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 2,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3_2018"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 3,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4_2018"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 4,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project5_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project5_2018"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 5,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project1a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project1a_2018"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 6,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project2a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project2a_2018"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 7,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project3a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project3a_2018"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 8,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseD_artist_project4a_2018",
+        "script_level.level_keys": [
+          "courseD_artist_project4a_2018"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 9,
+        "lesson.key": "Nested Loops with Frozen",
+        "lesson_group.key": "ramp_up",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_IntroSpriteLab",
+        "script_level.level_keys": [
+          "CourseEF_video_IntroSpriteLab"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 1,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 1-validated",
+        "script_level.level_keys": [
+          "Fish Tank 1-validated"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 2,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 2-validated",
+        "script_level.level_keys": [
+          "Fish Tank 2-validated"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 3,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 3-validated",
+        "script_level.level_keys": [
+          "Fish Tank 3-validated"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 4,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 4-validated",
+        "script_level.level_keys": [
+          "Fish Tank 4-validated"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 5,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseEF_video_MakeSprite",
+        "script_level.level_keys": [
+          "CourseEF_video_MakeSprite"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 6,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 5-validated",
+        "script_level.level_keys": [
+          "Fish Tank 5-validated"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 7,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 6-validated",
+        "script_level.level_keys": [
+          "Fish Tank 6-validated"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 8,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Fish Tank 7-validated",
+        "script_level.level_keys": [
+          "Fish Tank 7-validated"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 9,
+        "lesson.key": "Learning Sprites with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 1-validated",
+        "script_level.level_keys": [
+          "Dance Party 1-validated"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 1,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 2",
+        "script_level.level_keys": [
+          "Dance Party 2"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 2,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CDEF_video_SpritesInAction",
+        "script_level.level_keys": [
+          "CDEF_video_SpritesInAction"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 3,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 3",
+        "script_level.level_keys": [
+          "Dance Party 3"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 4,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 4",
+        "script_level.level_keys": [
+          "Dance Party 4"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 5,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 5",
+        "script_level.level_keys": [
+          "Dance Party 5"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 6,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 6",
+        "script_level.level_keys": [
+          "Dance Party 6"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 7,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party 7",
+        "script_level.level_keys": [
+          "Dance Party 7"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 8,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Dance Party Freeplay",
+        "script_level.level_keys": [
+          "Dance Party Freeplay"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 9,
+        "lesson.key": "Alien Dance Party with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 1",
+        "script_level.level_keys": [
+          "Virtual Pet 1"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 1,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 2",
+        "script_level.level_keys": [
+          "Virtual Pet 2"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 2,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 3",
+        "script_level.level_keys": [
+          "Virtual Pet 3"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 3,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 4",
+        "script_level.level_keys": [
+          "Virtual Pet 4"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 4,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 5",
+        "script_level.level_keys": [
+          "Virtual Pet 5"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 5,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet 6",
+        "script_level.level_keys": [
+          "Virtual Pet 6"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 6,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Virtual Pet Freeplay",
+        "script_level.level_keys": [
+          "Virtual Pet Freeplay"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 7,
+        "lesson.key": "Pet Giraffe with Sprite Lab",
+        "lesson_group.key": "csf_sprites",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c1_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_1"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 1,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c1_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_2"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 2,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c1_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_3"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 3,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c1_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_4"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 4,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c1_5_journal",
+        "script_level.level_keys": [
+          "timeforcs_demo_c1_5_journal"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 5,
+        "lesson.key": "Introduction to the Problem",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_crowdsourcing",
+        "script_level.level_keys": [
+          "timeforcs_demo_crowdsourcing"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 1,
+        "lesson.key": "Crowdsourcing",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 1,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 2,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 3,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 4,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 113,
+        "script_level.position": 5,
+        "lesson.key": "Everglades Habitats",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c3_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c3_1"
+        ],
+        "script_level.chapter": 114,
+        "script_level.position": 1,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_spritelab_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 115,
+        "script_level.position": 2,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_spritelab_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 116,
+        "script_level.position": 3,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_spritelab_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 117,
+        "script_level.position": 4,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_spritelab_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 118,
+        "script_level.position": 5,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_spritelab_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_spritelab_1"
+        ],
+        "script_level.chapter": 119,
+        "script_level.position": 6,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 120,
+        "script_level.position": 7,
+        "lesson.key": "Reviewing Projects",
+        "lesson_group.key": "time4cs_c1",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 121,
+        "script_level.position": 1,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 122,
+        "script_level.position": 2,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 123,
+        "script_level.position": 3,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 124,
+        "script_level.position": 4,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 125,
+        "script_level.position": 5,
+        "lesson.key": "Food Chains",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_conditionals",
+        "script_level.level_keys": [
+          "timeforcs_demo_conditionals"
+        ],
+        "script_level.chapter": 126,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals with Cards",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 127,
+        "script_level.position": 1,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 128,
+        "script_level.position": 2,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 129,
+        "script_level.position": 3,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 130,
+        "script_level.position": 4,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 131,
+        "script_level.position": 5,
+        "lesson.key": "Alligator Holes",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_1"
+        ],
+        "script_level.chapter": 132,
+        "script_level.position": 1,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_2"
+        ],
+        "script_level.chapter": 133,
+        "script_level.position": 2,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_3"
+        ],
+        "script_level.chapter": 134,
+        "script_level.position": 3,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_4"
+        ],
+        "script_level.chapter": 135,
+        "script_level.position": 4,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_5"
+        ],
+        "script_level.chapter": 136,
+        "script_level.position": 5,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_6",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_6"
+        ],
+        "script_level.chapter": 137,
+        "script_level.position": 6,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_7",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_7"
+        ],
+        "script_level.chapter": 138,
+        "script_level.position": 7,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_8",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_8"
+        ],
+        "script_level.chapter": 139,
+        "script_level.position": 8,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_9",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_9"
+        ],
+        "script_level.chapter": 140,
+        "script_level.position": 9,
+        "lesson.key": "Conditionals in Sprite Lab",
+        "lesson_group.key": "time4cs_c2",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 141,
+        "script_level.position": 1,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 142,
+        "script_level.position": 2,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 143,
+        "script_level.position": 3,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 144,
+        "script_level.position": 4,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 145,
+        "script_level.position": 5,
+        "lesson.key": "Invasive Species",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "BigEvent_2019",
+        "script_level.level_keys": [
+          "BigEvent_2019"
+        ],
+        "script_level.chapter": 146,
+        "script_level.position": 1,
+        "lesson.key": "Events: The Big Event",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_video_flappyIntro_2019",
+        "script_level.level_keys": [
+          "courseC_video_flappyIntro_2019"
+        ],
+        "script_level.chapter": 147,
+        "script_level.position": 1,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events1_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events1_2019"
+        ],
+        "script_level.chapter": 148,
+        "script_level.position": 2,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events2_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events2_2019"
+        ],
+        "script_level.chapter": 149,
+        "script_level.position": 3,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events3_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events3_2019"
+        ],
+        "script_level.chapter": 150,
+        "script_level.position": 4,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events4_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events4_2019"
+        ],
+        "script_level.chapter": 151,
+        "script_level.position": 5,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events5_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events5_2019"
+        ],
+        "script_level.chapter": 152,
+        "script_level.position": 6,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events6_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events6_2019"
+        ],
+        "script_level.chapter": 153,
+        "script_level.position": 7,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events7_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events7_2019"
+        ],
+        "script_level.chapter": 154,
+        "script_level.position": 8,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events8_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events8_2019"
+        ],
+        "script_level.chapter": 155,
+        "script_level.position": 9,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events9_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events9_2019"
+        ],
+        "script_level.chapter": 156,
+        "script_level.position": 10,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseC_flappy_events10_2019",
+        "script_level.level_keys": [
+          "courseC_flappy_events10_2019"
+        ],
+        "script_level.chapter": 157,
+        "script_level.position": 11,
+        "lesson.key": "Build a Flappy Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_StarWarsProject_2019",
+        "script_level.level_keys": [
+          "courseE_video_StarWarsProject_2019"
+        ],
+        "script_level.chapter": 158,
+        "script_level.position": 1,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_7_no_video",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_7_no_video"
+        ],
+        "script_level.chapter": 159,
+        "script_level.position": 2,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_8",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_8"
+        ],
+        "script_level.chapter": 160,
+        "script_level.position": 3,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_9",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_9"
+        ],
+        "script_level.chapter": 161,
+        "script_level.position": 4,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_10",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_10"
+        ],
+        "script_level.chapter": 162,
+        "script_level.position": 5,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_11",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_11"
+        ],
+        "script_level.chapter": 163,
+        "script_level.position": 6,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_12",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_12"
+        ],
+        "script_level.chapter": 164,
+        "script_level.position": 7,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_13",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_13"
+        ],
+        "script_level.chapter": 165,
+        "script_level.position": 8,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_14",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_14"
+        ],
+        "script_level.chapter": 166,
+        "script_level.position": 9,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "blockly:Studio:hoc2015_blockly_15",
+        "script_level.level_keys": [
+          "blockly:Studio:hoc2015_blockly_15"
+        ],
+        "script_level.chapter": 167,
+        "script_level.position": 10,
+        "lesson.key": "Build a Star Wars Game",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 168,
+        "script_level.position": 1,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 169,
+        "script_level.position": 2,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 170,
+        "script_level.position": 3,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 171,
+        "script_level.position": 4,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 172,
+        "script_level.position": 5,
+        "lesson.key": "I am in Big Trouble",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_1"
+        ],
+        "script_level.chapter": 173,
+        "script_level.position": 1,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_2"
+        ],
+        "script_level.chapter": 174,
+        "script_level.position": 2,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_3"
+        ],
+        "script_level.chapter": 175,
+        "script_level.position": 3,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_4"
+        ],
+        "script_level.chapter": 176,
+        "script_level.position": 4,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_5"
+        ],
+        "script_level.chapter": 177,
+        "script_level.position": 5,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_6",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_6"
+        ],
+        "script_level.chapter": 178,
+        "script_level.position": 6,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_7",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_7"
+        ],
+        "script_level.chapter": 179,
+        "script_level.position": 7,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_8",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_8"
+        ],
+        "script_level.chapter": 180,
+        "script_level.position": 8,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_sl_9",
+        "script_level.level_keys": [
+          "timeforcs_demo_sl_9"
+        ],
+        "script_level.chapter": 181,
+        "script_level.position": 9,
+        "lesson.key": "Events in Sprite Lab",
+        "lesson_group.key": "time4cs_c3",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 182,
+        "script_level.position": 1,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 183,
+        "script_level.position": 2,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 184,
+        "script_level.position": 3,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 185,
+        "script_level.position": 4,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 186,
+        "script_level.position": 5,
+        "lesson.key": "Fishy Business",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 187,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 188,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 189,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 190,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 191,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast a Message",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 192,
+        "script_level.position": 1,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 193,
+        "script_level.position": 2,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 194,
+        "script_level.position": 3,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 195,
+        "script_level.position": 4,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 196,
+        "script_level.position": 5,
+        "lesson.key": "Pythons & Mammals",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 197,
+        "script_level.position": 1,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 198,
+        "script_level.position": 2,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 199,
+        "script_level.position": 3,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 200,
+        "script_level.position": 4,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 201,
+        "script_level.position": 5,
+        "lesson.key": "Broadcast in Scratch",
+        "lesson_group.key": "time4cs_c4",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 202,
+        "script_level.position": 1,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 203,
+        "script_level.position": 2,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 204,
+        "script_level.position": 3,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 205,
+        "script_level.position": 4,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 206,
+        "script_level.position": 5,
+        "lesson.key": "Current Solutions",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "SongwritingParameters_2019",
+        "script_level.level_keys": [
+          "SongwritingParameters_2019"
+        ],
+        "script_level.chapter": 207,
+        "script_level.position": 1,
+        "lesson.key": "Functions: Songwriting",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_01_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_01_RETRY_2019"
+        ],
+        "script_level.chapter": 208,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_02_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_02_Cole_2019"
+        ],
+        "script_level.chapter": 209,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_03_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_03_Cole_2019"
+        ],
+        "script_level.chapter": 210,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04_Cole_2019"
+        ],
+        "script_level.chapter": 211,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_04POINT5_RYAN_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_04POINT5_RYAN_2019"
+        ],
+        "script_level.chapter": 212,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_05_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_05_Cole_2019"
+        ],
+        "script_level.chapter": 213,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_06_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_06_Cole_2019"
+        ],
+        "script_level.chapter": 214,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Function intro Ryan_2019",
+        "script_level.level_keys": [
+          "Function intro Ryan_2019"
+        ],
+        "script_level.chapter": 215,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_07_Cole_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_07_Cole_2019"
+        ],
+        "script_level.chapter": 216,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_10_RETRY_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_10_RETRY_2019"
+        ],
+        "script_level.chapter": 217,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_Ali_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_Ali_2019"
+        ],
+        "script_level.chapter": 218,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "MC_HOC_2017_FP20x20_2019",
+        "script_level.level_keys": [
+          "MC_HOC_2017_FP20x20_2019"
+        ],
+        "script_level.chapter": 219,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Minecraft",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "harvester_skinOverview_video_2019",
+        "script_level.level_keys": [
+          "harvester_skinOverview_video_2019"
+        ],
+        "script_level.chapter": 220,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1_2019"
+        ],
+        "script_level.chapter": 221,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions1a_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions1a_2019"
+        ],
+        "script_level.chapter": 222,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2b_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2b_2019"
+        ],
+        "script_level.chapter": 223,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions2ba_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions2ba_2019"
+        ],
+        "script_level.chapter": 224,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c_2019"
+        ],
+        "script_level.chapter": 225,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions3c1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions3c1_2019"
+        ],
+        "script_level.chapter": 226,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_video_createFunctions2_2019",
+        "script_level.level_keys": [
+          "courseE_video_createFunctions2_2019"
+        ],
+        "script_level.chapter": 227,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions7a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions7a1_2019"
+        ],
+        "script_level.chapter": 228,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions8a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions8a1_2019"
+        ],
+        "script_level.chapter": 229,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions9a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions9a1_2019"
+        ],
+        "script_level.chapter": 230,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions10a1_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions10a1_2019"
+        ],
+        "script_level.chapter": 231,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions13_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions13_2019"
+        ],
+        "script_level.chapter": 232,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_functions11_predict_2019",
+        "script_level.level_keys": [
+          "courseE_farmer_functions11_predict_2019"
+        ],
+        "script_level.chapter": 233,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Harvester",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict1_2019"
+        ],
+        "script_level.chapter": 234,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions2_2019"
+        ],
+        "script_level.chapter": 235,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions3_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions3_2019"
+        ],
+        "script_level.chapter": 236,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions5_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions5_2019"
+        ],
+        "script_level.chapter": 237,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions7_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions7_2019"
+        ],
+        "script_level.chapter": 238,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8a_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8a_2019"
+        ],
+        "script_level.chapter": 239,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8b_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8b_2019"
+        ],
+        "script_level.chapter": 240,
+        "script_level.position": 7,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8c_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8c_2019"
+        ],
+        "script_level.chapter": 241,
+        "script_level.position": 8,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions8_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions8_2019"
+        ],
+        "script_level.chapter": 242,
+        "script_level.position": 9,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions9_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions9_2019"
+        ],
+        "script_level.chapter": 243,
+        "script_level.position": 10,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions10_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions10_2019"
+        ],
+        "script_level.chapter": 244,
+        "script_level.position": 11,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_predict2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_predict2_2019"
+        ],
+        "script_level.chapter": 245,
+        "script_level.position": 12,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functionsProj_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functionsProj_2019"
+        ],
+        "script_level.chapter": 246,
+        "script_level.position": 13,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge1_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge1_2019"
+        ],
+        "script_level.chapter": 247,
+        "script_level.position": 14,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_functions_challenge2_2019",
+        "script_level.level_keys": [
+          "courseE_artist_functions_challenge2_2019"
+        ],
+        "script_level.chapter": 248,
+        "script_level.position": 15,
+        "lesson.key": "Functions in Artist",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept1_2018"
+        ],
+        "script_level.chapter": 249,
+        "script_level.position": 1,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept1_2018"
+        ],
+        "script_level.chapter": 250,
+        "script_level.position": 2,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept2_2018"
+        ],
+        "script_level.chapter": 251,
+        "script_level.position": 3,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept3_2018"
+        ],
+        "script_level.chapter": 252,
+        "script_level.position": 4,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept1_2018"
+        ],
+        "script_level.chapter": 253,
+        "script_level.position": 5,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept4_2018"
+        ],
+        "script_level.chapter": 254,
+        "script_level.position": 6,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept2_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept2_2018"
+        ],
+        "script_level.chapter": 255,
+        "script_level.position": 7,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_bee_concept5_2018",
+        "script_level.level_keys": [
+          "courseE_bee_concept5_2018"
+        ],
+        "script_level.chapter": 256,
+        "script_level.position": 8,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_farmer_concept3_2018",
+        "script_level.level_keys": [
+          "courseE_farmer_concept3_2018"
+        ],
+        "script_level.chapter": 257,
+        "script_level.position": 9,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept4_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept4_2018"
+        ],
+        "script_level.chapter": 258,
+        "script_level.position": 10,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge1_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge1_2018"
+        ],
+        "script_level.chapter": 259,
+        "script_level.position": 11,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseE_artist_concept_challenge2_2018",
+        "script_level.level_keys": [
+          "courseE_artist_concept_challenge2_2018"
+        ],
+        "script_level.chapter": 260,
+        "script_level.position": 12,
+        "lesson.key": "Determine the Concept",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_1",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_1"
+        ],
+        "script_level.chapter": 261,
+        "script_level.position": 1,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_2",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_2"
+        ],
+        "script_level.chapter": 262,
+        "script_level.position": 2,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_3",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_3"
+        ],
+        "script_level.chapter": 263,
+        "script_level.position": 3,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_4",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_4"
+        ],
+        "script_level.chapter": 264,
+        "script_level.position": 4,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "timeforcs_demo_c2_5",
+        "script_level.level_keys": [
+          "timeforcs_demo_c2_5"
+        ],
+        "script_level.chapter": 265,
+        "script_level.position": 5,
+        "lesson.key": "Debate",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 1",
+        "script_level.level_keys": [
+          "behaviors 1"
+        ],
+        "script_level.chapter": 266,
+        "script_level.position": 1,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 2",
+        "script_level.level_keys": [
+          "behaviors 2"
+        ],
+        "script_level.chapter": 267,
+        "script_level.position": 2,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 3",
+        "script_level.level_keys": [
+          "behaviors 3"
+        ],
+        "script_level.chapter": 268,
+        "script_level.position": 3,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 4",
+        "script_level.level_keys": [
+          "behaviors 4"
+        ],
+        "script_level.chapter": 269,
+        "script_level.position": 4,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 5",
+        "script_level.level_keys": [
+          "behaviors 5"
+        ],
+        "script_level.chapter": 270,
+        "script_level.position": 5,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "behaviors 6",
+        "script_level.level_keys": [
+          "behaviors 6"
+        ],
+        "script_level.chapter": 271,
+        "script_level.position": 6,
+        "lesson.key": "Functions in Sprite Lab",
+        "lesson_group.key": "time4cs_c5",
+        "script.name": "time4csdemo"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/transferring-over.script_json
+++ b/dashboard/config/scripts_json/transferring-over.script_json
@@ -1,0 +1,2029 @@
+{
+  "script": {
+    "name": "transferring-over",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "transferring-over"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "20-hr Stage 2",
+      "name": "20-hr Stage 2",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "key": "20-hr Stage 9",
+      "name": "20-hr Stage 9",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "key": "Course 2 Stage 17",
+      "name": "Course 2 Stage 17",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "key": "Course 3 Stage 16",
+      "name": "Course 3 Stage 16",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "key": "Course 3 Stage 17",
+      "name": "Course 3 Stage 17",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_1"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_2"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_3"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_4"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_5"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_6"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_7"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_8"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_9"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_10"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_11"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_12"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_13"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_14"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_14"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_15"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_15"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_16"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_17"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_18"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_18"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 19,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_19"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_19"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 20,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_maze_stage2_20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_maze_stage2_20"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_1"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_3"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_4"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_5"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_6"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_7"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_8"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_9"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_10"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "20hr_farmer_stage9_11"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_4"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_6"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_7"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_8"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_8"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_9"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_9"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_10"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_10"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course2_playlab_stage17_11"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course2_playlab_stage17_11"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_1"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_2"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_3"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_4"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_5"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage16_6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage16_6"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_1"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_2"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_3"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_4"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_5"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_6"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "course3_playlab_stage17_7"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      },
+      "level_keys": [
+        "course3_playlab_stage17_7"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_1",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_1"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_2",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_2"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_3",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_3"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_4",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_4"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_5",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_5"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_6",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_6"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_7",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_7"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_8",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_8"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_9",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_9"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_10",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_10"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_11",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_11"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_12",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_12"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_13",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_13"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_14",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_14"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_15",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_15"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_16",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_16"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_17",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_17"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 17,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_18",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_18"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 18,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_19",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_19"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 19,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_maze_stage2_20",
+        "script_level.level_keys": [
+          "20hr_maze_stage2_20"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 20,
+        "lesson.key": "20-hr Stage 2",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_1",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_1"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 1,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_2",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 2,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_3",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_3"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 3,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_4",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_4"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 4,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_5",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_5"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 5,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_6",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_6"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 6,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_7",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_7"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 7,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_8",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_8"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 8,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_9",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_9"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 9,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_10",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_10"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 10,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "20hr_farmer_stage9_11",
+        "script_level.level_keys": [
+          "20hr_farmer_stage9_11"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 11,
+        "lesson.key": "20-hr Stage 9",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_1",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_2",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_3",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_4",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_5",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_6",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_7",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_8",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_8"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_9",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_9"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_10",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_10"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 10,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course2_playlab_stage17_11",
+        "script_level.level_keys": [
+          "course2_playlab_stage17_11"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 11,
+        "lesson.key": "Course 2 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_1",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_1"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 1,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_2",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_2"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 2,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_3",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_3"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 3,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_4",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_4"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 4,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_5",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_5"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 5,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage16_6",
+        "script_level.level_keys": [
+          "course3_playlab_stage16_6"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 6,
+        "lesson.key": "Course 3 Stage 16",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_1",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_1"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_2",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_2"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 2,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_3",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_3"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 3,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_4",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_4"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 4,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_5",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_5"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 5,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_6",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_6"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 6,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "course3_playlab_stage17_7",
+        "script_level.level_keys": [
+          "course3_playlab_stage17_7"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 7,
+        "lesson.key": "Course 3 Stage 17",
+        "lesson_group.key": "",
+        "script.name": "transferring-over"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/usability.script_json
+++ b/dashboard/config/scripts_json/usability.script_json
@@ -1,0 +1,1504 @@
+{
+  "script": {
+    "name": "usability",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "usability"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Intro",
+      "name": "Intro",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "key": "Variables",
+      "name": "Variables",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "key": "For Loops",
+      "name": "For Loops",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "key": "Functions and Functions with Parameters",
+      "name": "Functions and Functions with Parameters",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "key": "Binary",
+      "name": "Binary",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Maze 6"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Maze 6"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee 2"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee 3"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee 4"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist 7"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist 8"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist 9"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 1"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Vars 2"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 2"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 3"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 5"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Vars 6"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee For Loops 4"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee For Loops 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Bee For Loops 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 1"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 2"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Labs For Loops 3"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Functions 2"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Functions 4"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Functions 5"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Params 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Params 1"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Params 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Params 2"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Params 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Params 3"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Params 4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Params 4"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 1"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 2"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 10,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Play Lab Params 3"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 1"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 2"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 3"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 4"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 5"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 6"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary 7"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary Free Play"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      },
+      "level_keys": [
+        "Course 4 Artist Binary Free Play 2"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Maze 6",
+        "script_level.level_keys": [
+          "Course 4 Maze 6"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 1",
+        "script_level.level_keys": [
+          "Course 4 Bee 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 2",
+        "script_level.level_keys": [
+          "Course 4 Bee 2"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 3",
+        "script_level.level_keys": [
+          "Course 4 Bee 3"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee 4",
+        "script_level.level_keys": [
+          "Course 4 Bee 4"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 7",
+        "script_level.level_keys": [
+          "Course 4 Artist 7"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 8",
+        "script_level.level_keys": [
+          "Course 4 Artist 8"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist 9",
+        "script_level.level_keys": [
+          "Course 4 Artist 9"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Intro",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 1",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 1"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 1,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Vars 2",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Vars 2"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 2,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 2"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 3,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 3",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 3"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 4,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 5,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 5",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 5"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 6,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Vars 6",
+        "script_level.level_keys": [
+          "Course 4 Artist Vars 6"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 7,
+        "lesson.key": "Variables",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee For Loops 4",
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 4"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 1,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee For Loops 5",
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 2,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Bee For Loops 6",
+        "script_level.level_keys": [
+          "Course 4 Bee For Loops 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 3,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 1",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 1"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 4,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 2",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 2"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 5,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Labs For Loops 3",
+        "script_level.level_keys": [
+          "Course 4 Play Labs For Loops 3"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 6,
+        "lesson.key": "For Loops",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Functions 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 2"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 1,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Functions 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 4"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 2,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Functions 5",
+        "script_level.level_keys": [
+          "Course 4 Artist Functions 5"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 3,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Params 1",
+        "script_level.level_keys": [
+          "Course 4 Artist Params 1"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 4,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Params 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Params 2"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 5,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Params 3",
+        "script_level.level_keys": [
+          "Course 4 Artist Params 3"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 6,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Params 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Params 4"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 7,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 1",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 1"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 8,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 2",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 2"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 9,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Play Lab Params 3",
+        "script_level.level_keys": [
+          "Course 4 Play Lab Params 3"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 10,
+        "lesson.key": "Functions and Functions with Parameters",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 1",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 1"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 1,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 2"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 2,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 3",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 3"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 3,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 4",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 4"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 4,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 5",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 5"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 5,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 6",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 6"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 6,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary 7",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary 7"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 7,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary Free Play",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 8,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Course 4 Artist Binary Free Play 2",
+        "script_level.level_keys": [
+          "Course 4 Artist Binary Free Play 2"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 9,
+        "lesson.key": "Binary",
+        "lesson_group.key": "",
+        "script.name": "usability"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/valentine.script_json
+++ b/dashboard/config/scripts_json/valentine.script_json
@@ -1,0 +1,189 @@
+{
+  "script": {
+    "name": "valentine",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "peer_reviews_to_complete": 0
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "valentine"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Valentine Puzzles",
+      "name": "Valentine Puzzles",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Valentine_playlab_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      },
+      "level_keys": [
+        "Valentine_playlab_01"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Valentine_artist_01"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      },
+      "level_keys": [
+        "Valentine_artist_01"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Valentine_artist2_01"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      },
+      "level_keys": [
+        "Valentine_artist2_01"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "valentine_artist_03"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      },
+      "level_keys": [
+        "valentine_artist_03"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Valentine_playlab_01",
+        "script_level.level_keys": [
+          "Valentine_playlab_01"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Valentine_artist_01",
+        "script_level.level_keys": [
+          "Valentine_artist_01"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Valentine_artist2_01",
+        "script_level.level_keys": [
+          "Valentine_artist2_01"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "valentine_artist_03",
+        "script_level.level_keys": [
+          "valentine_artist_03"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Valentine Puzzles",
+        "lesson_group.key": "",
+        "script.name": "valentine"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/vigenere.script_json
+++ b/dashboard/config/scripts_json/vigenere.script_json
@@ -1,0 +1,84 @@
+{
+  "script": {
+    "name": "vigenere",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "has_lesson_plan": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "vigenere"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "vigenere"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Vigenere",
+      "name": "Vigenere",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Vigenere",
+        "lesson_group.key": "",
+        "script.name": "vigenere"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Vigenere"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Vigenere",
+        "lesson_group.key": "",
+        "script.name": "vigenere"
+      },
+      "level_keys": [
+        "Vigenere"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Vigenere",
+        "script_level.level_keys": [
+          "Vigenere"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Vigenere",
+        "lesson_group.key": "",
+        "script.name": "vigenere"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/virtual-holding-place.script_json
+++ b/dashboard/config/scripts_json/virtual-holding-place.script_json
@@ -1,0 +1,4190 @@
+{
+  "script": {
+    "name": "virtual-holding-place",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "virtual-holding-place"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "content",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "csd3_2",
+      "user_facing": true,
+      "position": 2,
+      "properties": {
+        "display_name": "Chapter 2: Building Games"
+      },
+      "seeding_key": {
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Example Projects",
+      "name": "Example Projects",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Example Projects",
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Velocity",
+      "name": "Velocity",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Collision Detection",
+      "name": "Collision Detection",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Complex Sprite Movement",
+      "name": "Complex Sprite Movement",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Collisions",
+      "name": "Collisions",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Functions",
+      "name": "Functions",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "The Game Design Process",
+      "name": "The Game Design Process",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Using the Game Design Process",
+      "name": "Using the Game Design Process",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "key": "Project - Design a Game",
+      "name": "Project - Design a Game",
+      "absolute_position": 9,
+      "lockable": false,
+      "relative_position": 9,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Example Projects",
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 1_virtual"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Sample Programs"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Example Projects",
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Entertainment Sample 2_virtual"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD: Sprite Velocity_virtual"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX_virtual"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY_virtual"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation_virtual"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction rotation control_virtual"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityY control_virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 7,
+      "assessment": true,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX if-statements_virtual"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction velocityX control_virtual"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jump_2018_virtual"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction tumbleweed_virtual"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Side Scroller"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction looping_virtual"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 L15 Freeplay_virtual"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions car intro_virtual"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions build isTouching_virtual"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions isTouching intro_virtual"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg_virtual"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions egg2_virtual"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions horse_virtual"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "isTouching"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug isTouching_virtual"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions scoreboard_virtual"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions in Games"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions sidescroll2_virtual"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 L16 Freeplay_virtual"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Complex Movement counter prediction gamelab_virtual"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateX_virtual"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY_virtual"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction accelerateY up_virtual"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateX_virtual"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 6,
+      "assessment": true,
+      "properties": {
+        "progression": "Velocity and the Counter Pattern"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction decelerateY_virtual"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction jumping_virtual"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter_virtual"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction left right counter 2_virtual"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction add coin_virtual"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction reset coin_virtual"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 abstraction make it your own_virtual"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 L17 Freeplay_virtual"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions predict set velocity code_virtual"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace x_virtual"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace y_virtual"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions displace intro_virtual"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions try blocks_virtual"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions types_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions types_virtual"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions turtle_virtual"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions debug_virtual"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions setCollider_virtual"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collisions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions bounciness_virtual"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman add obstacles_virtual"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman bounceOff_virtual"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman displace coin_virtual"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman change colliders_virtual"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 15,
+      "assessment": true,
+      "properties": {
+        "progression": "Flyer Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 collisions flyman make it your own_virtual"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 L18 Freeplay_virtual"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 function video_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 function video_virtual"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Function_virtual"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Order Functions_virtual"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Prediction Order of Create_virtual"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Call Draw Loop_virtual"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Reset Sprite_virtual"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Randomize Sprite_virtual"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Functions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Create Function_virtual"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Write Reset_virtual"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add IsTouching_virtual"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 11,
+      "assessment": true,
+      "properties": {
+        "progression": "Collector Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 Functions Add Change Background_virtual"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 functions review_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 functions review_virtual"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Challenge"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 L19 Freeplay_virtual"
+      ]
+    },
+    {
+      "chapter": 67,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti Play Defender_virtual"
+      ]
+    },
+    {
+      "chapter": 68,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 69,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti introducing multiframe_virtual"
+      ]
+    },
+    {
+      "chapter": 70,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti slow down_virtual"
+      ]
+    },
+    {
+      "chapter": 71,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Multiframe Animations"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti mirror animation_virtual"
+      ]
+    },
+    {
+      "chapter": 72,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate cake enemies_virtual"
+      ]
+    },
+    {
+      "chapter": 73,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies move_virtual"
+      ]
+    },
+    {
+      "chapter": 74,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake_virtual"
+      ]
+    },
+    {
+      "chapter": 75,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender enemies touch cake sprite2_virtual"
+      ]
+    },
+    {
+      "chapter": 76,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender create set enemies_virtual"
+      ]
+    },
+    {
+      "chapter": 77,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move player_virtual"
+      ]
+    },
+    {
+      "chapter": 78,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender move up down_virtual"
+      ]
+    },
+    {
+      "chapter": 79,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender animate player_virtual"
+      ]
+    },
+    {
+      "chapter": 80,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender displace enemies_virtual"
+      ]
+    },
+    {
+      "chapter": 81,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender touch water_virtual"
+      ]
+    },
+    {
+      "chapter": 82,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Cake Defender"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 AnimationsMulti defender make it your own_virtual"
+      ]
+    },
+    {
+      "chapter": 83,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform sample1_virtual"
+      ]
+    },
+    {
+      "chapter": 84,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform intro_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 85,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background1_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform background1_virtual"
+      ]
+    },
+    {
+      "chapter": 86,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform variable1_virtual"
+      ]
+    },
+    {
+      "chapter": 87,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform background2_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform background2_virtual"
+      ]
+    },
+    {
+      "chapter": 88,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform scoreboard_virtual"
+      ]
+    },
+    {
+      "chapter": 89,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform platform1_virtual"
+      ]
+    },
+    {
+      "chapter": 90,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform platform2_virtual"
+      ]
+    },
+    {
+      "chapter": 91,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Platforms"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform platform3_virtual"
+      ]
+    },
+    {
+      "chapter": 92,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items1_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform items1_virtual"
+      ]
+    },
+    {
+      "chapter": 93,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items2_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform items2_virtual"
+      ]
+    },
+    {
+      "chapter": 94,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Items"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform items3_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform items3_virtual"
+      ]
+    },
+    {
+      "chapter": 95,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player1_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform player1_virtual"
+      ]
+    },
+    {
+      "chapter": 96,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player2_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform player2_virtual"
+      ]
+    },
+    {
+      "chapter": 97,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player3_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform player3_virtual"
+      ]
+    },
+    {
+      "chapter": 98,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Platform Jumper - Player"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform player4_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform player4_virtual"
+      ]
+    },
+    {
+      "chapter": 99,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform sample2_virtual"
+      ]
+    },
+    {
+      "chapter": 100,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform sample3_virtual"
+      ]
+    },
+    {
+      "chapter": 101,
+      "position": 19,
+      "assessment": true,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 platform challenge_virtual"
+      ]
+    },
+    {
+      "chapter": 102,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game intro_2018_2019_pilot_2020_virtual"
+      ]
+    },
+    {
+      "chapter": 103,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game variables_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game variables_virtual"
+      ]
+    },
+    {
+      "chapter": 104,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game backgrounds_virtual"
+      ]
+    },
+    {
+      "chapter": 105,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game display boards_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game display boards_virtual"
+      ]
+    },
+    {
+      "chapter": 106,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Background and Variables"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game choose background_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game choose background_virtual"
+      ]
+    },
+    {
+      "chapter": 107,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game animations_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game animations_virtual"
+      ]
+    },
+    {
+      "chapter": 108,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game create sprites_virtual"
+      ]
+    },
+    {
+      "chapter": 109,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game sprite movement_virtual"
+      ]
+    },
+    {
+      "chapter": 110,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game user controls_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game user controls_virtual"
+      ]
+    },
+    {
+      "chapter": 111,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Project - Sprites and Interactions"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 game interactions_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 game interactions_virtual"
+      ]
+    },
+    {
+      "chapter": 112,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      },
+      "level_keys": [
+        "CSD U3 finishing touches_virtual"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 1_virtual"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Example Projects",
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Entertainment Sample 2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Entertainment Sample 2_virtual"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Example Projects",
+        "lesson_group.key": "content",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprite Velocity_virtual",
+        "script_level.level_keys": [
+          "CSD: Sprite Velocity_virtual"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 1,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX_virtual"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 2,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY_virtual"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 3,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation_virtual"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 4,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction rotation control_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction rotation control_virtual"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 5,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityY control_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityY control_virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 6,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX if-statements_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX if-statements_virtual"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 7,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction velocityX control_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction velocityX control_virtual"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 8,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jump_2018_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jump_2018_virtual"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 9,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction tumbleweed_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction tumbleweed_virtual"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 10,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction looping_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction looping_virtual"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 11,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L15 Freeplay_virtual",
+        "script_level.level_keys": [
+          "CSD U3 L15 Freeplay_virtual"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 12,
+        "lesson.key": "Velocity",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions car intro_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions car intro_virtual"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 1,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions build isTouching_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions build isTouching_virtual"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 2,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions isTouching intro_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions isTouching intro_virtual"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 3,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg_virtual"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 4,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions egg2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions egg2_virtual"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 5,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions horse_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions horse_virtual"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 6,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug isTouching_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug isTouching_virtual"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 7,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions scoreboard_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions scoreboard_virtual"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 8,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions sidescroll2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions sidescroll2_virtual"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 9,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L16 Freeplay_virtual",
+        "script_level.level_keys": [
+          "CSD U3 L16 Freeplay_virtual"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 10,
+        "lesson.key": "Collision Detection",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Complex Movement counter prediction gamelab_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Complex Movement counter prediction gamelab_virtual"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 1,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateX_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateX_virtual"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 2,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY_virtual"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 3,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction accelerateY up_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction accelerateY up_virtual"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 4,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateX_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateX_virtual"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 5,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction decelerateY_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction decelerateY_virtual"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 6,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction jumping_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction jumping_virtual"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 7,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter_virtual"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 8,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction left right counter 2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction left right counter 2_virtual"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 9,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction add coin_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction add coin_virtual"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 10,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction reset coin_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction reset coin_virtual"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 11,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 abstraction make it your own_virtual",
+        "script_level.level_keys": [
+          "CSD U3 abstraction make it your own_virtual"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 12,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L17 Freeplay_virtual",
+        "script_level.level_keys": [
+          "CSD U3 L17 Freeplay_virtual"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 13,
+        "lesson.key": "Complex Sprite Movement",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions predict set velocity code_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions predict set velocity code_virtual"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 1,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace x_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace x_virtual"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 2,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace y_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace y_virtual"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 3,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions displace intro_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions displace intro_virtual"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 4,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions try blocks_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions try blocks_virtual"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 5,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions types_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions types_virtual"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 6,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions turtle_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions turtle_virtual"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 7,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions debug_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions debug_virtual"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 8,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions setCollider_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions setCollider_virtual"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 9,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions bounciness_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions bounciness_virtual"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 10,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman add obstacles_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman add obstacles_virtual"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 11,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman bounceOff_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman bounceOff_virtual"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 12,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman displace coin_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman displace coin_virtual"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 13,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman change colliders_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman change colliders_virtual"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 14,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 collisions flyman make it your own_virtual",
+        "script_level.level_keys": [
+          "CSD U3 collisions flyman make it your own_virtual"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 15,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L18 Freeplay_virtual",
+        "script_level.level_keys": [
+          "CSD U3 L18 Freeplay_virtual"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 16,
+        "lesson.key": "Collisions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 function video_virtual",
+        "script_level.level_keys": [
+          "CSD U3 function video_virtual"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 1,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Function_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Function_virtual"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 2,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Order Functions_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Order Functions_virtual"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 3,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Prediction Order of Create_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Prediction Order of Create_virtual"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 4,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Call Draw Loop_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Call Draw Loop_virtual"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 5,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Reset Sprite_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Reset Sprite_virtual"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 6,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Randomize Sprite_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Randomize Sprite_virtual"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 7,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Create Function_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Create Function_virtual"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 8,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Write Reset_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Write Reset_virtual"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 9,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add IsTouching_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add IsTouching_virtual"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 10,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Functions Add Change Background_virtual",
+        "script_level.level_keys": [
+          "CSD U3 Functions Add Change Background_virtual"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 11,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 functions review_virtual",
+        "script_level.level_keys": [
+          "CSD U3 functions review_virtual"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 12,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 L19 Freeplay_virtual",
+        "script_level.level_keys": [
+          "CSD U3 L19 Freeplay_virtual"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 13,
+        "lesson.key": "Functions",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti Play Defender_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti Play Defender_virtual"
+        ],
+        "script_level.chapter": 67,
+        "script_level.position": 1,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti STOP project guide_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 68,
+        "script_level.position": 2,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti introducing multiframe_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti introducing multiframe_virtual"
+        ],
+        "script_level.chapter": 69,
+        "script_level.position": 3,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti slow down_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti slow down_virtual"
+        ],
+        "script_level.chapter": 70,
+        "script_level.position": 4,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti mirror animation_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti mirror animation_virtual"
+        ],
+        "script_level.chapter": 71,
+        "script_level.position": 5,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate cake enemies_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate cake enemies_virtual"
+        ],
+        "script_level.chapter": 72,
+        "script_level.position": 6,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies move_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies move_virtual"
+        ],
+        "script_level.chapter": 73,
+        "script_level.position": 7,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake_virtual"
+        ],
+        "script_level.chapter": 74,
+        "script_level.position": 8,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender enemies touch cake sprite2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender enemies touch cake sprite2_virtual"
+        ],
+        "script_level.chapter": 75,
+        "script_level.position": 9,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender create set enemies_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender create set enemies_virtual"
+        ],
+        "script_level.chapter": 76,
+        "script_level.position": 10,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move player_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move player_virtual"
+        ],
+        "script_level.chapter": 77,
+        "script_level.position": 11,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender move up down_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender move up down_virtual"
+        ],
+        "script_level.chapter": 78,
+        "script_level.position": 12,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender animate player_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender animate player_virtual"
+        ],
+        "script_level.chapter": 79,
+        "script_level.position": 13,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender displace enemies_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender displace enemies_virtual"
+        ],
+        "script_level.chapter": 80,
+        "script_level.position": 14,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender touch water_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender touch water_virtual"
+        ],
+        "script_level.chapter": 81,
+        "script_level.position": 15,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 AnimationsMulti defender make it your own_virtual",
+        "script_level.level_keys": [
+          "CSD U3 AnimationsMulti defender make it your own_virtual"
+        ],
+        "script_level.chapter": 82,
+        "script_level.position": 16,
+        "lesson.key": "The Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform sample1_virtual"
+        ],
+        "script_level.chapter": 83,
+        "script_level.position": 1,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform intro_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform intro_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 84,
+        "script_level.position": 2,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform background1_virtual"
+        ],
+        "script_level.chapter": 85,
+        "script_level.position": 3,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform variable1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform variable1_virtual"
+        ],
+        "script_level.chapter": 86,
+        "script_level.position": 4,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform background2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform background2_virtual"
+        ],
+        "script_level.chapter": 87,
+        "script_level.position": 5,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform scoreboard_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform scoreboard_virtual"
+        ],
+        "script_level.chapter": 88,
+        "script_level.position": 6,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform platform1_virtual"
+        ],
+        "script_level.chapter": 89,
+        "script_level.position": 7,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform platform2_virtual"
+        ],
+        "script_level.chapter": 90,
+        "script_level.position": 8,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform platform3_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform platform3_virtual"
+        ],
+        "script_level.chapter": 91,
+        "script_level.position": 9,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform items1_virtual"
+        ],
+        "script_level.chapter": 92,
+        "script_level.position": 10,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform items2_virtual"
+        ],
+        "script_level.chapter": 93,
+        "script_level.position": 11,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform items3_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform items3_virtual"
+        ],
+        "script_level.chapter": 94,
+        "script_level.position": 12,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player1_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform player1_virtual"
+        ],
+        "script_level.chapter": 95,
+        "script_level.position": 13,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform player2_virtual"
+        ],
+        "script_level.chapter": 96,
+        "script_level.position": 14,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player3_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform player3_virtual"
+        ],
+        "script_level.chapter": 97,
+        "script_level.position": 15,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform player4_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform player4_virtual"
+        ],
+        "script_level.chapter": 98,
+        "script_level.position": 16,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample2_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform sample2_virtual"
+        ],
+        "script_level.chapter": 99,
+        "script_level.position": 17,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform sample3_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform sample3_virtual"
+        ],
+        "script_level.chapter": 100,
+        "script_level.position": 18,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 platform challenge_virtual",
+        "script_level.level_keys": [
+          "CSD U3 platform challenge_virtual"
+        ],
+        "script_level.chapter": 101,
+        "script_level.position": 19,
+        "lesson.key": "Using the Game Design Process",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game intro_2018_2019_pilot_2020_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game intro_2018_2019_pilot_2020_virtual"
+        ],
+        "script_level.chapter": 102,
+        "script_level.position": 1,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game variables_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game variables_virtual"
+        ],
+        "script_level.chapter": 103,
+        "script_level.position": 2,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game backgrounds_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game backgrounds_virtual"
+        ],
+        "script_level.chapter": 104,
+        "script_level.position": 3,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game display boards_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game display boards_virtual"
+        ],
+        "script_level.chapter": 105,
+        "script_level.position": 4,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game choose background_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game choose background_virtual"
+        ],
+        "script_level.chapter": 106,
+        "script_level.position": 5,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game animations_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game animations_virtual"
+        ],
+        "script_level.chapter": 107,
+        "script_level.position": 6,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game create sprites_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game create sprites_virtual"
+        ],
+        "script_level.chapter": 108,
+        "script_level.position": 7,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game sprite movement_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game sprite movement_virtual"
+        ],
+        "script_level.chapter": 109,
+        "script_level.position": 8,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game user controls_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game user controls_virtual"
+        ],
+        "script_level.chapter": 110,
+        "script_level.position": 9,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 game interactions_virtual",
+        "script_level.level_keys": [
+          "CSD U3 game interactions_virtual"
+        ],
+        "script_level.chapter": 111,
+        "script_level.position": 10,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 finishing touches_virtual",
+        "script_level.level_keys": [
+          "CSD U3 finishing touches_virtual"
+        ],
+        "script_level.chapter": 112,
+        "script_level.position": 11,
+        "lesson.key": "Project - Design a Game",
+        "lesson_group.key": "csd3_2",
+        "script.name": "virtual-holding-place"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/vpl-csd-2020.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2020.script_json
@@ -1,0 +1,2543 @@
+{
+  "script": {
+    "name": "vpl-csd-2020",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "pilot_experiment": "20-21-virtual-AYW-CSD",
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csd-20/"
+        ],
+        [
+          "teacherForum",
+          "https://forum.code.org/"
+        ],
+        [
+          "curriculumGuide",
+          "https://docs.google.com/document/d/1-O6o5yQ4I1dk0n4Qzh86quXGBtzDDtyJ3Skr6RpcpO4/preview"
+        ],
+        [
+          "professionalLearning",
+          "/link/to/professional/learning"
+        ]
+      ]
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "vpl-csd-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Module 1",
+      "name": "Module 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 2",
+      "name": "Module 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 3",
+      "name": "Module 3",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 4",
+      "name": "Module 4",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 5",
+      "name": "Module 5",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 6",
+      "name": "Module 6",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 7",
+      "name": "Module 7",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "key": "Module 8",
+      "name": "Module 8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "OPL - CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "OPL - CSD-PL AYWS1 Debugging Intro"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Summer Workshop Review (~ 10 - 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Summer Review Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 Summer Review Overview"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Summer Workshop Review (~ 10 - 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 Summer Review"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 Summer Review"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Variables Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Variables Overview"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module Variable Video with Reflection"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module Variable Video with Reflection"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Variables Predict Where XY_2020"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Variable Resources"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Variable Resources"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Variables naming rules v2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Random Numbers Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Random Numbers Overview"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD U3 Random random ellipse2_2018_2020"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "New Content (~ 35 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 New Content Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 New Content Reflection"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 Debugging Reflection 1"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD Games variables practice_2020"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Debugging (~ 25 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 1 Debugging Reflection 2"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Asynchronous Wrap Up (~ 10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 Overview"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 - CI"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 1 - CI"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD: Introduction to the Draw Loop_2020"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI The Draw Loop Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI The Draw Loop Reflection"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD: Animating Sprite Movement_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Sprite Movement Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI Sprite Movement Reflection"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U3 - Booleans Video_2020"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Conditionals"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL-CSD 2020 - Module 2 CI - Conditionals"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~ 60 min)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Conditionals Reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 2 CI Conditionals Reflection"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Conclusions and Connections"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Conclusions and Connections"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 Chapter 1 Project"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U3 Chapter 1 Project"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD: Sprite Velocity_2020"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U3 collisions car intro_2020"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~ 20 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Asynchronous Wrap Up (~ 10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 2 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Overview"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Check In (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD M3 Check-in"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD M3 Check-in"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Theme Introduction (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD M3 Theme Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD M3 Theme Introduction"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Curriculum Investigation Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Curriculum Investigation Overview"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L1 Investigation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - U4L1 Investigation"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - Problem Solving Process Guide"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Problem Solving Process"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 Problem Solving Process"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~60 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L2 Investigation"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 - U4L2 Investigation"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Reflection (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Reflection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 U4L2 Reflection"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Intro to Group Dynamics (~5 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Asynchronous Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 3 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 Overview"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - CI"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - CI2"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L4 Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L4 Reflection"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L8 CI"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L8 CI"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L8 Reflection"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L8 Reflection"
+      ]
+    },
+    {
+      "chapter": 51,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L12 GoalsTasks"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - L12 GoalsTasks"
+      ]
+    },
+    {
+      "chapter": 52,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Video Reflection"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 Video Reflection"
+      ]
+    },
+    {
+      "chapter": 53,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module - U4L12Level3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module - U4L12Level3"
+      ]
+    },
+    {
+      "chapter": 54,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level4"
+      ]
+    },
+    {
+      "chapter": 55,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level5"
+      ]
+    },
+    {
+      "chapter": 56,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - U4L12Level6"
+      ]
+    },
+    {
+      "chapter": 57,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Lesson Investigation (~70 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L12 Reflection"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD Module 4 U4L12 Reflection"
+      ]
+    },
+    {
+      "chapter": 58,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 14,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - Conclusions and Connections"
+      ]
+    },
+    {
+      "chapter": 59,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 1 Project"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 15,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U4 Chapter 1 Project"
+      ]
+    },
+    {
+      "chapter": 60,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L13 LInkingScreens"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 16,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 - L13 LInkingScreens"
+      ]
+    },
+    {
+      "chapter": 61,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Conclusions and Connections (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 2 Project"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 17,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD U4 Chapter 2 Project"
+      ]
+    },
+    {
+      "chapter": 62,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Asynchronous Wrap Up (~10 mins)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 18,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VPL - CSD - Module 4 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 63,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon-CSD"
+      ]
+    },
+    {
+      "chapter": 64,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon-CSD"
+      ]
+    },
+    {
+      "chapter": 65,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon-CSD"
+      ]
+    },
+    {
+      "chapter": 66,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon-CSD"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "OPL - CSD-PL AYWS1 Debugging Intro",
+        "script_level.level_keys": [
+          "OPL - CSD-PL AYWS1 Debugging Intro"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 Summer Review Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Summer Review Overview"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 Summer Review",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 Summer Review"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Variables Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Variables Overview"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module Variable Video with Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module Variable Video with Reflection"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Variables Predict Where XY_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables Predict Where XY_2020"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Variable Resources",
+        "script_level.level_keys": [
+          "VPL - CSD - Variable Resources"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Variables naming rules v2_2018_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Variables naming rules v2_2018_2020"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Random Numbers Overview",
+        "script_level.level_keys": [
+          "VPL - CSD - Random Numbers Overview"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD U3 Random random ellipse2_2018_2020",
+        "script_level.level_keys": [
+          "VPL-CSD U3 Random random ellipse2_2018_2020"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 New Content Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 New Content Reflection"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy",
+        "script_level.level_keys": [
+          "VPL- CSD - Module 1 Debugging OverviewOPD-K5 Pair_copy"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 Debugging Reflection 1",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 1"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD Games variables practice_2020",
+        "script_level.level_keys": [
+          "VPL-CSD Games variables practice_2020"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 14,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 1 Debugging Reflection 2",
+        "script_level.level_keys": [
+          "VPL - CSD Module 1 Debugging Reflection 2"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 15,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 16,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 Overview"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 1 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 1 - CI"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Introduction to the Draw Loop_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Introduction to the Draw Loop_2020"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Draw Loop",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Draw Loop"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI The Draw Loop Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI The Draw Loop Reflection"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Animating Sprite Movement_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Animating Sprite Movement_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Sprite Movement",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Sprite Movement"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI Sprite Movement Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Sprite Movement Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 - Booleans Video_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 - Booleans Video_2020"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL-CSD 2020 - Module 2 CI - Conditionals",
+        "script_level.level_keys": [
+          "VPL-CSD 2020 - Module 2 CI - Conditionals"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 2 CI Conditionals Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 2 CI Conditionals Reflection"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Conclusions and Connections",
+        "script_level.level_keys": [
+          "VPL - CSD - Conclusions and Connections"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 Chapter 1 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U3 Chapter 1 Project"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD: Sprite Velocity_2020",
+        "script_level.level_keys": [
+          "VPL - CSD: Sprite Velocity_2020"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 collisions car intro_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 collisions car intro_2020"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U3 game intro_2018_2019_pilot_2020",
+        "script_level.level_keys": [
+          "VPL - CSD U3 game intro_2018_2019_pilot_2020"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 2 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Overview"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD M3 Check-in",
+        "script_level.level_keys": [
+          "VPL - CSD M3 Check-in"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD M3 Theme Introduction",
+        "script_level.level_keys": [
+          "VPL - CSD M3 Theme Introduction"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Curriculum Investigation Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Curriculum Investigation Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - U4L1 Investigation",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L1 Investigation"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - Problem Solving Process Guide",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - Problem Solving Process Guide"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 Problem Solving Process",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 Problem Solving Process"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 - U4L2 Investigation",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 - U4L2 Investigation"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 U4L2 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Reflection"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 3 U4L2 Intro Group Dynamics",
+        "script_level.level_keys": [
+          "VPL - CSD Module 3 U4L2 Intro Group Dynamics"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 10,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 11,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 Overview",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Overview"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - CI2",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - CI2"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L4 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L4 Reflection"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L8 CI",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L8 CI"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L8 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L8 Reflection"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - L12 GoalsTasks",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L12 GoalsTasks"
+        ],
+        "script_level.chapter": 51,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 Video Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 Video Reflection"
+        ],
+        "script_level.chapter": 52,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module - U4L12Level3",
+        "script_level.level_keys": [
+          "VPL - CSD - Module - U4L12Level3"
+        ],
+        "script_level.chapter": 53,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level4",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level4"
+        ],
+        "script_level.chapter": 54,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level5",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level5"
+        ],
+        "script_level.chapter": 55,
+        "script_level.position": 11,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - U4L12Level6",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - U4L12Level6"
+        ],
+        "script_level.chapter": 56,
+        "script_level.position": 12,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD Module 4 U4L12 Reflection",
+        "script_level.level_keys": [
+          "VPL - CSD Module 4 U4L12 Reflection"
+        ],
+        "script_level.chapter": 57,
+        "script_level.position": 13,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - Conclusions and Connections",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - Conclusions and Connections"
+        ],
+        "script_level.chapter": 58,
+        "script_level.position": 14,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U4 Chapter 1 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 1 Project"
+        ],
+        "script_level.chapter": 59,
+        "script_level.position": 15,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 - L13 LInkingScreens",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 - L13 LInkingScreens"
+        ],
+        "script_level.chapter": 60,
+        "script_level.position": 16,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD U4 Chapter 2 Project",
+        "script_level.level_keys": [
+          "VPL - CSD U4 Chapter 2 Project"
+        ],
+        "script_level.chapter": 61,
+        "script_level.position": 17,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VPL - CSD - Module 4 Wrap Up",
+        "script_level.level_keys": [
+          "VPL - CSD - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 62,
+        "script_level.position": 18,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon-CSD",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 63,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon-CSD",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 64,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon-CSD",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 65,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon-CSD",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon-CSD"
+        ],
+        "script_level.chapter": 66,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csd-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/vpl-csp-2020.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2020.script_json
@@ -1,0 +1,1949 @@
+{
+  "script": {
+    "name": "vpl-csp-2020",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+      "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "pilot_experiment": "20-21-virtual-AYW-CSP"
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "vpl-csp-2020"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Module 1",
+      "name": "Module 1",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 2",
+      "name": "Module 2",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 3",
+      "name": "Module 3",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 4",
+      "name": "Module 4",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 5",
+      "name": "Module 5",
+      "absolute_position": 5,
+      "lockable": false,
+      "relative_position": 5,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 6",
+      "name": "Module 6",
+      "absolute_position": 6,
+      "lockable": false,
+      "relative_position": 6,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 7",
+      "name": "Module 7",
+      "absolute_position": 7,
+      "lockable": false,
+      "relative_position": 7,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "key": "Module 8",
+      "name": "Module 8",
+      "absolute_position": 8,
+      "lockable": false,
+      "relative_position": 8,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS1 Workshop Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL AYWS1 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Wrapping up Unit 3 (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 3 Context"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP Module 1 Unit 3 Context"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Unit 4 tasks overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Unit 4 tasks overview"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL - U4 L12 Practice PT 1"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL U4 L12 Practice PT 2"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Unit 4 Overview (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 4 Reflection"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP Module 1 Unit 4 Reflection"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing EIPM (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM Reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP Module 1 EIPM Reflection"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Introducing EIPM (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM goes virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP Module 1 EIPM goes virtual"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 1 Asynchronous Wrap Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Module 1 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS2 Workshop Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL AYWS2 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Variables Practice overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Variables Practice overview"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL - U4 L03 Variables numbers practice 1"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables numbers practice 4"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 1"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 3"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 2"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L03 Variables operator practice 5"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL8 - U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL8 - U4 L03 Variables operator practice 6"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Practice (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Practice Reflection"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - Practice Reflection"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Variables Make overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Variables Make overview"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL U4 L04 Variables Make Project_2020"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 14,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 15,
+      "assessment": null,
+      "properties": {
+        "progression": "Variables Make (~30 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Make Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - Make Reflection"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 16,
+      "assessment": null,
+      "properties": {
+        "progression": "Collaborative and Independent Work (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL - Unit 4 Wrap-up"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL - Unit 4 Wrap-up"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 17,
+      "assessment": null,
+      "properties": {
+        "progression": "Collaborative and Independent Work (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - PL - Collaboration Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - PL - Collaboration Reflection"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 18,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 2 Asynchronous Wrap Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 18,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Module 2 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWS3 Workshop Overview"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL AYWS3 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Understanding the context for the Model Lesson overview"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Understanding the context for the Model Lesson overview"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Synch3 - Reflection 1"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Understanding the Context for Lists (~55 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Synch3 - Reflection 2"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Intro to CI"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Intro to CI"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Broadening the def"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Broadening the def"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Feedback in CI"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Feedback in CI"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Broadening, labeling, and recognizing CS skills in the classroom (~20 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Practice feedback"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch3 - Practice feedback"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 3 Asynchronous Wrap-Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Module 3 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Overview (~5 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP-PL AYWA4 Workshop Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP-PL AYWA4 Workshop Overview"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Content of the Lists EIPM sequence (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Understanding the content of the Lists EIPM sequence"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Understanding the content of the Lists EIPM sequence"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Content of the Lists EIPM sequence (~25 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Lists EIPM reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Lists EIPM reflection"
+      ]
+    },
+    {
+      "chapter": 40,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Mental models in Unit 5 (~35 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP AYW4 - Mental Models in Unit 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP AYW4 - Mental Models in Unit 5"
+      ]
+    },
+    {
+      "chapter": 41,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 - Intro to Traversals"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch4 - Intro to Traversals"
+      ]
+    },
+    {
+      "chapter": 42,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+      ]
+    },
+    {
+      "chapter": 43,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 - U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch4 - U5L10 Traversals Investigate"
+      ]
+    },
+    {
+      "chapter": 44,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+      ]
+    },
+    {
+      "chapter": 45,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Traversals and datasets (~15 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP AYW4 - Reflection on datasets"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP AYW4 - Reflection on datasets"
+      ]
+    },
+    {
+      "chapter": 46,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Module 4 Asynchronous Wrap-Up (~10 minutes)"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSP - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "CSP - Module 4 Wrap Up"
+      ]
+    },
+    {
+      "chapter": 47,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon"
+      ]
+    },
+    {
+      "chapter": 48,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon"
+      ]
+    },
+    {
+      "chapter": 49,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon"
+      ]
+    },
+    {
+      "chapter": 50,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+        "progression": "Overview"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      },
+      "level_keys": [
+        "VirtualPLComingSoon"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS1 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS1 Workshop Overview"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 Unit 3 Context",
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 3 Context"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Unit 4 tasks overview",
+        "script_level.level_keys": [
+          "CSP - Unit 4 tasks overview"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - U4 L12 Practice PT 1",
+        "script_level.level_keys": [
+          "CSP-PL - U4 L12 Practice PT 1"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL U4 L12 Practice PT 2",
+        "script_level.level_keys": [
+          "CSP-PL U4 L12 Practice PT 2"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 Unit 4 Reflection",
+        "script_level.level_keys": [
+          "CSP Module 1 Unit 4 Reflection"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 EIPM Reflection",
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM Reflection"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP Module 1 EIPM goes virtual",
+        "script_level.level_keys": [
+          "CSP Module 1 EIPM goes virtual"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 1 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 1 Wrap Up"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Module 1",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS2 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS2 Workshop Overview"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 1,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Variables Practice overview",
+        "script_level.level_keys": [
+          "CSP - Variables Practice overview"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 2,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - U4 L03 Variables numbers practice 1",
+        "script_level.level_keys": [
+          "CSP-PL - U4 L03 Variables numbers practice 1"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 3,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables numbers practice 4",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables numbers practice 4"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 4,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 1",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 1"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 5,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 3",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 3"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 6,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 2",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 2"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 7,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L03 Variables operator practice 5",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L03 Variables operator practice 5"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 8,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL8 - U4 L03 Variables operator practice 6",
+        "script_level.level_keys": [
+          "CSP - PL8 - U4 L03 Variables operator practice 6"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 9,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global",
+        "script_level.level_keys": [
+          "CSP - PL9 - U4 L03 Variable Scope: Local vs. Global"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 10,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Practice Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Practice Reflection"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 11,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Variables Make overview",
+        "script_level.level_keys": [
+          "CSP - Variables Make overview"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 12,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL U4 L04 Variables Make Project_2020",
+        "script_level.level_keys": [
+          "CSP - PL U4 L04 Variables Make Project_2020"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 13,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - U4 L04 Variables Make Project Submit_2020",
+        "script_level.level_keys": [
+          "CSP - PL - U4 L04 Variables Make Project Submit_2020"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 14,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Make Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Make Reflection"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 15,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL - Unit 4 Wrap-up",
+        "script_level.level_keys": [
+          "CSP-PL - Unit 4 Wrap-up"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 16,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - PL - Collaboration Reflection",
+        "script_level.level_keys": [
+          "CSP - PL - Collaboration Reflection"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 17,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 2 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 2 Wrap Up"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 18,
+        "lesson.key": "Module 2",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWS3 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWS3 Workshop Overview"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 1,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Understanding the context for the Model Lesson overview",
+        "script_level.level_keys": [
+          "CSP - Understanding the context for the Model Lesson overview"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 2,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Synch3 - Reflection 1",
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 1"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 3,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Synch3 - Reflection 2",
+        "script_level.level_keys": [
+          "CSP - Synch3 - Reflection 2"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 4,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Intro to CI",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Intro to CI"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 5,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Broadening the def",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Broadening the def"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 6,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Feedback in CI",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Feedback in CI"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 7,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch3 - Practice feedback",
+        "script_level.level_keys": [
+          "CSP - Asynch3 - Practice feedback"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 8,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 3 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 3 Wrap Up"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 9,
+        "lesson.key": "Module 3",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP-PL AYWA4 Workshop Overview",
+        "script_level.level_keys": [
+          "CSP-PL AYWA4 Workshop Overview"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 1,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Understanding the content of the Lists EIPM sequence",
+        "script_level.level_keys": [
+          "CSP - Understanding the content of the Lists EIPM sequence"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 2,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Lists EIPM reflection",
+        "script_level.level_keys": [
+          "CSP - Lists EIPM reflection"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 3,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP AYW4 - Mental Models in Unit 5",
+        "script_level.level_keys": [
+          "CSP AYW4 - Mental Models in Unit 5"
+        ],
+        "script_level.chapter": 40,
+        "script_level.position": 4,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 - Intro to Traversals",
+        "script_level.level_keys": [
+          "CSP - Asynch4 - Intro to Traversals"
+        ],
+        "script_level.chapter": 41,
+        "script_level.position": 5,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify",
+        "script_level.level_keys": [
+          "CSP - Asynch 4 - U5 Traversals Investigate Mile Tracker Modify"
+        ],
+        "script_level.chapter": 42,
+        "script_level.position": 6,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 - U5L10 Traversals Investigate",
+        "script_level.level_keys": [
+          "CSP - Asynch4 - U5L10 Traversals Investigate"
+        ],
+        "script_level.chapter": 43,
+        "script_level.position": 7,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify",
+        "script_level.level_keys": [
+          "CSP - Asynch4 -U5 Traversals Investigate Dog Finder Modify"
+        ],
+        "script_level.chapter": 44,
+        "script_level.position": 8,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP AYW4 - Reflection on datasets",
+        "script_level.level_keys": [
+          "CSP AYW4 - Reflection on datasets"
+        ],
+        "script_level.chapter": 45,
+        "script_level.position": 9,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSP - Module 4 Wrap Up",
+        "script_level.level_keys": [
+          "CSP - Module 4 Wrap Up"
+        ],
+        "script_level.chapter": 46,
+        "script_level.position": 10,
+        "lesson.key": "Module 4",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 47,
+        "script_level.position": 1,
+        "lesson.key": "Module 5",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 48,
+        "script_level.position": 1,
+        "lesson.key": "Module 6",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 49,
+        "script_level.position": 1,
+        "lesson.key": "Module 7",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "VirtualPLComingSoon",
+        "script_level.level_keys": [
+          "VirtualPLComingSoon"
+        ],
+        "script_level.chapter": 50,
+        "script_level.position": 1,
+        "lesson.key": "Module 8",
+        "lesson_group.key": "",
+        "script.name": "vpl-csp-2020"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/workshop-gamelab.script_json
+++ b/dashboard/config/scripts_json/workshop-gamelab.script_json
@@ -1,0 +1,1455 @@
+{
+  "script": {
+    "name": "workshop-gamelab",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "workshop-gamelab"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Introduction",
+      "name": "Introduction",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "key": "Sprites",
+      "name": "Sprites",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "key": "Input",
+      "name": "Input",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "key": "Project: Interactive Card",
+      "name": "Project: Interactive Card",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Game Lab Workshop: Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "Game Lab Workshop: Introduction"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD: Drawing in Game Lab 1"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Rectangle"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Order of Blocks"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "U3 - Simple Drawing - Fill"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Game Lab Workshop: Random"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "Game Lab Workshop: Random"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Game Lab Workshop: Draw Loop"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "Game Lab Workshop: Draw Loop"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD: Introduction to the Draw Loop"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "GameLab Workshop: Draw Loop Shapes"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "GameLab Workshop: Draw Loop Shapes"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Random Animation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Random Animation"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Variables make a square"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Variables make a square"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 Variables misconceptions try it"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "U3 Variables misconceptions try it"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 13,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Counters counter square movement"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Counters counter square movement"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Game Lab Workshop: Variables to Sprites"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "Game Lab Workshop: Variables to Sprites"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD: Sprites in Game Lab"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Sprites intro sprites"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites animating with sprites"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Sprites animating with sprites"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug watchers"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug watchers"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug background"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Sprites debug background"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD: Animation Tab"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - first sprite with image"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 - images - first sprite with image"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - images - changing scene"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 - images - changing scene"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Mouse X and Y"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "U3 - Sprites and Mod - Mouse X and Y"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 - Booleans Video"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Boolean Modify"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 - conditionals - Matching"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Boolean"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 UP_ARROW"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Direction Arrows"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 If Else"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Watchers"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Keypress Matching"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 SFLP Card Project"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 SFLP Card Project"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Exemplar"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Background"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Sprites"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card User Input"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Other Conditionals"
+      ]
+    },
+    {
+      "chapter": 39,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      },
+      "level_keys": [
+        "CSD U3 Interactive Card Final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "Game Lab Workshop: Introduction",
+        "script_level.level_keys": [
+          "Game Lab Workshop: Introduction"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Drawing in Game Lab 1",
+        "script_level.level_keys": [
+          "CSD: Drawing in Game Lab 1"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Rectangle",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Rectangle"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Order of Blocks",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Order of Blocks"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Simple Drawing - Fill",
+        "script_level.level_keys": [
+          "U3 - Simple Drawing - Fill"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Game Lab Workshop: Random",
+        "script_level.level_keys": [
+          "Game Lab Workshop: Random"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 6,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Game Lab Workshop: Draw Loop",
+        "script_level.level_keys": [
+          "Game Lab Workshop: Draw Loop"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 7,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Introduction to the Draw Loop",
+        "script_level.level_keys": [
+          "CSD: Introduction to the Draw Loop"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 8,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "GameLab Workshop: Draw Loop Shapes",
+        "script_level.level_keys": [
+          "GameLab Workshop: Draw Loop Shapes"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 9,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Random Animation",
+        "script_level.level_keys": [
+          "CSD U3 Random Animation"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 10,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Variables make a square",
+        "script_level.level_keys": [
+          "CSD U3 Variables make a square"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 11,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 Variables misconceptions try it",
+        "script_level.level_keys": [
+          "U3 Variables misconceptions try it"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 12,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Counters counter square movement",
+        "script_level.level_keys": [
+          "CSD U3 Counters counter square movement"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 13,
+        "lesson.key": "Introduction",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Game Lab Workshop: Variables to Sprites",
+        "script_level.level_keys": [
+          "Game Lab Workshop: Variables to Sprites"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 1,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Sprites in Game Lab",
+        "script_level.level_keys": [
+          "CSD: Sprites in Game Lab"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 2,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites intro sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites intro sprites"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 3,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites animating with sprites",
+        "script_level.level_keys": [
+          "CSD U3 Sprites animating with sprites"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 4,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug watchers",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug watchers"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 5,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Sprites debug background",
+        "script_level.level_keys": [
+          "CSD U3 Sprites debug background"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 6,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Animation Tab",
+        "script_level.level_keys": [
+          "CSD: Animation Tab"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 7,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - first sprite with image",
+        "script_level.level_keys": [
+          "CSD U3 - images - first sprite with image"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 8,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - images - changing scene",
+        "script_level.level_keys": [
+          "CSD U3 - images - changing scene"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 9,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "U3 - Sprites and Mod - Mouse X and Y",
+        "script_level.level_keys": [
+          "U3 - Sprites and Mod - Mouse X and Y"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 10,
+        "lesson.key": "Sprites",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - Booleans Video",
+        "script_level.level_keys": [
+          "CSD U3 - Booleans Video"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 1,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Boolean Modify",
+        "script_level.level_keys": [
+          "CSD U3 Boolean Modify"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 2,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 - conditionals - Matching",
+        "script_level.level_keys": [
+          "CSD U3 - conditionals - Matching"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 3,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Boolean",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Boolean"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 4,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 UP_ARROW",
+        "script_level.level_keys": [
+          "CSD U3 UP_ARROW"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 5,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Direction Arrows",
+        "script_level.level_keys": [
+          "CSD U3 Direction Arrows"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 6,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 If Else",
+        "script_level.level_keys": [
+          "CSD U3 If Else"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 7,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Watchers",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Watchers"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 8,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Keypress Matching",
+        "script_level.level_keys": [
+          "CSD U3 Keypress Matching"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 9,
+        "lesson.key": "Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 SFLP Card Project",
+        "script_level.level_keys": [
+          "CSD U3 SFLP Card Project"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 1,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Exemplar",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Exemplar"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 2,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Background",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Background"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 3,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Sprites",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Sprites"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 4,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card User Input",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card User Input"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 5,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Other Conditionals",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Other Conditionals"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 6,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD U3 Interactive Card Final",
+        "script_level.level_keys": [
+          "CSD U3 Interactive Card Final"
+        ],
+        "script_level.chapter": 39,
+        "script_level.position": 7,
+        "lesson.key": "Project: Interactive Card",
+        "lesson_group.key": "",
+        "script.name": "workshop-gamelab"
+      }
+    }
+  ]
+}

--- a/dashboard/config/scripts_json/workshop-maker.script_json
+++ b/dashboard/config/scripts_json/workshop-maker.script_json
@@ -1,0 +1,1445 @@
+{
+  "script": {
+    "name": "workshop-maker",
+    "wrapup_video_id": null,
+    "hidden": true,
+    "login_required": false,
+    "properties": {
+    },
+    "new_name": null,
+    "family_name": null,
+    "seeding_key": {
+      "script.name": "workshop-maker"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "",
+      "user_facing": false,
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "App Lab Basics",
+      "name": "App Lab Basics",
+      "absolute_position": 1,
+      "lockable": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "key": "The Circuit Playground",
+      "name": "The Circuit Playground",
+      "absolute_position": 2,
+      "lockable": false,
+      "relative_position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "key": "Physical Input",
+      "name": "Physical Input",
+      "absolute_position": 3,
+      "lockable": false,
+      "relative_position": 3,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "key": "Analog Input",
+      "name": "Analog Input",
+      "absolute_position": 4,
+      "lockable": false,
+      "relative_position": 4,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Review: Design Mode, IDs, and Events"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD Review: Design Mode, IDs, and Events"
+      ]
+    },
+    {
+      "chapter": 2,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD: Review Events"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD: Review Events"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD - Getters and Setters"
+      ]
+    },
+    {
+      "chapter": 4,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - setText"
+      ]
+    },
+    {
+      "chapter": 5,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Getters and Setters"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - UI and Inputs - hide show"
+      ]
+    },
+    {
+      "chapter": 6,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Circuit Playground Map: LEDS"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "Circuit Playground Map: LEDS"
+      ]
+    },
+    {
+      "chapter": 7,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 Circuit Playground Test"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.on"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 LED basics led.on"
+      ]
+    },
+    {
+      "chapter": 9,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics onEvent"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 LED basics onEvent"
+      ]
+    },
+    {
+      "chapter": 10,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.off()"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 LED basics led.off()"
+      ]
+    },
+    {
+      "chapter": 11,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED predict"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 LED predict"
+      ]
+    },
+    {
+      "chapter": 12,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the LED"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 LED alarm silent"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 LED alarm silent"
+      ]
+    },
+    {
+      "chapter": 13,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Circuit Playground Map: Buzzer"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "Circuit Playground Map: Buzzer"
+      ]
+    },
+    {
+      "chapter": 14,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer freq"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 buzzer freq"
+      ]
+    },
+    {
+      "chapter": 15,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer stop"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 buzzer stop"
+      ]
+    },
+    {
+      "chapter": 16,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buzzer"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 buzzer alarm"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 buzzer alarm"
+      ]
+    },
+    {
+      "chapter": 17,
+      "position": 12,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Challenge: Buzzer and LED"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "Challenge: Buzzer and LED"
+      ]
+    },
+    {
+      "chapter": 18,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Map: onBoardEvent"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD Map: onBoardEvent"
+      ]
+    },
+    {
+      "chapter": 19,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonL"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button screen buttonL"
+      ]
+    },
+    {
+      "chapter": 20,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Board Events"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonR"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button screen buttonR"
+      ]
+    },
+    {
+      "chapter": 21,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Map: Board Buttons"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD Map: Board Buttons"
+      ]
+    },
+    {
+      "chapter": 22,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button toggle"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button toggle"
+      ]
+    },
+    {
+      "chapter": 23,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button on off"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button on off"
+      ]
+    },
+    {
+      "chapter": 24,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button up down predict"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button up down predict"
+      ]
+    },
+    {
+      "chapter": 25,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Using the Buttons"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button up down"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button up down"
+      ]
+    },
+    {
+      "chapter": 26,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war right button"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war right button"
+      ]
+    },
+    {
+      "chapter": 27,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War Game"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war left button"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war left button"
+      ]
+    },
+    {
+      "chapter": 28,
+      "position": 11,
+      "assessment": null,
+      "properties": {
+        "progression": "Tug o War game"
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - button tug o war challenge"
+      ]
+    },
+    {
+      "chapter": 29,
+      "position": 1,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors experiment"
+      ]
+    },
+    {
+      "chapter": 30,
+      "position": 2,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Map: Board Sensors"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD Map: Board Sensors"
+      ]
+    },
+    {
+      "chapter": 31,
+      "position": 3,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors sound"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors sound"
+      ]
+    },
+    {
+      "chapter": 32,
+      "position": 4,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors light"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors light"
+      ]
+    },
+    {
+      "chapter": 33,
+      "position": 5,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors temp"
+      ]
+    },
+    {
+      "chapter": 34,
+      "position": 6,
+      "assessment": null,
+      "properties": {
+        "progression": "Using Sensors"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors predict"
+      ]
+    },
+    {
+      "chapter": 35,
+      "position": 7,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSD Map: Polling Events"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSD Map: Polling Events"
+      ]
+    },
+    {
+      "chapter": 36,
+      "position": 8,
+      "assessment": null,
+      "properties": {
+        "progression": "Displaying Sensor Values"
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp f c"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 - sensors temp f c"
+      ]
+    },
+    {
+      "chapter": 37,
+      "position": 9,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": null,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CSDU6 light sensor alarm"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "CSDU6 light sensor alarm"
+      ]
+    },
+    {
+      "chapter": 38,
+      "position": 10,
+      "assessment": null,
+      "properties": {
+      },
+      "named_level": true,
+      "bonus": null,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "maker workshop final"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      },
+      "level_keys": [
+        "maker workshop final"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "CSD Review: Design Mode, IDs, and Events",
+        "script_level.level_keys": [
+          "CSD Review: Design Mode, IDs, and Events"
+        ],
+        "script_level.chapter": 1,
+        "script_level.position": 1,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD: Review Events",
+        "script_level.level_keys": [
+          "CSD: Review Events"
+        ],
+        "script_level.chapter": 2,
+        "script_level.position": 2,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD - Getters and Setters",
+        "script_level.level_keys": [
+          "CSD - Getters and Setters"
+        ],
+        "script_level.chapter": 3,
+        "script_level.position": 3,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - setText",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - setText"
+        ],
+        "script_level.chapter": 4,
+        "script_level.position": 4,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - UI and Inputs - hide show",
+        "script_level.level_keys": [
+          "CSDU6 - UI and Inputs - hide show"
+        ],
+        "script_level.chapter": 5,
+        "script_level.position": 5,
+        "lesson.key": "App Lab Basics",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Circuit Playground Map: LEDS",
+        "script_level.level_keys": [
+          "Circuit Playground Map: LEDS"
+        ],
+        "script_level.chapter": 6,
+        "script_level.position": 1,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 Circuit Playground Test",
+        "script_level.level_keys": [
+          "CSDU6 Circuit Playground Test"
+        ],
+        "script_level.chapter": 7,
+        "script_level.position": 2,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics led.on",
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.on"
+        ],
+        "script_level.chapter": 8,
+        "script_level.position": 3,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics onEvent",
+        "script_level.level_keys": [
+          "CSDU6 LED basics onEvent"
+        ],
+        "script_level.chapter": 9,
+        "script_level.position": 4,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED basics led.off()",
+        "script_level.level_keys": [
+          "CSDU6 LED basics led.off()"
+        ],
+        "script_level.chapter": 10,
+        "script_level.position": 5,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED predict",
+        "script_level.level_keys": [
+          "CSDU6 LED predict"
+        ],
+        "script_level.chapter": 11,
+        "script_level.position": 6,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 LED alarm silent",
+        "script_level.level_keys": [
+          "CSDU6 LED alarm silent"
+        ],
+        "script_level.chapter": 12,
+        "script_level.position": 7,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Circuit Playground Map: Buzzer",
+        "script_level.level_keys": [
+          "Circuit Playground Map: Buzzer"
+        ],
+        "script_level.chapter": 13,
+        "script_level.position": 8,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer freq",
+        "script_level.level_keys": [
+          "CSDU6 buzzer freq"
+        ],
+        "script_level.chapter": 14,
+        "script_level.position": 9,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer stop",
+        "script_level.level_keys": [
+          "CSDU6 buzzer stop"
+        ],
+        "script_level.chapter": 15,
+        "script_level.position": 10,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 buzzer alarm",
+        "script_level.level_keys": [
+          "CSDU6 buzzer alarm"
+        ],
+        "script_level.chapter": 16,
+        "script_level.position": 11,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Challenge: Buzzer and LED",
+        "script_level.level_keys": [
+          "Challenge: Buzzer and LED"
+        ],
+        "script_level.chapter": 17,
+        "script_level.position": 12,
+        "lesson.key": "The Circuit Playground",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Map: onBoardEvent",
+        "script_level.level_keys": [
+          "CSD Map: onBoardEvent"
+        ],
+        "script_level.chapter": 18,
+        "script_level.position": 1,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button screen buttonL",
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonL"
+        ],
+        "script_level.chapter": 19,
+        "script_level.position": 2,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button screen buttonR",
+        "script_level.level_keys": [
+          "CSDU6 - button screen buttonR"
+        ],
+        "script_level.chapter": 20,
+        "script_level.position": 3,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Map: Board Buttons",
+        "script_level.level_keys": [
+          "CSD Map: Board Buttons"
+        ],
+        "script_level.chapter": 21,
+        "script_level.position": 4,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button toggle",
+        "script_level.level_keys": [
+          "CSDU6 - button toggle"
+        ],
+        "script_level.chapter": 22,
+        "script_level.position": 5,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button on off",
+        "script_level.level_keys": [
+          "CSDU6 - button on off"
+        ],
+        "script_level.chapter": 23,
+        "script_level.position": 6,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button up down predict",
+        "script_level.level_keys": [
+          "CSDU6 - button up down predict"
+        ],
+        "script_level.chapter": 24,
+        "script_level.position": 7,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button up down",
+        "script_level.level_keys": [
+          "CSDU6 - button up down"
+        ],
+        "script_level.chapter": 25,
+        "script_level.position": 8,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war right button",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war right button"
+        ],
+        "script_level.chapter": 26,
+        "script_level.position": 9,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war left button",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war left button"
+        ],
+        "script_level.chapter": 27,
+        "script_level.position": 10,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - button tug o war challenge",
+        "script_level.level_keys": [
+          "CSDU6 - button tug o war challenge"
+        ],
+        "script_level.chapter": 28,
+        "script_level.position": 11,
+        "lesson.key": "Physical Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors experiment",
+        "script_level.level_keys": [
+          "CSDU6 - sensors experiment"
+        ],
+        "script_level.chapter": 29,
+        "script_level.position": 1,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Map: Board Sensors",
+        "script_level.level_keys": [
+          "CSD Map: Board Sensors"
+        ],
+        "script_level.chapter": 30,
+        "script_level.position": 2,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors sound",
+        "script_level.level_keys": [
+          "CSDU6 - sensors sound"
+        ],
+        "script_level.chapter": 31,
+        "script_level.position": 3,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors light",
+        "script_level.level_keys": [
+          "CSDU6 - sensors light"
+        ],
+        "script_level.chapter": 32,
+        "script_level.position": 4,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors temp",
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp"
+        ],
+        "script_level.chapter": 33,
+        "script_level.position": 5,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors predict",
+        "script_level.level_keys": [
+          "CSDU6 - sensors predict"
+        ],
+        "script_level.chapter": 34,
+        "script_level.position": 6,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSD Map: Polling Events",
+        "script_level.level_keys": [
+          "CSD Map: Polling Events"
+        ],
+        "script_level.chapter": 35,
+        "script_level.position": 7,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 - sensors temp f c",
+        "script_level.level_keys": [
+          "CSDU6 - sensors temp f c"
+        ],
+        "script_level.chapter": 36,
+        "script_level.position": 8,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CSDU6 light sensor alarm",
+        "script_level.level_keys": [
+          "CSDU6 light sensor alarm"
+        ],
+        "script_level.chapter": 37,
+        "script_level.position": 9,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "maker workshop final",
+        "script_level.level_keys": [
+          "maker workshop final"
+        ],
+        "script_level.chapter": 38,
+        "script_level.position": 10,
+        "lesson.key": "Analog Input",
+        "lesson_group.key": "",
+        "script.name": "workshop-maker"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I think I want to generate these files directly on the levelbuilder machine, after https://github.com/code-dot-org/code-dot-org/pull/36959 is deployed to levelbuilder, to reduce the chance of data being out of sync. This PR is to show the snippet I'll run, and the results of running it locally.

Steps I did locally:

1. Pulled latest staging and created new branch
2. Reset local development db and seeded using "old seeding" (`bundle exec rake db:reset && bundle exec rake seed:all`)
3. Generated `.script_json` files by running the following in rails console:
```
Script.all.each_with_index do |s, i|
  filename = File.join('config', 'scripts_json', "#{s.name}.script_json")
  puts "Serializing script #{i}: #{filename}"
  File.write(filename, s.serialize_seeding_json)
end
```
4. Verified counts of files created:
```
Winters-MacBook-Pro:dashboard winterdong$ ls config/scripts/*.script | wc -l
     444
Winters-MacBook-Pro:dashboard winterdong$ ls config/scripts_json/*.script_json | wc -l
     444
```

This adds 25 MB of files:
```
Winters-MacBook-Pro:scripts_json winterdong$ du -hs
 25M	.
```

`config/scripts` is already 239 MB (doesn't include these new files, does include .level files):
```
Winters-MacBook-Pro:scripts winterdong$ du -hs
239M	.
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
